### PR TITLE
feat: add mobile password change screen

### DIFF
--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -1,0 +1,5 @@
+import ChangePasswordScreen from "@/features/profile/ChangePasswordScreen";
+
+export default function ChangePasswordRoute() {
+  return <ChangePasswordScreen />;
+}

--- a/features/profile/ChangePasswordScreen.tsx
+++ b/features/profile/ChangePasswordScreen.tsx
@@ -1,0 +1,215 @@
+import { ErrorBanner, PasswordInput } from "@/components/ui";
+import { supabase } from "@/lib/supabase";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import { router } from "expo-router";
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+
+export default function ChangePasswordScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const validate = (): string | null => {
+    if (!newPassword.trim()) return "Bitte ein neues Passwort eingeben.";
+    if (newPassword.length < 6) return "Das Passwort muss mindestens 6 Zeichen lang sein.";
+    if (newPassword !== confirmPassword) return "Die Passwörter stimmen nicht überein.";
+    return null;
+  };
+
+  const handleSave = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        password: newPassword,
+      });
+
+      if (updateError) {
+        setError(updateError.message);
+        return;
+      }
+
+      Alert.alert("Gespeichert", "Dein Passwort wurde erfolgreich geändert.", [
+        { text: "OK", onPress: () => router.back() },
+      ]);
+    } catch {
+      setError("Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        {/* ── Header ── */}
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backButton}
+            activeOpacity={0.8}
+            onPress={() => router.back()}
+          >
+            <Ionicons name="chevron-back" size={18} color={theme.colors.onSurface} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Passwort ändern</Text>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {error && (
+            <ErrorBanner
+              message={error}
+              onDismiss={() => setError(null)}
+              type="error"
+            />
+          )}
+
+          <View style={styles.form}>
+            <PasswordInput
+              label="Neues Passwort"
+              placeholder="Mindestens 6 Zeichen"
+              value={newPassword}
+              onChangeText={(text) => {
+                setNewPassword(text);
+                if (error) setError(null);
+              }}
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="next"
+              editable={!loading}
+            />
+
+            <PasswordInput
+              label="Passwort bestätigen"
+              placeholder="Passwort wiederholen"
+              value={confirmPassword}
+              onChangeText={(text) => {
+                setConfirmPassword(text);
+                if (error) setError(null);
+              }}
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="done"
+              onSubmitEditing={handleSave}
+              editable={!loading}
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.saveButton, loading && styles.saveButtonDisabled]}
+            activeOpacity={0.8}
+            onPress={handleSave}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator size="small" color={theme.colors.onPrimary} />
+            ) : (
+              <Text style={styles.saveButtonText}>Passwort speichern</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    flex: {
+      flex: 1,
+    },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+
+    // ── Header
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.outlineVariant,
+    },
+    backButton: {
+      width: 36,
+      height: 36,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    headerTitle: {
+      flex: 1,
+      textAlign: "center",
+      fontSize: theme.typography.size.lg,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    headerSpacer: {
+      width: 36,
+    },
+
+    // ── Content
+    content: {
+      padding: theme.spacing.lg,
+      gap: theme.spacing.lg,
+    },
+    form: {
+      gap: theme.spacing.md,
+    },
+
+    // ── Speichern-Button
+    saveButton: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: theme.spacing.tapTarget,
+    },
+    saveButtonDisabled: {
+      opacity: 0.6,
+    },
+    saveButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimary,
+    },
+  });
+}

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -160,8 +160,7 @@ export default function ProfileScreen({
           <SettingsRow
             icon="lock-closed-outline"
             label="Passwort ändern"
-            comingSoon
-            onPress={showComingSoon}
+            onPress={() => router.push("/change-password")}
             isLast
             styles={styles}
             theme={theme}


### PR DESCRIPTION
Nutzer können ihr Passwort jetzt direkt im Profil-Tab ändern. Neuer Screen mit Validierung, ErrorBanner, Loading-State und supabase.auth.updateUser; "Passwort ändern" Row navigiert dorthin.