### PR TITLE
fix(auth): redirect to Login (Anmeldung) after logout (#29)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -26,7 +26,10 @@ export default function IndexScreen() {
   let redirectTo: string | null = null;
   if (!loading) {
     if (!session) {
-      redirectTo = "/welcome";
+      // Abgemeldete Nutzer landen immer auf der Anmeldung (Login), nicht auf
+      // Welcome/Register. Die Registrierung ist von dort nur über eine
+      // explizite Nutzeraktion erreichbar (Link "Firma registrieren").
+      redirectTo = "/login";
     } else if (profile) {
       if (!profile.company_id) redirectTo = "/setup-company";
       else if (role === "admin") redirectTo = "/(admin-tabs)/dashboard";
@@ -65,7 +68,9 @@ export default function IndexScreen() {
     try {
       await signOut();
     } catch {
-      router.replace("/welcome");
+      // Fallback bei fehlgeschlagenem Sign-out: ebenfalls zur Anmeldung, nicht
+      // zu Welcome/Register.
+      router.replace("/login");
     }
   };
 

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -138,6 +138,10 @@ export default function AdminScreen() {
         onPress: async () => {
           try {
             await signOut();
+            // Explizit zur Anmeldung navigieren, statt uns auf das Neu-Mounten
+            // der Auth-Gruppe durch die Auth-Gates zu verlassen (das konnte den
+            // zuletzt sichtbaren Auth-Screen — Register — wieder aufdecken).
+            router.replace("/login");
           } catch (err: unknown) {
             const msg =
               err instanceof Error ? err.message : "Abmeldung fehlgeschlagen.";

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -97,7 +97,10 @@ Vielen Dank.`;
         onPress: async () => {
           try {
             await signOut();
-            router.replace("/");
+            // Nach dem Abmelden immer zur Anmeldung (Login). router.replace
+            // ersetzt die aktuelle Route und die geschützten Gruppen werden
+            // durch die Auth-Gates entfernt → kein Zurück in geschützte Screens.
+            router.replace("/login");
           } catch {
             Alert.alert("Fehler", "Logout fehlgeschlagen.");
           }


### PR DESCRIPTION
Closes #29

## Problem
After logout, the user was not reliably taken to the Login (Anmeldung) screen — depending on the entry point they landed on Welcome (whose primary CTA is "Firma registrieren") or on the Register screen.

## Root cause
Two compounding issues:
1. `app/index.tsx` routed every signed-out user (`!session`) to `/welcome`, not `/login`. Welcome's dominant button pushes `/register`, so users perceived "logout dumped me on Register."
2. `AuthContext.signOut` performs no navigation, and `AdminScreen.handleLogout` did no explicit navigation either — it relied on `Stack.Protected` re-mounting the `welcome/login/register/forgot-password` group, which reveals that group's **stale last route** (typically `register`, because Welcome's primary CTA had pushed `/register`).

## Fix (client-only — no SQL / schema / notification / Edge Function changes)
- **`app/index.tsx`:** the no-session gate now redirects to `/login` instead of `/welcome`; the error-state logout fallback also targets `/login`.
- **`features/profile/ProfileScreen.tsx`:** `handleLogout` now `router.replace("/login")` instead of `router.replace("/")`.
- **`features/admin/AdminScreen.tsx`:** `handleLogout` now calls `router.replace("/login")` after `signOut()`, making logout deterministic and preventing the stale Register screen from resurfacing.

## Why this satisfies each requirement
- **Always ends on Login:** both logout handlers and the gate target `/login`.
- **Never Register/Welcome for logged-out users:** the only auto-redirect for `!session` is now `/login`.
- **Registration only via explicit action:** reachable solely through the existing "Firma registrieren" link on `LoginScreen` (`router.replace("/register")`).
- **Protected history cleared / back button safe:** `router.replace` replaces the current route and the `Stack.Protected` auth gates unmount the admin/employee groups on logout, so back cannot reopen protected screens.
- **Onboarding preserved:** the authenticated branches in `app/index.tsx` (`/setup-company` when no company, `/accept-invite` for unaccepted invites) are unchanged.

## Files changed
- `app/index.tsx`
- `features/profile/ProfileScreen.tsx`
- `features/admin/AdminScreen.tsx`

## Verification
- `tsc --noEmit -p tsconfig.json` → clean (exit 0)
- `expo lint` → clean (exit 0)
- No JS test runner configured in the repo (only SQL tests requiring a live DB, out of scope).

## Notes for reviewer
- `WelcomeScreen` is intentionally left unchanged; it is simply no longer the default signed-out destination (still reachable if deep-linked, and its register button remains an explicit action).
- Requires manual verification on a device/simulator: logout from admin job-create, admin profile, and employee profile all land on Login; cold start with no session lands on Login; back button after logout cannot re-enter tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KxADxCFZhEiAFVS32hNy5)_