### PR TITLE
ci: run typecheck and lint on pull requests to main (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Läuft bei jedem Pull Request gegen main: installiert die Abhängigkeiten aus
+# dem vorhandenen Lockfile, prüft die Typen und lintet. Kein Zugriff auf
+# Supabase/SQL — reine statische Checks.
+on:
+  pull_request:
+    branches: [main]
+
+# Nur der neueste Lauf pro PR-Branch; ältere laufende Checks werden abgebrochen.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck-lint:
+    name: Typecheck & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies (from lockfile)
+        run: npm ci
+
+      - name: TypeScript check
+        run: npx tsc --noEmit -p tsconfig.json
+
+      - name: Expo lint
+        run: npm run lint


### PR DESCRIPTION
Closes #38

## What
Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on every Pull Request targeting `main` and executes:
1. **Dependency install from the lockfile** — `npm ci`
2. **TypeScript check** — `npx tsc --noEmit -p tsconfig.json`
3. **Expo lint** — `npm run lint` (`expo lint`)

## Workflow details
- Trigger: `pull_request` → `branches: [main]`
- Runner: `ubuntu-latest`, Node 20 via `actions/setup-node@v4` with npm cache
- `actions/checkout@v4`
- Least-privilege `permissions: contents: read`
- `concurrency` cancels superseded runs for the same PR branch

## Scope / constraints honored
- **Only** adds the workflow file — no application code, SQL, or Supabase changes.
- **No dependency updates**; `npm ci` installs strictly from `package-lock.json` and never rewrites it (verified locally: lockfile untouched after `npm ci`).

## Local validation of the exact CI commands
- `npm ci` → exit 0 (lockfile in sync, not modified)
- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `npm run lint` → exit 0

## Files changed
- `.github/workflows/ci.yml` (new, +39)

## Note
This is the first workflow in the repo, so the CI check will begin appearing on PRs opened after this workflow lands on `main`. Not merging per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KxADxCFZhEiAFVS32hNy5)_