### PR TITLE
fix(jobs): navigate to Jobs page after successful job creation (#28)

### DIFF
--- a/context/JobContext.tsx
+++ b/context/JobContext.tsx
@@ -45,7 +45,12 @@ type JobContextType = {
   refreshEmployees: () => Promise<void>;
   // Setzt den Aktiv-Status eines Mitarbeiters und lädt die Liste neu.
   setEmployeeActive: (employeeId: string, active: boolean) => Promise<void>;
-  createJob: (input: CreateJobInput) => Promise<void>;
+  // Gibt zurück, ob die Recurring-Occurrence-Generierung fehlschlug, damit die
+  // UI zwischen vollem Erfolg und Teil-Erfolg (Job angelegt, Termine fehlen)
+  // unterscheiden kann.
+  createJob: (
+    input: CreateJobInput,
+  ) => Promise<{ recurringOccurrencesFailed: boolean }>;
   updateJob: (input: {
     jobId: string;
     customerName: string;
@@ -437,7 +442,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
 
   const createJob = useCallback(async (input: CreateJobInput) => {
     try {
-      const createdJob = await createJobService(input);
+      const { job: createdJob, recurringOccurrencesFailed } =
+        await createJobService(input);
 
       setJobs((prevJobs) => {
         const exists = prevJobs.some((job) => job.id === createdJob.id);
@@ -453,6 +459,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       if (__DEV__) {
         console.log("Creating job with employeeId:", input.employeeId);
       }
+
+      return { recurringOccurrencesFailed };
     } catch (err) {
       console.error("Failed to create job:", err);
       throw err;

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -101,6 +101,11 @@ export default function AdminScreen() {
   const { createJob, employees, loading } = useJobs();
   const { signOut, role, loading: authLoading } = useAuth();
   const [submitting, setSubmitting] = useState(false);
+  // Synchrone Re-Entrancy-Sperre gegen Doppel-Absendung. setSubmitting(true)
+  // wirkt erst beim nächsten Render — zwei sehr schnelle Taps könnten daher
+  // beide den submitting-Check passieren, bevor der State aktualisiert ist.
+  // Der Ref flippt synchron und schließt dieses Zeitfenster sofort.
+  const submittingRef = useRef(false);
 
   // Beim Job-Erstellen nur aktive Mitarbeiter zur Auswahl anbieten.
   const activeEmployees = useMemo(
@@ -150,11 +155,13 @@ export default function AdminScreen() {
 
   // ── Job erstellen
   const handleCreateJob = async () => {
-    // Doppel-Absendung verhindern — zusätzlich zum disabled-Button auch eine
-    // Re-Entrancy-Sperre, falls handleCreateJob doch mehrfach ausgelöst wird.
-    if (submitting) return;
+    // Doppel-Absendung verhindern: synchroner Ref-Lock (sofort wirksam) UND
+    // der submitting-State (steuert disabled-Button / Beschriftung). Der Ref
+    // fängt sehr schnelle Doppel-Taps ab, bevor der State greift.
+    if (submittingRef.current || submitting) return;
     if (!validate()) return;
 
+    submittingRef.current = true;
     try {
       setSubmitting(true);
 
@@ -224,6 +231,8 @@ export default function AdminScreen() {
           : "Job konnte nicht erstellt werden.";
       Alert.alert("Fehler", msg);
     } finally {
+      // Sperre in beiden Fällen wieder freigeben (Erfolg wie Fehler).
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -148,8 +148,11 @@ export default function AdminScreen() {
     ]);
   };
 
-  // ── Job erstellen (unveränderte Logik)
+  // ── Job erstellen
   const handleCreateJob = async () => {
+    // Doppel-Absendung verhindern — zusätzlich zum disabled-Button auch eine
+    // Re-Entrancy-Sperre, falls handleCreateJob doch mehrfach ausgelöst wird.
+    if (submitting) return;
     if (!validate()) return;
 
     try {
@@ -187,11 +190,34 @@ export default function AdminScreen() {
               scheduledStart: null,
             };
 
-      await createJob(input);
+      const { recurringOccurrencesFailed } = await createJob(input);
 
+      // Formular vor dem Erfolgshinweis zurücksetzen.
       reset();
-      Alert.alert("✓ Erstellt", "Der Job wurde erfolgreich angelegt.");
+
+      // Nach Bestätigung des Hinweises zur Jobs-Übersicht navigieren. Der Job
+      // ist bereits angelegt — deshalb navigieren wir auch bei fehlgeschlagener
+      // Occurrence-Generierung; wir zeigen dann aber KEINEN vollen Erfolg,
+      // sondern einen Teil-Erfolg-Hinweis (Termine bitte prüfen).
+      const goToJobs = () => router.replace("/(admin-tabs)/jobs");
+
+      if (recurringOccurrencesFailed) {
+        Alert.alert(
+          "Job angelegt",
+          "Der Job wurde angelegt, aber die Termine konnten nicht vollständig erzeugt werden. Bitte prüfe die Terminierung.",
+          [{ text: "OK", onPress: goToJobs }],
+          { cancelable: false },
+        );
+      } else {
+        Alert.alert(
+          "✓ Erstellt",
+          "Der Job wurde erfolgreich angelegt.",
+          [{ text: "OK", onPress: goToJobs }],
+          { cancelable: false },
+        );
+      }
     } catch (err: unknown) {
+      // Bei einem Fehler wird NICHT navigiert — der Admin bleibt im Formular.
       const msg =
         err instanceof Error
           ? err.message

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -318,8 +318,18 @@ export async function setEmployeeActive(
   }
 }
 
+// Ergebnis von createJob: der angelegte Job plus ein Hinweis, ob die
+// Generierung der Recurring-Occurrences fehlgeschlagen ist. So kann die UI einen
+// vollen Erfolg von einem Teil-Erfolg unterscheiden (Job angelegt, aber Termine
+// noch nicht erzeugt), ohne den bereits erstellten Job als Fehler zu behandeln.
+export type CreateJobResult = {
+  job: Job;
+  // true nur bei recurring, wenn generate_job_occurrences fehlschlug.
+  recurringOccurrencesFailed: boolean;
+};
+
 // Erstellt einen neuen Job
-export async function createJob(input: CreateJobInput): Promise<Job> {
+export async function createJob(input: CreateJobInput): Promise<CreateJobResult> {
   // Aktuellen User holen
   const { data: authData, error: authError } = await supabase.auth.getUser();
 
@@ -453,12 +463,17 @@ export async function createJob(input: CreateJobInput): Promise<Job> {
     );
   }
 
+  // Merkt sich, ob die Occurrence-Generierung fehlschlug — die UI zeigt dann
+  // keinen vollen Erfolg an (der Parent-Job existiert aber bereits).
+  let recurringOccurrencesFailed = false;
+
   if (schedule.job_type === "recurring") {
     const { data: rpcResult, error: occurrenceError } = await supabase.rpc(
       "generate_job_occurrences",
       { parent_job_id_input: data.id }
     );
     if (occurrenceError) {
+      recurringOccurrencesFailed = true;
       // Immer loggen (nicht nur in Dev), damit der Fehler im Expo-Log sichtbar ist.
       console.error(
         "[createJob] generate_job_occurrences fehlgeschlagen:",
@@ -502,7 +517,7 @@ export async function createJob(input: CreateJobInput): Promise<Job> {
   }
 
   // Rückgabe im App-Format
-  return mapJob(data as JobRow);
+  return { job: mapJob(data as JobRow), recurringOccurrencesFailed };
 }
 
 // Aktualisiert einen bestehenden Job


### PR DESCRIPTION
Closes #28

## Problem
After an admin successfully created a job, the app did not navigate anywhere. The success `Alert` in `AdminScreen.handleCreateJob` had **no button and no `onPress`**, so the admin was left on the (now-reset) create form with no way back except the manual header back button.

## Root cause
`features/admin/AdminScreen.tsx` `handleCreateJob` awaited `createJob(input)`, called `reset()`, then fired a bare `Alert.alert("✓ Erstellt", …)` — no navigation action at all. Additionally, `createJob` swallowed recurring-occurrence-generation errors, so a partial success could be reported as full success.

## Fix (client-only — no SQL / schema / notification / Edge Function changes)
- **Navigation on OK:** the success `Alert` now has an `OK` button whose `onPress` calls `router.replace("/(admin-tabs)/jobs")` (the same target already used by the screen's back-button fallback). `{ cancelable: false }` ensures OK is the path taken.
- **No navigation on failure:** the `catch` branch still only shows an error Alert and stays on the form.
- **Duplicate-submit protection:** kept the existing `submitting`/`disabled` button guard and added a defensive `if (submitting) return;` re-entrancy check.
- **Partial-success honesty:** `createJob` (service) now returns `{ job, recurringOccurrencesFailed }`; `JobContext.createJob` propagates the flag; `AdminScreen` shows a softer "Job angelegt, Termine bitte prüfen" message (still navigating, because the job exists) instead of claiming full success when occurrence generation failed.
- **Form reset** preserved (before the Alert).

## Files changed
- `features/admin/AdminScreen.tsx`
- `context/JobContext.tsx`
- `services/jobs/jobs.service.ts`

## Verification
- `tsc --noEmit -p tsconfig.json` → clean (exit 0)
- `expo lint` → clean (exit 0)
- No JS test runner configured in the repo (only SQL tests requiring a live DB, out of scope).

## Acceptance criteria
- [x] Success → navigates to Jobs page on OK; form reset
- [x] Recurring success → navigates; occurrences visible
- [x] Failure → stays on form, error shown, no navigation
- [x] Double-tap creates exactly one job
- [x] Occurrence-gen failure does not report full success

## Notes for reviewer
Requires manual verification on a device/simulator (Alert OK navigation, Android back-button behavior) since no automated UI tests exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KxADxCFZhEiAFVS32hNy5)_