### PR TITLE
feat(account): add secure in-app account deletion

### DIFF
--- a/app/delete-account.tsx
+++ b/app/delete-account.tsx
@@ -1,0 +1,5 @@
+import DeleteAccountScreen from "@/features/profile/DeleteAccountScreen";
+
+export default function DeleteAccountRoute() {
+  return <DeleteAccountScreen />;
+}

--- a/features/profile/DeleteAccountScreen.tsx
+++ b/features/profile/DeleteAccountScreen.tsx
@@ -1,0 +1,585 @@
+// features/profile/DeleteAccountScreen.tsx
+// In-App-Kontolöschung (DSGVO / Google-Play-Account-Deletion-Policy).
+// Vollständig theme-aware (Light + Dark). Zweistufige Bestätigung gegen
+// versehentliche Löschung: (1) Pflicht-Checkbox „Ich verstehe …", (2) nativer
+// Bestätigungsdialog vor der eigentlichen Löschung.
+//
+// Backend: services/account/deleteAccount.ts → Edge Function delete-account.
+// Nach Erfolg: lokale Caches leeren, lokal abmelden, zurück zum Login.
+
+import { Card } from "@/components/ui";
+import { useAuth } from "@/context/AuthContext";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { supabase } from "@/lib/supabase";
+import { requestAccountDeletion } from "@/services/account/deleteAccount";
+import { clearPendingJobActions } from "@/services/offline/jobs.queue";
+import { clearCachedJobs } from "@/services/offline/jobs.storage";
+import { clearCachedProfile } from "@/services/offline/profile.storage";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function DeleteAccountScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const { user, role } = useAuth();
+  const isAdmin = role === "admin";
+
+  const [confirmed, setConfirmed] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const email = user?.email ?? "dein Konto";
+
+  // Leert ALLE lokalen persistenten Caches, damit auf einem geteilten Gerät
+  // keine Daten des gelöschten Kontos zurückbleiben.
+  const clearAllLocalData = async () => {
+    await Promise.all([
+      clearCachedProfile(),
+      clearCachedJobs(),
+      clearPendingJobActions(),
+    ]);
+  };
+
+  // Führt die Löschung aus (nach der nativen Bestätigung). Wirft nie.
+  const runDeletion = async () => {
+    setLoading(true);
+
+    const result = await requestAccountDeletion();
+
+    if (!result.ok) {
+      setLoading(false);
+
+      if (result.code === "last_admin") {
+        Alert.alert("Löschung nicht möglich", result.message);
+        return;
+      }
+
+      Alert.alert("Fehler", result.message);
+      return;
+    }
+
+    // ── Erfolg: lokal aufräumen und abmelden. ──
+    // Wichtig: scope "local" verwenden — ein serverseitiger Logout würde für
+    // das bereits gelöschte Konto fehlschlagen. Der lokale Logout löst den
+    // SIGNED_OUT-Auth-Event aus → AuthContext setzt Session/Profil zurück,
+    // die authentifizierten Screens werden verlassen.
+    await clearAllLocalData();
+    await supabase.auth.signOut({ scope: "local" }).catch(() => {});
+
+    // Auf das Routing-Gate zurück; ohne Session leitet es nach /welcome.
+    router.replace("/");
+  };
+
+  // Erste Stufe: nur mit gesetzter Checkbox; zweite Stufe = nativer Dialog.
+  const handleDeletePress = () => {
+    if (!confirmed || loading) {
+      return;
+    }
+
+    Alert.alert(
+      "Konto endgültig löschen?",
+      "Diese Aktion kann nicht rückgängig gemacht werden. Dein Konto und dein " +
+        "Profil werden dauerhaft gelöscht.",
+      [
+        { text: "Abbrechen", style: "cancel" },
+        {
+          text: "Endgültig löschen",
+          style: "destructive",
+          onPress: () => {
+            void runDeletion();
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
+
+      {/* ── Header ── */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.backButton}
+          activeOpacity={0.8}
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back();
+              return;
+            }
+            router.replace("/");
+          }}
+          disabled={loading}
+        >
+          <Ionicons
+            name="chevron-back"
+            size={18}
+            color={theme.colors.onSurface}
+          />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Konto löschen</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Warn-Header ── */}
+        <View style={styles.warnHero}>
+          <View style={styles.warnIcon}>
+            <Ionicons
+              name="warning-outline"
+              size={26}
+              color={theme.colors.error}
+            />
+          </View>
+          <Text style={styles.warnTitle}>Konto dauerhaft löschen</Text>
+          <Text style={styles.warnSubtitle}>
+            Diese Aktion ist unwiderruflich und kann nicht rückgängig gemacht
+            werden.
+          </Text>
+          <View style={styles.emailChip}>
+            <Ionicons
+              name="mail-outline"
+              size={13}
+              color={theme.colors.onSurfaceVariant}
+            />
+            <Text style={styles.emailChipText} numberOfLines={1}>
+              {email}
+            </Text>
+          </View>
+        </View>
+
+        {/* ── Was passiert ── */}
+        <Section title="Was passiert bei der Löschung?" theme={theme} styles={styles}>
+          <Bullet
+            icon="person-remove-outline"
+            text="Dein Anmeldekonto (E-Mail und Passwort) wird dauerhaft entfernt."
+            theme={theme}
+            styles={styles}
+          />
+          <Bullet
+            icon="id-card-outline"
+            text="Dein Profil (Name, Telefonnummer, Push-Token) wird gelöscht."
+            theme={theme}
+            styles={styles}
+          />
+          <Bullet
+            icon="log-out-outline"
+            text="Du wirst sofort abgemeldet und verlierst den Zugriff auf die App."
+            theme={theme}
+            styles={styles}
+            isLast
+          />
+        </Section>
+
+        {/* ── Verbleibende Daten (anonymisiert) ── */}
+        <Section
+          title="Welche Daten bleiben erhalten?"
+          theme={theme}
+          styles={styles}
+        >
+          <Bullet
+            icon="briefcase-outline"
+            text={
+              "Aufträge, Kommentare und Fotos, die du erstellt oder bearbeitet " +
+              "hast, bleiben aus betrieblichen und rechtlichen Gründen bei " +
+              "deinem Unternehmen erhalten."
+            }
+            theme={theme}
+            styles={styles}
+          />
+          <Bullet
+            icon="eye-off-outline"
+            text={
+              "Diese Einträge werden jedoch anonymisiert – sie sind danach nicht " +
+              "mehr mit deinem Namen oder Konto verknüpft."
+            }
+            theme={theme}
+            styles={styles}
+            isLast
+          />
+        </Section>
+
+        {/* ── Hinweis für Admins ── */}
+        {isAdmin && (
+          <View style={styles.adminNote}>
+            <Ionicons
+              name="information-circle-outline"
+              size={18}
+              color={theme.colors.statusInProgress}
+            />
+            <Text style={styles.adminNoteText}>
+              Als Administrator kannst du dein Konto nur löschen, wenn ein
+              weiterer aktiver Administrator existiert. Bist du der einzige
+              Administrator deiner Firma, löse zuerst die Firma auf oder ernenne
+              einen weiteren Administrator.
+            </Text>
+          </View>
+        )}
+
+        {/* ── Bestätigungs-Checkbox ── */}
+        <TouchableOpacity
+          style={styles.checkboxRow}
+          activeOpacity={0.8}
+          onPress={() => setConfirmed((v) => !v)}
+          disabled={loading}
+        >
+          <View
+            style={[styles.checkbox, confirmed && styles.checkboxChecked]}
+          >
+            {confirmed && (
+              <Ionicons
+                name="checkmark"
+                size={15}
+                color={theme.colors.onPrimary}
+              />
+            )}
+          </View>
+          <Text style={styles.checkboxLabel}>
+            Ich verstehe, dass diese Aktion unwiderruflich ist und mein Konto
+            dauerhaft gelöscht wird.
+          </Text>
+        </TouchableOpacity>
+
+        {/* ── Löschen-Button ── */}
+        <TouchableOpacity
+          style={[
+            styles.deleteButton,
+            (!confirmed || loading) && styles.deleteButtonDisabled,
+          ]}
+          activeOpacity={0.85}
+          onPress={handleDeletePress}
+          disabled={!confirmed || loading}
+        >
+          {loading ? (
+            <ActivityIndicator size="small" color={theme.colors.error} />
+          ) : (
+            <>
+              <Ionicons
+                name="trash-outline"
+                size={18}
+                color={theme.colors.error}
+              />
+              <Text style={styles.deleteButtonText}>Konto endgültig löschen</Text>
+            </>
+          )}
+        </TouchableOpacity>
+
+        {/* ── Abbrechen ── */}
+        <TouchableOpacity
+          style={styles.cancelButton}
+          activeOpacity={0.7}
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back();
+              return;
+            }
+            router.replace("/");
+          }}
+          disabled={loading}
+        >
+          <Text style={styles.cancelButtonText}>Abbrechen</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Section
+// ─────────────────────────────────────────────
+function Section({
+  title,
+  children,
+  theme,
+  styles,
+}: {
+  title: string;
+  children: React.ReactNode;
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <Card padding={0}>
+        <View style={styles.sectionInner}>{children}</View>
+      </Card>
+    </View>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Bullet
+// ─────────────────────────────────────────────
+function Bullet({
+  icon,
+  text,
+  theme,
+  styles,
+  isLast = false,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+  text: string;
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+  isLast?: boolean;
+}) {
+  return (
+    <View style={[styles.bulletRow, !isLast && styles.bulletDivider]}>
+      <View style={styles.bulletIcon}>
+        <Ionicons name={icon} size={16} color={theme.colors.onSurfaceVariant} />
+      </View>
+      <Text style={styles.bulletText}>{text}</Text>
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+
+    // ── Header
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.outlineVariant,
+    },
+    backButton: {
+      width: 36,
+      height: 36,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    headerTitle: {
+      flex: 1,
+      textAlign: "center",
+      fontSize: theme.typography.size.lg,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    headerSpacer: {
+      width: 36,
+    },
+
+    // ── Content
+    content: {
+      paddingHorizontal: theme.spacing.lg,
+      paddingTop: theme.spacing.lg,
+      paddingBottom: theme.spacing.xxl,
+      gap: theme.spacing.xl,
+    },
+
+    // ── Warn hero
+    warnHero: {
+      alignItems: "center",
+      gap: theme.spacing.sm,
+    },
+    warnIcon: {
+      width: 56,
+      height: 56,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.errorContainer,
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: theme.spacing.xs,
+    },
+    warnTitle: {
+      fontSize: theme.typography.size.xl,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+      textAlign: "center",
+      letterSpacing: theme.typography.letterSpacing.tight,
+    },
+    warnSubtitle: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      textAlign: "center",
+      lineHeight: theme.typography.lineHeight.sm,
+      maxWidth: 300,
+    },
+    emailChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.full,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 5,
+      marginTop: theme.spacing.xs,
+      maxWidth: "100%",
+    },
+    emailChipText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+      flexShrink: 1,
+    },
+
+    // ── Section
+    section: {
+      gap: theme.spacing.sm,
+    },
+    sectionTitle: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurfaceVariant,
+      letterSpacing: theme.typography.letterSpacing.wider,
+      textTransform: "uppercase",
+      marginLeft: theme.spacing.xs,
+    },
+    sectionInner: {
+      paddingHorizontal: theme.spacing.md,
+    },
+
+    // ── Bullet
+    bulletRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: theme.spacing.md,
+      paddingVertical: 14,
+    },
+    bulletDivider: {
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.outlineVariant,
+    },
+    bulletIcon: {
+      width: 30,
+      height: 30,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      alignItems: "center",
+      justifyContent: "center",
+      marginTop: 1,
+    },
+    bulletText: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+
+    // ── Admin note
+    adminNote: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.statusInProgressBg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusInProgressBorder,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.md,
+    },
+    adminNoteText: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+
+    // ── Checkbox
+    checkboxRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: theme.spacing.md,
+      backgroundColor: theme.colors.surface,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.md,
+    },
+    checkbox: {
+      width: 24,
+      height: 24,
+      borderRadius: theme.radius.sm,
+      borderWidth: 2,
+      borderColor: theme.colors.outline,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    checkboxChecked: {
+      backgroundColor: theme.colors.error,
+      borderColor: theme.colors.error,
+    },
+    checkboxLabel: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+
+    // ── Delete button
+    deleteButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      backgroundColor: theme.colors.errorContainer,
+      borderWidth: 1,
+      borderColor: theme.colors.error,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    deleteButtonDisabled: {
+      opacity: 0.45,
+    },
+    deleteButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.error,
+    },
+
+    // ── Cancel
+    cancelButton: {
+      alignItems: "center",
+      justifyContent: "center",
+      paddingVertical: theme.spacing.sm,
+      minHeight: theme.spacing.tapTarget,
+    },
+    cancelButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -18,7 +18,6 @@ import { router } from "expo-router";
 import React, { useMemo } from "react";
 import {
   Alert,
-  Linking,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -53,39 +52,6 @@ export default function ProfileScreen({
   const fullName = profile?.full_name?.trim() || email;
   const isAdmin = role === "admin";
   const hasCompany = !!profile?.company_id;
-
-  // ── Account- und Datenlöschung: öffnet die Mail-App mit vorausgefüllter
-  // Vorlage (kein echtes Löschsystem — nur mailto-Link, siehe Datenschutz-
-  // /Account-Löschungs-Text: Anfrage per E-Mail an info@novaflowdigital.de).
-  const handleRequestDeletion = () => {
-    const subject = "Account- und Datenlöschung – TaskOps Manager";
-    const body = `Hallo,
-
-ich möchte die Löschung meines Nutzerkontos und meiner personenbezogenen Daten in TaskOps Manager beantragen.
-
-Name:
-${profile?.full_name?.trim() || "[bitte ergänzen]"}
-
-Registrierte E-Mail:
-${user?.email || "[bitte ergänzen]"}
-
-Unternehmen / Company:
-[bitte ergänzen]
-
-Technische Company-ID:
-${profile?.company_id || "[bitte ergänzen]"}
-
-Vielen Dank.`;
-
-    const url = `mailto:info@novaflowdigital.de?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-
-    Linking.openURL(url).catch(() => {
-      Alert.alert(
-        "Keine Mail-App gefunden",
-        "Bitte sende eine E-Mail an info@novaflowdigital.de.",
-      );
-    });
-  };
 
   // ── Logout mit Bestätigung (signOut-Logik unverändert)
   const handleLogout = () => {
@@ -300,8 +266,8 @@ Vielen Dank.`;
           />
           <SettingsRow
             icon="trash-outline"
-            label="Account- und Datenlöschung beantragen"
-            onPress={handleRequestDeletion}
+            label="Konto löschen"
+            onPress={() => router.push("/delete-account")}
             styles={styles}
             theme={theme}
           />

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -335,6 +335,104 @@ grant execute on function public.current_user_role() to authenticated;
 grant execute on function public.current_user_company_id() to authenticated;
 
 -- =========================================================
+-- RPC: KONTOLÖSCHUNG — LAST-ADMIN-RESERVIERUNG
+-- =========================================================
+-- Siehe supabase/migrations/20260723000000_last_admin_deletion_reservation.sql
+-- für die ausführliche Begründung (Race Condition zwischen Admin-Zählung und
+-- auth.admin.deleteUser() in supabase/functions/delete-account/index.ts).
+--
+-- prepare_self_account_deletion() reserviert vor der eigentlichen Löschung
+-- den Admin-Platz, indem sie is_active=false auf das eigene Profil setzt und
+-- dabei ALLE Admin-Zeilen der Firma in einer einzigen, nach id sortierten
+-- FOR-UPDATE-Query sperrt (verhindert Deadlocks zwischen zwei gleichzeitig
+-- löschenden Admins). Ist der Aufrufer der letzte aktive Admin seiner Firma,
+-- schlägt die Funktion mit 'last_admin' fehl. Mitarbeiter (oder Admins ohne
+-- Firma) brauchen keine Reservierung und laufen ohne Sperre durch.
+create or replace function public.prepare_self_account_deletion()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+  v_role text;
+  v_company_id uuid;
+  v_other_active_admins int;
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  select role, company_id
+    into v_role, v_company_id
+  from public.profiles
+  where id = v_caller;
+
+  if not found then
+    raise exception 'profile_not_found';
+  end if;
+
+  if v_role <> 'admin' or v_company_id is null then
+    return;
+  end if;
+
+  perform 1
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+  order by id
+  for update;
+
+  select count(*)
+    into v_other_active_admins
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+    and is_active = true
+    and id <> v_caller;
+
+  if v_other_active_admins = 0 then
+    raise exception 'last_admin';
+  end if;
+
+  update public.profiles
+     set is_active = false
+   where id = v_caller;
+end;
+$$;
+
+revoke all on function public.prepare_self_account_deletion() from public, anon;
+grant execute on function public.prepare_self_account_deletion() to authenticated;
+
+-- Macht die Reservierung rückgängig, falls auth.admin.deleteUser() in der
+-- Edge Function fehlschlägt. No-op außer für genau den reservierten Zustand
+-- (role='admin', is_active=false) der eigenen Zeile.
+create or replace function public.rollback_self_account_deletion()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  update public.profiles
+     set is_active = true
+   where id = v_caller
+     and role = 'admin'
+     and is_active = false;
+end;
+$$;
+
+revoke all on function public.rollback_self_account_deletion() from public, anon;
+grant execute on function public.rollback_self_account_deletion() to authenticated;
+
+-- =========================================================
 -- RPC: SETUP COMPANY FOR ADMIN
 -- =========================================================
 

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -66,6 +66,12 @@ create table if not exists public.profiles (
   -- Migrations-Backfill bereits als akzeptiert markiert.
   invited_at timestamptz,
   invite_accepted_at timestamptz,
+  -- Selbstlöschungs-Reservierung (siehe 20260723000001_account_deletion_
+  -- reservation_tokens.sql): NULL = keine laufende Löschung. Getrennt von
+  -- is_active, das ausschließlich der administrativen Deaktivierung
+  -- vorbehalten bleibt.
+  account_deletion_token uuid,
+  account_deletion_reserved_at timestamptz,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
@@ -335,21 +341,24 @@ grant execute on function public.current_user_role() to authenticated;
 grant execute on function public.current_user_company_id() to authenticated;
 
 -- =========================================================
--- RPC: KONTOLÖSCHUNG — LAST-ADMIN-RESERVIERUNG
+-- RPC: KONTOLÖSCHUNG — LAST-ADMIN-RESERVIERUNG (Token-basiert, v2)
 -- =========================================================
--- Siehe supabase/migrations/20260723000000_last_admin_deletion_reservation.sql
--- für die ausführliche Begründung (Race Condition zwischen Admin-Zählung und
--- auth.admin.deleteUser() in supabase/functions/delete-account/index.ts).
+-- Siehe supabase/migrations/20260723000001_account_deletion_reservation_tokens.sql
+-- für die ausführliche Begründung. Kurzfassung: eine frühere Version nutzte
+-- is_active=false selbst als Reservierungs-Marker — das hatte zwei Probleme:
+-- (1) kein Recovery, falls die Edge Function zwischen Reservierung und
+-- deleteUser()/Rollback abstürzt, das Konto bliebe dauerhaft is_active=false;
+-- (2) is_active hätte damit zwei Bedeutungen geteilt (administrative
+-- Deaktivierung vs. Lösch-Reservierung) — rollback_self_account_deletion()
+-- hätte so ein administrativ deaktiviertes Konto reaktivieren können.
 --
--- prepare_self_account_deletion() reserviert vor der eigentlichen Löschung
--- den Admin-Platz, indem sie is_active=false auf das eigene Profil setzt und
--- dabei ALLE Admin-Zeilen der Firma in einer einzigen, nach id sortierten
--- FOR-UPDATE-Query sperrt (verhindert Deadlocks zwischen zwei gleichzeitig
--- löschenden Admins). Ist der Aufrufer der letzte aktive Admin seiner Firma,
--- schlägt die Funktion mit 'last_admin' fehl. Mitarbeiter (oder Admins ohne
--- Firma) brauchen keine Reservierung und laufen ohne Sperre durch.
+-- Diese Version trennt beides: is_active bleibt ausschließlich der
+-- administrativen Deaktivierung vorbehalten. Die Reservierung läuft über
+-- account_deletion_token/account_deletion_reserved_at + einen von der Edge
+-- Function verwalteten Zufalls-Token; recover_stale_account_deletion_
+-- reservations() räumt veraltete Reservierungen unabhängig von is_active ab.
 create or replace function public.prepare_self_account_deletion()
-returns void
+returns uuid
 language plpgsql
 security definer
 set search_path = public
@@ -358,14 +367,16 @@ declare
   v_caller uuid := auth.uid();
   v_role text;
   v_company_id uuid;
-  v_other_active_admins int;
+  v_is_active boolean;
+  v_other_available_admins int;
+  v_token uuid;
 begin
   if v_caller is null then
     raise exception 'unauthenticated';
   end if;
 
-  select role, company_id
-    into v_role, v_company_id
+  select role, company_id, is_active
+    into v_role, v_company_id, v_is_active
   from public.profiles
   where id = v_caller;
 
@@ -373,8 +384,17 @@ begin
     raise exception 'profile_not_found';
   end if;
 
+  if v_is_active is distinct from true then
+    raise exception 'inactive_account';
+  end if;
+
   if v_role <> 'admin' or v_company_id is null then
-    return;
+    v_token := gen_random_uuid();
+    update public.profiles
+       set account_deletion_token = v_token,
+           account_deletion_reserved_at = now()
+     where id = v_caller;
+    return v_token;
   end if;
 
   perform 1
@@ -385,30 +405,35 @@ begin
   for update;
 
   select count(*)
-    into v_other_active_admins
+    into v_other_available_admins
   from public.profiles
   where company_id = v_company_id
     and role = 'admin'
     and is_active = true
+    and account_deletion_token is null
     and id <> v_caller;
 
-  if v_other_active_admins = 0 then
+  if v_other_available_admins = 0 then
     raise exception 'last_admin';
   end if;
 
+  v_token := gen_random_uuid();
   update public.profiles
-     set is_active = false
+     set account_deletion_token = v_token,
+         account_deletion_reserved_at = now()
    where id = v_caller;
+
+  return v_token;
 end;
 $$;
 
 revoke all on function public.prepare_self_account_deletion() from public, anon;
 grant execute on function public.prepare_self_account_deletion() to authenticated;
 
--- Macht die Reservierung rückgängig, falls auth.admin.deleteUser() in der
--- Edge Function fehlschlägt. No-op außer für genau den reservierten Zustand
--- (role='admin', is_active=false) der eigenen Zeile.
-create or replace function public.rollback_self_account_deletion()
+-- Macht die Reservierung nur rückgängig, wenn der übergebene Token exakt
+-- passt. Fasst is_active nie an — kann daher nie ein administrativ
+-- deaktiviertes Konto reaktivieren.
+create or replace function public.rollback_self_account_deletion(p_token uuid)
 returns void
 language plpgsql
 security definer
@@ -416,21 +441,59 @@ set search_path = public
 as $$
 declare
   v_caller uuid := auth.uid();
+  v_rows int;
 begin
   if v_caller is null then
     raise exception 'unauthenticated';
   end if;
 
+  if p_token is null then
+    raise exception 'reservation_not_found';
+  end if;
+
   update public.profiles
-     set is_active = true
+     set account_deletion_token = null,
+         account_deletion_reserved_at = null
    where id = v_caller
-     and role = 'admin'
-     and is_active = false;
+     and account_deletion_token = p_token;
+
+  get diagnostics v_rows = row_count;
+
+  if v_rows = 0 then
+    raise exception 'reservation_not_found';
+  end if;
 end;
 $$;
 
-revoke all on function public.rollback_self_account_deletion() from public, anon;
-grant execute on function public.rollback_self_account_deletion() to authenticated;
+revoke all on function public.rollback_self_account_deletion(uuid) from public, anon;
+grant execute on function public.rollback_self_account_deletion(uuid) to authenticated;
+
+-- Räumt Reservierungen ab, die älter als 15 Minuten sind (Crash-/Timeout-
+-- Recovery). Nur service_role darf sie aufrufen — kein SECURITY DEFINER
+-- nötig, service_role umgeht RLS bereits über die eigene Rolle. Aktuell
+-- ausgelöst durch die Edge Function (best effort vor jedem neuen
+-- Löschversuch), kein Cron aktiv.
+create or replace function public.recover_stale_account_deletion_reservations()
+returns int
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_rows int;
+begin
+  update public.profiles
+     set account_deletion_token = null,
+         account_deletion_reserved_at = null
+   where account_deletion_reserved_at is not null
+     and account_deletion_reserved_at < now() - interval '15 minutes';
+
+  get diagnostics v_rows = row_count;
+  return v_rows;
+end;
+$$;
+
+revoke all on function public.recover_stale_account_deletion_reservations() from public, anon, authenticated;
+grant execute on function public.recover_stale_account_deletion_reservations() to service_role;
 
 -- =========================================================
 -- RPC: SETUP COMPANY FOR ADMIN

--- a/services/account/deleteAccount.ts
+++ b/services/account/deleteAccount.ts
@@ -11,7 +11,9 @@ export type DeleteAccountErrorCode =
   | "unauthenticated"
   | "profile_not_found"
   | "last_admin"
+  | "prepare_failed"
   | "delete_failed"
+  | "rollback_failed"
   | "server_error"
   | "unknown";
 

--- a/services/account/deleteAccount.ts
+++ b/services/account/deleteAccount.ts
@@ -10,6 +10,7 @@ export type DeleteAccountResult =
 export type DeleteAccountErrorCode =
   | "unauthenticated"
   | "profile_not_found"
+  | "inactive_account"
   | "last_admin"
   | "prepare_failed"
   | "delete_failed"

--- a/services/account/deleteAccount.ts
+++ b/services/account/deleteAccount.ts
@@ -1,0 +1,85 @@
+import { supabase } from "@/lib/supabase";
+
+// Ergebnis der Kontolöschung. Klar getrennt, damit die UI den Sonderfall
+// „letzter Admin" (409) mit einem erklärenden Hinweis behandeln kann, statt
+// nur eine generische Fehlermeldung zu zeigen.
+export type DeleteAccountResult =
+  | { ok: true }
+  | { ok: false; code: DeleteAccountErrorCode; message: string };
+
+export type DeleteAccountErrorCode =
+  | "unauthenticated"
+  | "profile_not_found"
+  | "last_admin"
+  | "delete_failed"
+  | "server_error"
+  | "unknown";
+
+const DEFAULT_ERROR =
+  "Dein Konto konnte nicht gelöscht werden. Bitte versuche es später erneut.";
+
+// Ruft die Edge Function delete-account auf. Der Server ermittelt die zu
+// löschende Identität ausschließlich aus der Session (kein Body-Parameter) —
+// ein Nutzer kann so nur sein eigenes Konto löschen.
+export async function requestAccountDeletion(): Promise<DeleteAccountResult> {
+  try {
+    const { data, error } = await supabase.functions.invoke("delete-account", {
+      body: {},
+    });
+
+    if (error) {
+      // Bei non-2xx liefert supabase-js einen FunctionsHttpError, dessen
+      // context die rohe Response ist — daraus den strukturierten Fehlercode
+      // lesen (z. B. "last_admin"), damit die UI passend reagieren kann.
+      const parsed = await parseFunctionError(error);
+      return {
+        ok: false,
+        code: parsed.code,
+        message: parsed.message,
+      };
+    }
+
+    // 2xx, aber Function meldet fachlich einen Fehler (defensiv).
+    if (data && typeof data === "object" && "error" in data && data.error) {
+      const body = data as { code?: DeleteAccountErrorCode; error?: string };
+      return {
+        ok: false,
+        code: body.code ?? "unknown",
+        message: body.error ?? DEFAULT_ERROR,
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    return { ok: false, code: "unknown", message: DEFAULT_ERROR };
+  }
+}
+
+async function parseFunctionError(
+  error: unknown,
+): Promise<{ code: DeleteAccountErrorCode; message: string }> {
+  const context = (error as { context?: unknown })?.context;
+
+  // context ist bei FunctionsHttpError eine Response — Body einmalig auslesen.
+  if (
+    context &&
+    typeof context === "object" &&
+    "json" in context &&
+    typeof (context as { json?: unknown }).json === "function"
+  ) {
+    try {
+      const body = (await (context as Response).json()) as {
+        code?: DeleteAccountErrorCode;
+        error?: string;
+      };
+      return {
+        code: body?.code ?? "unknown",
+        message: body?.error ?? DEFAULT_ERROR,
+      };
+    } catch {
+      // Body nicht lesbar/kein JSON → generischer Fehler.
+    }
+  }
+
+  return { code: "unknown", message: DEFAULT_ERROR };
+}

--- a/services/photos/photos.service.ts
+++ b/services/photos/photos.service.ts
@@ -90,7 +90,7 @@ type JobPhotoRow = {
   id: string;
   job_id: string;
   company_id: string;
-  uploaded_by: string;
+  uploaded_by: string | null;
   storage_path: string;
   file_name: string;
   file_size: number | null;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -426,6 +426,12 @@ enabled = true
 verify_jwt = false
 import_map = "./functions/dispatch-notifications/deno.json"
 entrypoint = "./functions/dispatch-notifications/index.ts"
+
+[functions.delete-account]
+enabled = true
+verify_jwt = false
+import_map = "./functions/delete-account/deno.json"
+entrypoint = "./functions/delete-account/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/create-employee/*.html" ]

--- a/supabase/functions/delete-account/.npmrc
+++ b/supabase/functions/delete-account/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/delete-account/DEPLOY.md
+++ b/supabase/functions/delete-account/DEPLOY.md
@@ -1,0 +1,55 @@
+# delete-account — Deployment & manuelle Schritte
+
+In-App-Kontolöschung (DSGVO / Google-Play-Account-Deletion-Policy). Der Nutzer
+löscht sein **eigenes** Konto über `Profil → Support → Konto löschen`
+(`app/delete-account.tsx` → `features/profile/DeleteAccountScreen.tsx`). Die
+Function entfernt den Auth-User mit dem Service-Role-Key; alle abhängigen Daten
+werden über die bestehenden Foreign Keys aufgelöst — es ist **keine SQL-Migration
+nötig**.
+
+## Voraussetzung: keine Schema-Änderung
+
+`admin.deleteUser` löscht die `auth.users`-Zeile. Die vorhandenen FKs (siehe
+`lib/schema.sql`) erledigen den Rest:
+
+- `profiles.id → auth.users(id) ON DELETE CASCADE` → Profil (Name, Telefon,
+  Push-Token) wird gelöscht.
+- `jobs.assigned_to` / `jobs.created_by` → `ON DELETE SET NULL` (Aufträge bleiben,
+  anonymisiert).
+- `job_comments.author_id` / `job_photos.uploaded_by` → `ON DELETE SET NULL`.
+- `job_comment_reads.user_id` → `ON DELETE CASCADE`.
+- `notification_deliveries.recipient_id` → `ON DELETE CASCADE`;
+  `notification_outbox.employee_id` → `ON DELETE SET NULL`.
+
+Firmen- und Auftragsdaten bleiben also aus betrieblichen/rechtlichen Gründen
+erhalten, verlieren aber jede Verknüpfung zum gelöschten Konto.
+
+## Deployen
+
+```bash
+supabase functions deploy delete-account
+```
+
+`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` werden für
+deployte Functions automatisch injiziert. Die Function prüft die Authorization
+selbst (`verify_jwt = false` in `config.toml`) und akzeptiert **keine** User-ID
+aus dem Request-Body — gelöscht wird ausschließlich die Identität aus der
+Session (`getUser()`).
+
+## Schutz „letzter Admin"
+
+Ist der Aufrufer der **einzige aktive Admin** seiner Firma, wird die Löschung mit
+HTTP 409 / `code: "last_admin"` abgelehnt (die App zeigt einen erklärenden
+Hinweis). Er muss zuerst die Firma auflösen bzw. einen weiteren aktiven Admin
+haben. Existiert ein weiterer aktiver Admin, wird nur das anfragende Konto
+gelöscht; die Firma bleibt unberührt. Mitarbeiter (`role = 'employee'`) können
+sich jederzeit selbst löschen.
+
+## Sicherheit
+
+- Der Service-Role-Key verlässt die Function nie und liegt nur serverseitig
+  (`Deno.env`) — niemals im App-Bundle.
+- Es kann nur das **eigene** Konto gelöscht werden (Identität aus der Session,
+  kein Body-Parameter).
+- Nach erfolgreicher Löschung meldet die App den Nutzer lokal ab, leert alle
+  lokalen Caches (Profil, Jobs, Offline-Queue) und leitet zum Login zurück.

--- a/supabase/functions/delete-account/DEPLOY.md
+++ b/supabase/functions/delete-account/DEPLOY.md
@@ -45,6 +45,15 @@ haben. Existiert ein weiterer aktiver Admin, wird nur das anfragende Konto
 gelöscht; die Firma bleibt unberührt. Mitarbeiter (`role = 'employee'`) können
 sich jederzeit selbst löschen.
 
+Die Prüfung läuft **atomar** über die RPC `public.prepare_self_account_deletion()`
+(siehe `supabase/migrations/20260723000000_last_admin_deletion_reservation.sql`)
+— ein reines SELECT-dann-`deleteUser()` ohne gemeinsame Transaktion würde
+zulassen, dass sich zwei Admins derselben Firma fast zeitgleich löschen und
+beide die Prüfung bestehen. Die RPC reserviert den Admin-Platz stattdessen
+vorab (`is_active=false`, committet vor `deleteUser()`); schlägt `deleteUser()`
+danach fehl, macht `public.rollback_self_account_deletion()` die Reservierung
+rückgängig.
+
 ## Sicherheit
 
 - Der Service-Role-Key verlässt die Function nie und liegt nur serverseitig

--- a/supabase/functions/delete-account/DEPLOY.md
+++ b/supabase/functions/delete-account/DEPLOY.md
@@ -4,10 +4,21 @@ In-App-Kontolöschung (DSGVO / Google-Play-Account-Deletion-Policy). Der Nutzer
 löscht sein **eigenes** Konto über `Profil → Support → Konto löschen`
 (`app/delete-account.tsx` → `features/profile/DeleteAccountScreen.tsx`). Die
 Function entfernt den Auth-User mit dem Service-Role-Key; alle abhängigen Daten
-werden über die bestehenden Foreign Keys aufgelöst — es ist **keine SQL-Migration
-nötig**.
+werden über die bestehenden Foreign Keys aufgelöst.
 
-## Voraussetzung: keine Schema-Änderung
+## Migrationen (müssen vor dem Deploy angewendet sein)
+
+- `20260722000000_fix_job_photos_uploaded_by_on_delete.sql` +
+  `20260722000001_job_photos_uploaded_by_drop_not_null.sql` — FK-Drift-Fix,
+  siehe unten.
+- `20260723000001_account_deletion_reservation_tokens.sql` — legt
+  `profiles.account_deletion_token` / `account_deletion_reserved_at` an und
+  die drei RPCs für den Last-Admin-Schutz (`prepare_self_account_deletion`,
+  `rollback_self_account_deletion`, `recover_stale_account_deletion_
+  reservations`). Ohne diese Migration schlägt jeder Löschversuch fehl, da
+  die Function diese RPCs zwingend aufruft.
+
+## Foreign Keys
 
 `admin.deleteUser` löscht die `auth.users`-Zeile. Die vorhandenen FKs (siehe
 `lib/schema.sql`) erledigen den Rest:
@@ -46,13 +57,24 @@ gelöscht; die Firma bleibt unberührt. Mitarbeiter (`role = 'employee'`) könne
 sich jederzeit selbst löschen.
 
 Die Prüfung läuft **atomar** über die RPC `public.prepare_self_account_deletion()`
-(siehe `supabase/migrations/20260723000000_last_admin_deletion_reservation.sql`)
+(siehe `supabase/migrations/20260723000001_account_deletion_reservation_tokens.sql`)
 — ein reines SELECT-dann-`deleteUser()` ohne gemeinsame Transaktion würde
 zulassen, dass sich zwei Admins derselben Firma fast zeitgleich löschen und
 beide die Prüfung bestehen. Die RPC reserviert den Admin-Platz stattdessen
-vorab (`is_active=false`, committet vor `deleteUser()`); schlägt `deleteUser()`
-danach fehl, macht `public.rollback_self_account_deletion()` die Reservierung
-rückgängig.
+vorab über `account_deletion_token`/`account_deletion_reserved_at` (**nicht**
+über `is_active`, das ausschließlich der administrativen Deaktivierung
+vorbehalten bleibt) und gibt einen Reservierungs-Token zurück. Schlägt
+`deleteUser()` danach fehl, macht `public.rollback_self_account_deletion(token)`
+die Reservierung — nur mit exakt diesem Token — rückgängig. Bricht die
+Function irgendwo dazwischen ab (Crash/Timeout), bleibt eine "verwaiste"
+Reservierung ohne Auswirkung auf Login/Nutzung des Kontos zurück, die
+`public.recover_stale_account_deletion_reservations()` (nur `service_role`,
+wird best-effort vor jedem neuen Löschversuch aufgerufen) nach 15 Minuten
+automatisch abräumt.
+
+Ist der Aufrufer bereits administrativ deaktiviert (`is_active=false`), lehnt
+die RPC die Vorbereitung mit `code: "inactive_account"` ab — ein deaktiviertes
+Konto darf keine Löschung anstoßen.
 
 ## Sicherheit
 

--- a/supabase/functions/delete-account/deno.json
+++ b/supabase/functions/delete-account/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/server": "npm:@supabase/server@^1"
+  }
+}

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,167 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+// Selbstlöschung des eigenen Kontos (DSGVO / Google-Play-Account-Deletion).
+// Ein Nutzer darf AUSSCHLIESSLICH sein eigenes Konto löschen — es wird nie eine
+// User-ID aus dem Request-Body akzeptiert, sondern immer die aus der Session
+// (userClient.auth.getUser()). Die eigentliche Löschung läuft über den
+// Service-Role-Admin-Client (admin.deleteUser); der Service-Key verlässt die
+// Function nie. Gleiches Auth-Muster wie create-employee / resend-invite.
+//
+// Datenfolgen der Auth-User-Löschung (FKs, siehe lib/schema.sql):
+// - profiles.id -> auth.users(id) ON DELETE CASCADE  → Profil (Name, Push-Token
+//   etc.) wird mitgelöscht.
+// - jobs.assigned_to / jobs.created_by            -> ON DELETE SET NULL (anonymisiert)
+// - job_comments.author_id / job_photos.uploaded_by -> ON DELETE SET NULL (anonymisiert)
+// - job_comment_reads.user_id                     -> ON DELETE CASCADE
+// - notification_deliveries.recipient_id          -> ON DELETE CASCADE
+// - notification_outbox.employee_id               -> ON DELETE SET NULL
+// Firmen-/Auftragsdaten bleiben also erhalten, nur ohne Verknüpfung zum Konto.
+//
+// Schutz „letzter Admin": Ein Admin, der der EINZIGE aktive Admin seiner Firma
+// ist, kann sich nicht löschen (Firma würde führungslos zurückbleiben). Er muss
+// zuerst die Firma auflösen bzw. einen weiteren Admin haben. Existiert ein
+// weiterer aktiver Admin, wird nur das anfragende Konto gelöscht.
+
+type DeleteAccountErrorCode =
+  | "unauthenticated"
+  | "profile_not_found"
+  | "last_admin"
+  | "delete_failed"
+  | "server_error";
+
+function errorResponse(
+  code: DeleteAccountErrorCode,
+  message: string,
+  status: number,
+) {
+  return Response.json(
+    { success: false, code, error: message },
+    { status, headers: corsHeaders },
+  );
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+    if (!supabaseUrl || !anonKey || !serviceRoleKey) {
+      throw new Error("Missing Supabase environment variables.");
+    }
+
+    const authHeader = req.headers.get("Authorization");
+
+    if (!authHeader) {
+      return errorResponse("unauthenticated", "Nicht eingeloggt.", 401);
+    }
+
+    // Client im Namen des aufrufenden Nutzers (nur zum Ermitteln der Identität).
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: {
+        headers: {
+          Authorization: authHeader,
+        },
+      },
+    });
+
+    // Privilegierter Client (Service Role) für Profil-Lookup + Löschung.
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    const {
+      data: { user },
+      error: userError,
+    } = await userClient.auth.getUser();
+
+    if (userError || !user) {
+      return errorResponse("unauthenticated", "Ungültige Session.", 401);
+    }
+
+    // Profil des Aufrufers laden (Rolle + Firma) — über den Admin-Client, damit
+    // RLS die Prüfung nicht verfälscht.
+    const { data: profile, error: profileError } = await adminClient
+      .from("profiles")
+      .select("id, role, company_id")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError || !profile) {
+      // Kein Profil (z. B. bereits gelöscht/inkonsistent): das Auth-Konto
+      // trotzdem entfernen, damit keine verwaiste auth.users-Zeile bleibt.
+      const { error: orphanDeleteError } =
+        await adminClient.auth.admin.deleteUser(user.id);
+
+      if (orphanDeleteError) {
+        return errorResponse(
+          "delete_failed",
+          "Konto konnte nicht gelöscht werden.",
+          500,
+        );
+      }
+
+      return Response.json({ success: true }, { headers: corsHeaders });
+    }
+
+    // ── Schutz „letzter Admin" ──
+    if (profile.role === "admin" && profile.company_id) {
+      const { count, error: countError } = await adminClient
+        .from("profiles")
+        .select("id", { count: "exact", head: true })
+        .eq("company_id", profile.company_id)
+        .eq("role", "admin")
+        .eq("is_active", true)
+        .neq("id", user.id);
+
+      if (countError) {
+        return errorResponse(
+          "server_error",
+          "Firmenprüfung fehlgeschlagen.",
+          500,
+        );
+      }
+
+      // Kein weiterer aktiver Admin → Firma wäre führungslos. Löschung sperren.
+      if (!count || count === 0) {
+        return errorResponse(
+          "last_admin",
+          "Als einziger Administrator kannst du dein Konto nicht löschen, " +
+            "solange deine Firma noch existiert. Bitte entferne zuerst alle " +
+            "Mitarbeiter und Auftragsdaten und löse die Firma auf, oder ernenne " +
+            "einen weiteren Administrator.",
+          409,
+        );
+      }
+    }
+
+    // ── Löschung: entfernt auth.users → cascade/set-null gemäß FKs oben. ──
+    const { error: deleteError } = await adminClient.auth.admin.deleteUser(
+      user.id,
+    );
+
+    if (deleteError) {
+      return errorResponse(
+        "delete_failed",
+        "Konto konnte nicht gelöscht werden.",
+        500,
+      );
+    }
+
+    return Response.json({ success: true }, { headers: corsHeaders });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unbekannter Fehler.";
+
+    return errorResponse("server_error", message, 500);
+  }
+});

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -28,12 +28,25 @@ const corsHeaders = {
 // ist, kann sich nicht löschen (Firma würde führungslos zurückbleiben). Er muss
 // zuerst die Firma auflösen bzw. einen weiteren Admin haben. Existiert ein
 // weiterer aktiver Admin, wird nur das anfragende Konto gelöscht.
+//
+// Race-Condition-Schutz: die Last-Admin-Prüfung läuft NICHT mehr als
+// separates SELECT hier in der Function (zwei Admins derselben Firma
+// könnten sich sonst fast zeitgleich löschen und beide "es gibt ja noch
+// einen anderen Admin" sehen). Stattdessen ruft diese Function zuerst die
+// atomare RPC public.prepare_self_account_deletion() auf (auth.uid()-basiert,
+// sperrt firmenweit alle Admin-Zeilen deterministisch und committet eine
+// is_active=false-Reservierung — siehe
+// supabase/migrations/20260723000000_last_admin_deletion_reservation.sql).
+// Schlägt das anschließende auth.admin.deleteUser() fehl, macht
+// public.rollback_self_account_deletion() die Reservierung rückgängig.
 
 type DeleteAccountErrorCode =
   | "unauthenticated"
   | "profile_not_found"
   | "last_admin"
+  | "prepare_failed"
   | "delete_failed"
+  | "rollback_failed"
   | "server_error";
 
 function errorResponse(
@@ -88,17 +101,20 @@ Deno.serve(async (req) => {
       return errorResponse("unauthenticated", "Ungültige Session.", 401);
     }
 
-    // Profil des Aufrufers laden (Rolle + Firma) — über den Admin-Client, damit
-    // RLS die Prüfung nicht verfälscht.
+    // Profil-Existenz prüfen — über den Admin-Client, damit RLS die Prüfung
+    // nicht verfälscht. Rolle/Firma werden nicht mehr hier gebraucht: die
+    // Last-Admin-Logik lebt jetzt vollständig in prepare_self_account_deletion().
     const { data: profile, error: profileError } = await adminClient
       .from("profiles")
-      .select("id, role, company_id")
+      .select("id")
       .eq("id", user.id)
       .single();
 
     if (profileError || !profile) {
       // Kein Profil (z. B. bereits gelöscht/inkonsistent): das Auth-Konto
       // trotzdem entfernen, damit keine verwaiste auth.users-Zeile bleibt.
+      // Keine Last-Admin-Reservierung nötig — ohne Profil gibt es keine
+      // Firmenzugehörigkeit zu schützen.
       const { error: orphanDeleteError } =
         await adminClient.auth.admin.deleteUser(user.id);
 
@@ -113,26 +129,17 @@ Deno.serve(async (req) => {
       return Response.json({ success: true }, { headers: corsHeaders });
     }
 
-    // ── Schutz „letzter Admin" ──
-    if (profile.role === "admin" && profile.company_id) {
-      const { count, error: countError } = await adminClient
-        .from("profiles")
-        .select("id", { count: "exact", head: true })
-        .eq("company_id", profile.company_id)
-        .eq("role", "admin")
-        .eq("is_active", true)
-        .neq("id", user.id);
+    // ── Schutz „letzter Admin" (atomar, RPC statt separates SELECT) ──
+    // Über userClient aufrufen, NICHT adminClient: auth.uid() innerhalb der
+    // RPC löst sich aus dem Authorization-Header dieses Requests auf — mit
+    // dem Service-Role-Client wäre auth.uid() NULL. Für Mitarbeiter (und
+    // Admins ohne Firma) ist dies ein no-op ohne Sperre, siehe RPC-Kommentar.
+    const { error: prepareError } = await userClient.rpc(
+      "prepare_self_account_deletion",
+    );
 
-      if (countError) {
-        return errorResponse(
-          "server_error",
-          "Firmenprüfung fehlgeschlagen.",
-          500,
-        );
-      }
-
-      // Kein weiterer aktiver Admin → Firma wäre führungslos. Löschung sperren.
-      if (!count || count === 0) {
+    if (prepareError) {
+      if (prepareError.message === "last_admin") {
         return errorResponse(
           "last_admin",
           "Als einziger Administrator kannst du dein Konto nicht löschen, " +
@@ -142,6 +149,18 @@ Deno.serve(async (req) => {
           409,
         );
       }
+
+      // Alles andere (profile_not_found, unerwarteter DB-Fehler): Details
+      // nur ins Server-Log, dem Client nur eine generische Meldung.
+      console.error("delete-account: prepare_self_account_deletion failed", {
+        userId: user.id,
+        message: prepareError.message,
+      });
+      return errorResponse(
+        "prepare_failed",
+        "Konto konnte nicht gelöscht werden.",
+        500,
+      );
     }
 
     // ── Löschung: entfernt auth.users → cascade/set-null gemäß FKs oben. ──
@@ -150,6 +169,30 @@ Deno.serve(async (req) => {
     );
 
     if (deleteError) {
+      // Reservierung (falls gesetzt) rückgängig machen — sonst bliebe ein
+      // Admin dauerhaft is_active=false, ohne dass sein Konto gelöscht wurde.
+      console.error("delete-account: deleteUser failed, rolling back", {
+        userId: user.id,
+        message: deleteError.message,
+      });
+
+      const { error: rollbackError } = await userClient.rpc(
+        "rollback_self_account_deletion",
+      );
+
+      if (rollbackError) {
+        console.error("delete-account: rollback_self_account_deletion failed", {
+          userId: user.id,
+          message: rollbackError.message,
+        });
+        return errorResponse(
+          "rollback_failed",
+          "Konto konnte nicht gelöscht werden und die Wiederherstellung ist " +
+            "fehlgeschlagen. Bitte kontaktiere den Support.",
+          500,
+        );
+      }
+
       return errorResponse(
         "delete_failed",
         "Konto konnte nicht gelöscht werden.",

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -29,20 +29,34 @@ const corsHeaders = {
 // zuerst die Firma auflösen bzw. einen weiteren Admin haben. Existiert ein
 // weiterer aktiver Admin, wird nur das anfragende Konto gelöscht.
 //
-// Race-Condition-Schutz: die Last-Admin-Prüfung läuft NICHT mehr als
-// separates SELECT hier in der Function (zwei Admins derselben Firma
-// könnten sich sonst fast zeitgleich löschen und beide "es gibt ja noch
-// einen anderen Admin" sehen). Stattdessen ruft diese Function zuerst die
-// atomare RPC public.prepare_self_account_deletion() auf (auth.uid()-basiert,
-// sperrt firmenweit alle Admin-Zeilen deterministisch und committet eine
-// is_active=false-Reservierung — siehe
-// supabase/migrations/20260723000000_last_admin_deletion_reservation.sql).
-// Schlägt das anschließende auth.admin.deleteUser() fehl, macht
-// public.rollback_self_account_deletion() die Reservierung rückgängig.
+// Race-Condition-Schutz: die Last-Admin-Prüfung läuft NICHT als separates
+// SELECT hier in der Function (zwei Admins derselben Firma könnten sich
+// sonst fast zeitgleich löschen und beide "es gibt ja noch einen anderen
+// Admin" sehen). Stattdessen ruft diese Function zuerst die atomare RPC
+// public.prepare_self_account_deletion() auf (auth.uid()-basiert, sperrt
+// firmenweit alle Admin-Zeilen deterministisch) — sie gibt bei Erfolg einen
+// Reservierungs-Token zurück. Schlägt das anschließende
+// auth.admin.deleteUser() fehl, macht public.rollback_self_account_deletion()
+// die Reservierung rückgängig, aber NUR mit genau diesem Token.
+//
+// Reservierung ≠ is_active: is_active bleibt ausschließlich der
+// administrativen Deaktivierung vorbehalten (prepare/rollback fassen es nie
+// an) — die Reservierung läuft komplett über account_deletion_token /
+// account_deletion_reserved_at. Bricht diese Function irgendwo zwischen
+// erfolgreichem prepare() und deleteUser()/rollback() ab (Crash, Timeout,
+// Netzwerkfehler), bleibt eine "verwaiste" Reservierung zurück, die KEINE
+// Auswirkung auf den Login/die Nutzung des Kontos hat (is_active
+// unverändert) — sie blockiert lediglich, dass ein anderer Admin derselben
+// Firma sich zeitgleich löscht. public.recover_stale_account_deletion_
+// reservations() (nur service_role) räumt solche Reservierungen nach 15
+// Minuten automatisch ab; diese Function ruft sie best-effort vor jedem
+// neuen Löschversuch auf. Details:
+// supabase/migrations/20260723000001_account_deletion_reservation_tokens.sql
 
 type DeleteAccountErrorCode =
   | "unauthenticated"
   | "profile_not_found"
+  | "inactive_account"
   | "last_admin"
   | "prepare_failed"
   | "delete_failed"
@@ -129,14 +143,31 @@ Deno.serve(async (req) => {
       return Response.json({ success: true }, { headers: corsHeaders });
     }
 
+    // Best effort: veraltete Reservierungen (Crash/Timeout eines früheren
+    // Löschversuchs, egal welcher Firma) vor diesem Versuch abräumen. Läuft
+    // über den Service-Role-Client, da nur service_role diese RPC ausführen
+    // darf. Ein Fehler hier ist nicht fatal für DIESEN Request — im
+    // schlimmsten Fall bleibt eine veraltete Fremd-Reservierung noch aktiv
+    // und der Aufrufer bekommt ggf. last_admin, obwohl der andere Admin
+    // eigentlich längst abgebrochen ist; das behebt der nächste Versuch.
+    const { error: recoverError } = await adminClient.rpc(
+      "recover_stale_account_deletion_reservations",
+    );
+
+    if (recoverError) {
+      console.error(
+        "delete-account: recover_stale_account_deletion_reservations failed",
+        { message: recoverError.message },
+      );
+    }
+
     // ── Schutz „letzter Admin" (atomar, RPC statt separates SELECT) ──
     // Über userClient aufrufen, NICHT adminClient: auth.uid() innerhalb der
     // RPC löst sich aus dem Authorization-Header dieses Requests auf — mit
     // dem Service-Role-Client wäre auth.uid() NULL. Für Mitarbeiter (und
     // Admins ohne Firma) ist dies ein no-op ohne Sperre, siehe RPC-Kommentar.
-    const { error: prepareError } = await userClient.rpc(
-      "prepare_self_account_deletion",
-    );
+    const { data: reservationToken, error: prepareError } =
+      await userClient.rpc("prepare_self_account_deletion");
 
     if (prepareError) {
       if (prepareError.message === "last_admin") {
@@ -147,6 +178,15 @@ Deno.serve(async (req) => {
             "Mitarbeiter und Auftragsdaten und löse die Firma auf, oder ernenne " +
             "einen weiteren Administrator.",
           409,
+        );
+      }
+
+      if (prepareError.message === "inactive_account") {
+        return errorResponse(
+          "inactive_account",
+          "Dein Konto ist deaktiviert. Bitte wende dich an deinen " +
+            "Administrator.",
+          403,
         );
       }
 
@@ -169,8 +209,11 @@ Deno.serve(async (req) => {
     );
 
     if (deleteError) {
-      // Reservierung (falls gesetzt) rückgängig machen — sonst bliebe ein
-      // Admin dauerhaft is_active=false, ohne dass sein Konto gelöscht wurde.
+      // Reservierung mit dem exakten Token rückgängig machen — sonst bliebe
+      // sie stehen, ohne dass das Konto gelöscht wurde (is_active ist davon
+      // nie betroffen, siehe Kommentar oben; recover_stale_... würde sie
+      // spätestens nach 15 Minuten ohnehin abräumen, aber der Rollback hier
+      // macht das sofort, statt auf das Zeitfenster zu warten).
       console.error("delete-account: deleteUser failed, rolling back", {
         userId: user.id,
         message: deleteError.message,
@@ -178,6 +221,7 @@ Deno.serve(async (req) => {
 
       const { error: rollbackError } = await userClient.rpc(
         "rollback_self_account_deletion",
+        { p_token: reservationToken },
       );
 
       if (rollbackError) {

--- a/supabase/migrations/20260722000000_fix_job_photos_uploaded_by_on_delete.sql
+++ b/supabase/migrations/20260722000000_fix_job_photos_uploaded_by_on_delete.sql
@@ -1,0 +1,37 @@
+-- Fix: job_photos.uploaded_by ON DELETE RESTRICT -> SET NULL
+--
+-- Kontext: In der Produktions-DB war der Fremdschlüssel
+-- job_photos_uploaded_by_fkey mit ON DELETE RESTRICT angelegt (Drift gegenüber
+-- lib/schema.sql, das seit jeher SET NULL dokumentiert). RESTRICT verhindert die
+-- Löschung eines Profils, sobald der Nutzer mindestens EIN Job-Foto hochgeladen
+-- hat: admin.deleteUser(auth.users) -> CASCADE auf profiles wird durch den
+-- RESTRICT-FK blockiert, die gesamte Kontolöschung schlägt fehl.
+--
+-- Das bricht die In-App-Kontolöschung (Edge Function delete-account) und damit
+-- die Google-Play-Account-Deletion-Policy: Ein Mitarbeiter, der Nachweisfotos
+-- hochgeladen hat, könnte sein Konto nicht löschen.
+--
+-- Korrektes Verhalten (wie bei jobs.created_by / job_comments.author_id):
+-- uploaded_by wird auf NULL gesetzt, das Foto bleibt als betrieblicher Nachweis
+-- erhalten, ist danach aber nicht mehr mit dem gelöschten Konto verknüpft
+-- (anonymisiert). Idempotent: nur ändern, wenn der FK aktuell nicht SET NULL ist.
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_constraint
+    where conname = 'job_photos_uploaded_by_fkey'
+      and conrelid = 'public.job_photos'::regclass
+      and confdeltype <> 'n'   -- 'n' = SET NULL
+  ) then
+    alter table public.job_photos
+      drop constraint job_photos_uploaded_by_fkey;
+
+    alter table public.job_photos
+      add constraint job_photos_uploaded_by_fkey
+      foreign key (uploaded_by)
+      references public.profiles(id)
+      on delete set null;
+  end if;
+end $$;

--- a/supabase/migrations/20260722000001_job_photos_uploaded_by_drop_not_null.sql
+++ b/supabase/migrations/20260722000001_job_photos_uploaded_by_drop_not_null.sql
@@ -1,0 +1,15 @@
+-- Fix (Teil 2): job_photos.uploaded_by NOT NULL entfernen.
+--
+-- Ergänzung zu 20260722000000: Der FK ist jetzt ON DELETE SET NULL, aber die
+-- Spalte uploaded_by war in der Produktions-DB zusätzlich NOT NULL (weiterer
+-- Drift gegenüber lib/schema.sql, wo die Spalte nullable dokumentiert ist).
+-- Solange NOT NULL gilt, kann SET NULL beim Löschen des Uploaders nicht greifen
+-- ("null value in column uploaded_by violates not-null constraint") und die
+-- Kontolöschung schlägt weiterhin fehl.
+--
+-- uploaded_by nullable machen (wie jobs.created_by / job_comments.author_id):
+-- Das Foto bleibt als betrieblicher Nachweis erhalten, der Uploader-Verweis wird
+-- beim Löschen des Kontos anonymisiert (NULL). Idempotent.
+
+alter table public.job_photos
+  alter column uploaded_by drop not null;

--- a/supabase/migrations/20260723000000_last_admin_deletion_reservation.sql
+++ b/supabase/migrations/20260723000000_last_admin_deletion_reservation.sql
@@ -1,0 +1,157 @@
+-- Last-Admin-Schutz für die Kontolöschung: schließt die Race Condition der
+-- bisherigen Prüfung in supabase/functions/delete-account/index.ts.
+--
+-- Bisher: die Edge Function zählte aktive Admins der Firma (SELECT), und rief
+-- danach separat auth.admin.deleteUser() auf — zwei unabhängige Schritte ohne
+-- gemeinsame Transaktion. Zwei Admins derselben Firma, die sich fast zeitgleich
+-- selbst löschen, sehen beide "es gibt noch einen weiteren aktiven Admin" und
+-- werden beide gelöscht → die Firma bleibt führungslos zurück.
+--
+-- Warum ein einfaches "SELECT ... FOR UPDATE" innerhalb der RPC NICHT reicht:
+-- Der Row-Lock existiert nur bis zum Ende der RPC-Transaktion (Commit beim
+-- Rückkehren der Funktion). auth.admin.deleteUser() läuft danach als
+-- separater Aufruf gegen GoTrue (Auth-Service), nicht innerhalb derselben
+-- Postgres-Transaktion — der Lock ist zu diesem Zeitpunkt längst freigegeben
+-- und schützt nichts mehr.
+--
+-- Lösung: prepare_self_account_deletion() reserviert den Admin-Platz VOR dem
+-- eigentlichen Löschen, indem sie das aufrufende Admin-Profil innerhalb der
+-- Prüf-Transaktion auf is_active=false setzt (COMMIT beim Funktionsende). Ein
+-- zeitgleicher zweiter Aufruf sieht diesen committeten Zustand (oder wartet
+-- durch den Row-Lock darauf) und zählt den ersten Admin korrekt nicht mehr
+-- mit. Schlägt der anschließende auth.admin.deleteUser() in der Edge Function
+-- fehl, macht rollback_self_account_deletion() die Reservierung rückgängig
+-- (is_active wieder true).
+--
+-- Keine neue Spalte nötig: is_active ist bereits die zentrale
+-- Deaktivierungs-Markierung (current_user_role()/current_user_company_id()
+-- liefern für is_active=false bewusst NULL, siehe Kommentar dort) — exakt
+-- das Verhalten, das eine "reservierte" Admin-Zeile für die Dauer der
+-- Löschung braucht. Nebeneffekt (gewollt, kein neuer Mechanismus): der
+-- clear_push_token_on_deactivate-Trigger und der Live-Deaktivierungs-Kanal
+-- in context/AuthContext.tsx reagieren auf is_active=false wie bei jeder
+-- anderen Deaktivierung auch — der Aufrufer wird ggf. bereits während der
+-- kurzen Reservierung clientseitig abgemeldet. Das ist unkritisch: entweder
+-- die Löschung schließt Sekundenbruchteile später ohnehin ab, oder — im
+-- seltenen Rollback-Fall (z. B. GoTrue-Ausfall) — der Nutzer muss sich
+-- lediglich erneut anmelden; das Konto selbst bleibt unverändert erhalten.
+
+-- =========================================================
+-- RPC: PREPARE SELF ACCOUNT DELETION (Last-Admin-Reservierung)
+-- =========================================================
+create or replace function public.prepare_self_account_deletion()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+  v_role text;
+  v_company_id uuid;
+  v_other_active_admins int;
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  -- Ungesperrtes Lesen: entscheidet nur, ob eine Reservierung überhaupt
+  -- nötig ist. Bewusst OHNE FOR UPDATE — siehe Kommentar bei der
+  -- Multi-Row-Sperre unten, warum ein separater Row-Lock auf die eigene
+  -- Zeile hier zu einem Deadlock zwischen zwei gleichzeitig aufrufenden
+  -- Admins führen würde.
+  select role, company_id
+    into v_role, v_company_id
+  from public.profiles
+  where id = v_caller;
+
+  if not found then
+    raise exception 'profile_not_found';
+  end if;
+
+  if v_role <> 'admin' or v_company_id is null then
+    -- Mitarbeiter (oder Admin ohne Firma): keine Reservierung nötig, die
+    -- Edge Function kann direkt mit auth.admin.deleteUser() fortfahren.
+    return;
+  end if;
+
+  -- Sperrt ALLE Admin-Zeilen der Firma (inkl. der eigenen) in EINEM
+  -- Statement, deterministisch nach id sortiert. Das ist absichtlich die
+  -- EINZIGE Sperre in dieser Funktion: würde man stattdessen zuerst nur die
+  -- eigene Zeile sperren und danach separat die der anderen Admins, würden
+  -- zwei sich gleichzeitig löschende Admins A und B jeweils die eigene
+  -- Zeile halten und auf die des jeweils anderen warten → klassischer
+  -- Postgres-Deadlock. Eine einzige Sperr-Query mit fester Reihenfolge
+  -- vermeidet das: beide Aufrufer fordern dieselben Zeilen in derselben
+  -- Reihenfolge an, es gibt keine zirkuläre Wartebeziehung — der zweite
+  -- Aufrufer wartet einfach, bis der erste committet.
+  perform 1
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+  order by id
+  for update;
+
+  select count(*)
+    into v_other_active_admins
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+    and is_active = true
+    and id <> v_caller;
+
+  if v_other_active_admins = 0 then
+    -- Kurzer, maschinenlesbarer Fehlertext: diese RPC wird ausschließlich
+    -- von supabase/functions/delete-account/index.ts aufgerufen, die daraus
+    -- die freundliche Nutzermeldung baut — kein Mensch sieht diesen Text
+    -- direkt.
+    raise exception 'last_admin';
+  end if;
+
+  -- Reservierung: is_active=false wird HIER committet (Funktionsende =
+  -- Ende der RPC-Transaktion), nicht nur gesperrt — das ist der Teil, der
+  -- über das Ende der Transaktion hinaus wirkt und die Race Condition
+  -- schließt, denn der Row-Lock selbst ist beim nachfolgenden
+  -- auth.admin.deleteUser()-Aufruf in der Edge Function bereits wieder frei.
+  update public.profiles
+     set is_active = false
+   where id = v_caller;
+end;
+$$;
+
+revoke all on function public.prepare_self_account_deletion() from public, anon;
+grant execute on function public.prepare_self_account_deletion() to authenticated;
+
+-- =========================================================
+-- RPC: ROLLBACK SELF ACCOUNT DELETION
+-- =========================================================
+-- Macht die Reservierung aus prepare_self_account_deletion() rückgängig,
+-- falls auth.admin.deleteUser() in der Edge Function fehlschlägt (z. B.
+-- GoTrue-Fehler). Sicher als no-op: setzt is_active nur zurück, wenn der
+-- Aufrufer aktuell genau im reservierten Zustand ist (role='admin',
+-- is_active=false) — ein Mitarbeiter (der nie reserviert wurde) oder ein
+-- bereits wieder aktiver Admin bleibt unberührt. Wirkt ausschließlich auf
+-- die eigene Zeile (auth.uid()), es gibt keinen user_id-Parameter.
+create or replace function public.rollback_self_account_deletion()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  update public.profiles
+     set is_active = true
+   where id = v_caller
+     and role = 'admin'
+     and is_active = false;
+end;
+$$;
+
+revoke all on function public.rollback_self_account_deletion() from public, anon;
+grant execute on function public.rollback_self_account_deletion() to authenticated;

--- a/supabase/migrations/20260723000001_account_deletion_reservation_tokens.sql
+++ b/supabase/migrations/20260723000001_account_deletion_reservation_tokens.sql
@@ -1,0 +1,243 @@
+-- Ersetzt is_active als Reservierungs-Marker für die Kontolöschung durch
+-- explizite Reservierungsspalten + Token.
+--
+-- Zwei Probleme mit dem is_active-basierten Ansatz aus
+-- 20260723000000_last_admin_deletion_reservation.sql:
+--
+-- 1. Crash-Fenster ohne Recovery: prepare_self_account_deletion() committet
+--    is_active=false, BEVOR die Edge Function auth.admin.deleteUser()
+--    aufruft. Bricht die Function danach ab (Timeout, Crash, Netzwerkfehler)
+--    BEVOR sie deleteUser() ODER den Rollback ausführen konnte, bleibt das
+--    Konto dauerhaft is_active=false, ohne gelöscht zu sein — kein Cron, kein
+--    Recovery-Mechanismus holt das nachträglich ein.
+--
+-- 2. is_active hat zwei unterscheidbare Bedeutungen, die dieselbe Spalte
+--    teilten: "administrativ deaktiviert" (z. B. durch einen anderen Admin)
+--    und "vorübergehend für die Löschung reserviert". rollback_self_account_
+--    deletion() konnte das nicht unterscheiden — sie prüfte nur
+--    role='admin' AND is_active=false und hätte damit auch ein ADMINISTRATIV
+--    deaktiviertes Konto reaktivieren können, wenn der betroffene Admin sie
+--    selbst aufruft (auth.uid()-bound, aber ohne echten Nachweis, dass GENAU
+--    DIESE Deaktivierung von einer eigenen Löschreservierung stammte).
+--
+-- Lösung: is_active bleibt AUSSCHLIESSLICH der administrativen Deaktivierung
+-- vorbehalten und wird von der Löschung nie mehr angefasst. Die Reservierung
+-- läuft stattdessen über zwei neue, ausschließlich für diesen Zweck genutzte
+-- Spalten + einen zufälligen Token, den nur die Edge Function kennt (sie wird
+-- von prepare_self_account_deletion() zurückgegeben und muss unverändert an
+-- rollback_self_account_deletion() übergeben werden — ein falscher/fremder
+-- Token bewirkt nichts).
+
+alter table public.profiles
+  add column if not exists account_deletion_token uuid null,
+  add column if not exists account_deletion_reserved_at timestamptz null;
+
+comment on column public.profiles.account_deletion_token is
+  'Zufälliger Token einer laufenden Selbstlöschungs-Reservierung (siehe prepare_self_account_deletion). NULL = keine Reservierung. Unabhängig von is_active.';
+comment on column public.profiles.account_deletion_reserved_at is
+  'Zeitpunkt der letzten Löschreservierung. Wird von recover_stale_account_deletion_reservations() genutzt, um veraltete Reservierungen (Crash/Timeout der Edge Function) automatisch abzuräumen.';
+
+-- Alte Funktionen entfernen: prepare_self_account_deletion() ändert den
+-- Rückgabetyp (void -> uuid), das kann CREATE OR REPLACE nicht (siehe
+-- Kommentar bei current_user_role() in lib/schema.sql). rollback_self_
+-- account_deletion() bekommt einen neuen Parameter (p_token uuid) — ohne
+-- expliziten DROP würde CREATE OR REPLACE eine zusätzliche Überladung
+-- anlegen und die alte, unsichere parameterlose Version bliebe weiter
+-- aufrufbar.
+drop function if exists public.prepare_self_account_deletion();
+drop function if exists public.rollback_self_account_deletion();
+
+-- =========================================================
+-- RPC: PREPARE SELF ACCOUNT DELETION (v2, Token-basiert)
+-- =========================================================
+-- Gibt den neu erzeugten Reservierungs-Token zurück. Schlägt fehl, wenn:
+--   - kein Profil existiert ('profile_not_found')
+--   - das Profil bereits is_active=false ist ('inactive_account') — ein
+--     administrativ deaktiviertes Konto darf gar nicht erst eine Löschung
+--     anstoßen, unabhängig von jeder Reservierung
+--   - der Aufrufer der letzte verfügbare Admin seiner Firma ist ('last_admin')
+create or replace function public.prepare_self_account_deletion()
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+  v_role text;
+  v_company_id uuid;
+  v_is_active boolean;
+  v_other_available_admins int;
+  v_token uuid;
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  -- Ungesperrtes Lesen: entscheidet nur den weiteren Ablauf. Bewusst OHNE
+  -- FOR UPDATE — siehe Kommentar bei der Multi-Row-Sperre unten, warum ein
+  -- separater Row-Lock auf die eigene Zeile hier zu einem Deadlock zwischen
+  -- zwei gleichzeitig aufrufenden Admins führen würde.
+  select role, company_id, is_active
+    into v_role, v_company_id, v_is_active
+  from public.profiles
+  where id = v_caller;
+
+  if not found then
+    raise exception 'profile_not_found';
+  end if;
+
+  if v_is_active is distinct from true then
+    -- Administrativ deaktivierte Konten dürfen keine Löschung anstoßen.
+    -- is_active wird von dieser RPC nie gesetzt — ist es hier schon false,
+    -- kann das nur ein anderer Vorgang (Admin-Deaktivierung) gewesen sein.
+    raise exception 'inactive_account';
+  end if;
+
+  if v_role <> 'admin' or v_company_id is null then
+    -- Mitarbeiter (oder Admin ohne Firma): keine Last-Admin-Prüfung nötig,
+    -- aber trotzdem einen Token vergeben, damit die Edge Function bei einem
+    -- Rollback-Bedarf einheitlich verfahren kann.
+    v_token := gen_random_uuid();
+    update public.profiles
+       set account_deletion_token = v_token,
+           account_deletion_reserved_at = now()
+     where id = v_caller;
+    return v_token;
+  end if;
+
+  -- Sperrt ALLE Admin-Zeilen der Firma (inkl. der eigenen) in EINEM
+  -- Statement, deterministisch nach id sortiert — die einzige Sperre in
+  -- dieser Funktion. Zwei separate Sperren (erst eigene Zeile, dann die der
+  -- anderen Admins) würden bei zwei gleichzeitig löschenden Admins zu einer
+  -- zirkulären Wartebeziehung und damit zu einem Postgres-Deadlock führen.
+  -- Eine einzige Sperr-Query mit fester Reihenfolge vermeidet das.
+  perform 1
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+  order by id
+  for update;
+
+  -- "Verfügbar" heißt: aktiv UND ohne eigene laufende Löschreservierung.
+  -- Ein Admin mit account_deletion_token IS NOT NULL zählt nicht mehr mit,
+  -- auch wenn is_active noch true ist (is_active wird ja nicht mehr
+  -- geändert) — sonst könnten sich zwei Admins gegenseitig als "verfügbar"
+  -- sehen, obwohl beide bereits mitten in der eigenen Löschung stecken.
+  select count(*)
+    into v_other_available_admins
+  from public.profiles
+  where company_id = v_company_id
+    and role = 'admin'
+    and is_active = true
+    and account_deletion_token is null
+    and id <> v_caller;
+
+  if v_other_available_admins = 0 then
+    -- Kurzer, maschinenlesbarer Fehlertext: diese RPC wird ausschließlich
+    -- von supabase/functions/delete-account/index.ts aufgerufen.
+    raise exception 'last_admin';
+  end if;
+
+  v_token := gen_random_uuid();
+  update public.profiles
+     set account_deletion_token = v_token,
+         account_deletion_reserved_at = now()
+   where id = v_caller;
+
+  return v_token;
+end;
+$$;
+
+revoke all on function public.prepare_self_account_deletion() from public, anon;
+grant execute on function public.prepare_self_account_deletion() to authenticated;
+
+-- =========================================================
+-- RPC: ROLLBACK SELF ACCOUNT DELETION (v2, Token-basiert)
+-- =========================================================
+-- Macht NUR die eigene Reservierung rückgängig, und nur wenn der
+-- übergebene Token exakt zum aktuell gespeicherten passt. is_active wird
+-- nie angefasst — kann also auch nie fälschlich ein administrativ
+-- deaktiviertes Konto reaktivieren, unabhängig davon, wer die Funktion
+-- aufruft oder welchen Token er übergibt. Bei fehlendem Treffer (falscher/
+-- fremder Token ODER die Reservierung wurde inzwischen bereits durch
+-- recover_stale_account_deletion_reservations() entfernt) wirft die
+-- Funktion 'reservation_not_found', statt still keine Zeile zu ändern —
+-- die Edge Function soll das explizit als rollback_failed erkennen können.
+create or replace function public.rollback_self_account_deletion(p_token uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+  v_rows int;
+begin
+  if v_caller is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  if p_token is null then
+    raise exception 'reservation_not_found';
+  end if;
+
+  update public.profiles
+     set account_deletion_token = null,
+         account_deletion_reserved_at = null
+   where id = v_caller
+     and account_deletion_token = p_token;
+
+  get diagnostics v_rows = row_count;
+
+  if v_rows = 0 then
+    raise exception 'reservation_not_found';
+  end if;
+end;
+$$;
+
+revoke all on function public.rollback_self_account_deletion(uuid) from public, anon;
+grant execute on function public.rollback_self_account_deletion(uuid) to authenticated;
+
+-- =========================================================
+-- RPC: RECOVER STALE ACCOUNT DELETION RESERVATIONS
+-- =========================================================
+-- Räumt NUR die Reservierungs-Marker ab (Token + Timestamp) von
+-- Reservierungen, die älter als 15 Minuten sind — weit über jeder
+-- realistischen Edge-Function-Laufzeit, aber kurz genug, um nach einem
+-- Crash/Timeout zeitnah einen neuen Löschversuch zuzulassen. Fasst is_active
+-- NIE an (die Reservierung setzt es ja auch nie), kann also nie
+-- fälschlich einen administrativ deaktivierten Nutzer reaktivieren.
+--
+-- Kein SECURITY DEFINER: nur service_role darf diese Funktion aufrufen
+-- (siehe Grants unten), und service_role umgeht RLS bereits durch die
+-- eigene Rolle — SECURITY DEFINER wäre hier ein ungenutztes Privileg.
+--
+-- Auslösung (aktuell): die Edge Function ruft diese Funktion best-effort
+-- vor JEDEM neuen Löschversuch auf (supabase/functions/delete-account/
+-- index.ts) — das reicht für den MVP-Betrieb aus, ohne dass eine
+-- zusätzliche Infrastruktur (Cron) nötig ist. Ein zukünftiger pg_cron-Job
+-- (z. B. alle 15 Minuten) wäre eine sinnvolle Ergänzung, falls einmal
+-- Reservierungen anfallen, ohne dass zeitnah ein neuer Löschversuch
+-- unternommen wird — NICHT Teil dieser Migration, bewusst nicht aktiviert.
+create or replace function public.recover_stale_account_deletion_reservations()
+returns int
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_rows int;
+begin
+  update public.profiles
+     set account_deletion_token = null,
+         account_deletion_reserved_at = null
+   where account_deletion_reserved_at is not null
+     and account_deletion_reserved_at < now() - interval '15 minutes';
+
+  get diagnostics v_rows = row_count;
+  return v_rows;
+end;
+$$;
+
+revoke all on function public.recover_stale_account_deletion_reservations() from public, anon, authenticated;
+grant execute on function public.recover_stale_account_deletion_reservations() to service_role;

--- a/supabase/tests/last_admin_deletion_reservation.test.sql
+++ b/supabase/tests/last_admin_deletion_reservation.test.sql
@@ -1,19 +1,26 @@
 -- =========================================================
--- TEST: prepare_self_account_deletion / rollback_self_account_deletion
--- (Migration 20260723000000_last_admin_deletion_reservation)
+-- TEST: prepare_self_account_deletion / rollback_self_account_deletion /
+--       recover_stale_account_deletion_reservations
+-- (Migrationen 20260723000000_last_admin_deletion_reservation +
+--  20260723000001_account_deletion_reservation_tokens)
 -- =========================================================
--- Prüft die atomare Last-Admin-Reservierung für die Kontolöschung: ein
--- Mitarbeiter darf immer vorbereiten, ein einzelner (letzter) Admin wird
--- abgelehnt, ein Admin von zweien wird reserviert (is_active=false) ohne
--- den anderen Admin zu berühren, ein zweiter Admin wird danach korrekt
--- abgelehnt, rollback stellt den Ausgangszustand wieder her, und weder
--- anon noch ein anderer Nutzer können die Reservierung für ein fremdes
--- Konto auslösen.
+-- Deckt die Token-basierte Last-Admin-Reservierung ab: ein Mitarbeiter darf
+-- immer vorbereiten, ein einzelner (letzter) Admin wird abgelehnt, ein Admin
+-- von zweien wird reserviert (Token, OHNE is_active zu ändern) ohne den
+-- anderen Admin zu berühren, ein zweiter Admin wird danach korrekt
+-- abgelehnt, Rollback mit korrektem Token stellt den Ausgangszustand wieder
+-- her, Rollback mit falschem/fremdem Token schlägt fehl, ein administrativ
+-- deaktiviertes Konto darf keine Löschung anstoßen, veraltete Reservierungen
+-- werden von der Recovery-Funktion entfernt (frische bleiben unberührt),
+-- und weder anon noch normale authenticated-Nutzer können die
+-- privilegierten Pfade missbrauchen.
 --
 -- AUSFÜHREN: im Supabase SQL Editor (läuft als postgres) komplett einfügen
--- und ausführen. Legt Testdaten an, simuliert Aufrufer über SET ROLE +
--- request.jwt.claims, macht am Ende ROLLBACK — es bleiben KEINE Testdaten
--- zurück.
+-- und ausführen, oder lokal via
+--   psql "$(supabase status -o env | grep DB_URL | cut -d= -f2- | tr -d '"')" \
+--     -f supabase/tests/last_admin_deletion_reservation.test.sql
+-- Legt Testdaten an, simuliert Aufrufer über SET ROLE + request.jwt.claims,
+-- macht am Ende ROLLBACK — es bleiben KEINE Testdaten zurück.
 --
 -- Ergebnis: eine Tabelle am Ende (case_no | beschreibung | erwartet |
 -- ergebnis | verdikt) sowie NOTICE-Meldungen im Messages-/Log-Panel.
@@ -22,9 +29,12 @@
 begin;
 
 -- Fixe IDs für Lesbarkeit:
---   Firma Solo (ein Admin)  = 31111111…
---   Firma Duo  (zwei Admins + ein Mitarbeiter) = 32222222…
---   adminSolo = 41…1 | adminX = 42…2 | adminY = 43…3 | employeeZ = 44…4
+--   Firma Solo (ein Admin)              = 31111111…
+--   Firma Duo  (2 Admins + 1 Mitarbeiter) = 32222222…
+--   Firma Inactive (1 administrativ deaktivierter Admin) = 33333333…
+--   Firma Recovery (2 Admins, für Recovery-Fixtures)     = 34444444…
+--   adminSolo=41…1 | adminX=42…2 | adminY=43…3 | employeeZ=44…4
+--   adminInactive=45…5 | adminOld=46…6 | adminFresh=47…7
 do $$
 begin
   insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
@@ -32,17 +42,41 @@ begin
     ('00000000-0000-0000-0000-000000000000','41000000-0000-0000-0000-000000000001','authenticated','authenticated','lastadmin-solo@example.test','{"full_name":"Admin Solo"}'),
     ('00000000-0000-0000-0000-000000000000','42000000-0000-0000-0000-000000000002','authenticated','authenticated','lastadmin-x@example.test','{"full_name":"Admin X"}'),
     ('00000000-0000-0000-0000-000000000000','43000000-0000-0000-0000-000000000003','authenticated','authenticated','lastadmin-y@example.test','{"full_name":"Admin Y"}'),
-    ('00000000-0000-0000-0000-000000000000','44000000-0000-0000-0000-000000000004','authenticated','authenticated','lastadmin-emp@example.test','{"full_name":"Mitarbeiter Z"}');
+    ('00000000-0000-0000-0000-000000000000','44000000-0000-0000-0000-000000000004','authenticated','authenticated','lastadmin-emp@example.test','{"full_name":"Mitarbeiter Z"}'),
+    ('00000000-0000-0000-0000-000000000000','45000000-0000-0000-0000-000000000005','authenticated','authenticated','lastadmin-inactive@example.test','{"full_name":"Admin Inactive"}'),
+    ('00000000-0000-0000-0000-000000000000','46000000-0000-0000-0000-000000000006','authenticated','authenticated','lastadmin-old@example.test','{"full_name":"Admin Old"}'),
+    ('00000000-0000-0000-0000-000000000000','47000000-0000-0000-0000-000000000007','authenticated','authenticated','lastadmin-fresh@example.test','{"full_name":"Admin Fresh"}');
 end $$;
+
+-- Absicherung für lokale Baselines ohne den auth.users-Trigger
+-- handle_new_user (siehe Hinweis in supabase/tests/profile_field_guard.test.sql-
+-- Historie / Projekt-Memory): legt die profiles-Zeile nur an, falls der
+-- Trigger sie nicht schon erzeugt hat. Auf einer Umgebung MIT Trigger ist
+-- dies ein reines No-op (ON CONFLICT DO NOTHING), auf einer Umgebung ohne
+-- Trigger übernimmt es dessen Aufgabe für den Test.
+insert into public.profiles (id, full_name) values
+  ('41000000-0000-0000-0000-000000000001','Admin Solo'),
+  ('42000000-0000-0000-0000-000000000002','Admin X'),
+  ('43000000-0000-0000-0000-000000000003','Admin Y'),
+  ('44000000-0000-0000-0000-000000000004','Mitarbeiter Z'),
+  ('45000000-0000-0000-0000-000000000005','Admin Inactive'),
+  ('46000000-0000-0000-0000-000000000006','Admin Old'),
+  ('47000000-0000-0000-0000-000000000007','Admin Fresh')
+on conflict (id) do nothing;
 
 insert into public.companies (id, name, slug) values
   ('31111111-1111-1111-1111-111111111111','Lastadmin Firma Solo','lastadmin-firma-solo'),
-  ('32222222-2222-2222-2222-222222222222','Lastadmin Firma Duo','lastadmin-firma-duo');
+  ('32222222-2222-2222-2222-222222222222','Lastadmin Firma Duo','lastadmin-firma-duo'),
+  ('33333333-3333-3333-3333-333333333333','Lastadmin Firma Inactive','lastadmin-firma-inactive'),
+  ('34444444-4444-4444-4444-444444444444','Lastadmin Firma Recovery','lastadmin-firma-recovery');
 
-update public.profiles set role='admin',    company_id='31111111-1111-1111-1111-111111111111', is_active=true where id='41000000-0000-0000-0000-000000000001';
-update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='42000000-0000-0000-0000-000000000002';
-update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='43000000-0000-0000-0000-000000000003';
-update public.profiles set role='employee', company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='44000000-0000-0000-0000-000000000004';
+update public.profiles set role='admin',    company_id='31111111-1111-1111-1111-111111111111', is_active=true  where id='41000000-0000-0000-0000-000000000001';
+update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true  where id='42000000-0000-0000-0000-000000000002';
+update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true  where id='43000000-0000-0000-0000-000000000003';
+update public.profiles set role='employee', company_id='32222222-2222-2222-2222-222222222222', is_active=true  where id='44000000-0000-0000-0000-000000000004';
+update public.profiles set role='admin',    company_id='33333333-3333-3333-3333-333333333333', is_active=false where id='45000000-0000-0000-0000-000000000005';
+update public.profiles set role='admin',    company_id='34444444-4444-4444-4444-444444444444', is_active=true  where id='46000000-0000-0000-0000-000000000006';
+update public.profiles set role='admin',    company_id='34444444-4444-4444-4444-444444444444', is_active=true  where id='47000000-0000-0000-0000-000000000007';
 
 create temp table _lastadmin_results (
   case_no  int,
@@ -51,32 +85,15 @@ create temp table _lastadmin_results (
   ergebnis text
 ) on commit drop;
 
--- =========================================================
--- CASE 1: Mitarbeiter bereitet Löschung vor → ERLAUBT, keine Reservierung
--- (is_active bleibt true — Mitarbeiter brauchen keine Sperre)
--- =========================================================
-do $$
-declare v text; active_after boolean;
-begin
-  perform set_config('request.jwt.claims','{"sub":"44000000-0000-0000-0000-000000000004","role":"authenticated"}', true);
-  execute 'set local role authenticated';
-  begin
-    perform public.prepare_self_account_deletion();
-    v := 'ALLOWED';
-  exception
-    when others then v := 'ERROR:'||sqlerrm;
-  end;
-  execute 'reset role';
-  select is_active into active_after from public.profiles where id='44000000-0000-0000-0000-000000000004';
-  if v = 'ALLOWED' and active_after is distinct from true then
-    v := 'ALLOWED_BUT_DEACTIVATED';
-  end if;
-  insert into _lastadmin_results values (1,'Mitarbeiter bereitet Löschung vor','ALLOWED',v);
-  raise notice 'CASE 1 (employee prepares) -> %', v;
-end $$;
+-- Stash für Tokens zwischen den Cases (jede do-Block-Ausführung hat einen
+-- eigenen PL/pgSQL-Scope, Werte müssen also zwischengespeichert werden).
+create temp table _lastadmin_tokens (
+  who text primary key,
+  token uuid
+) on commit drop;
 
 -- =========================================================
--- CASE 2: Einziger Admin seiner Firma bereitet Löschung vor → BLOCKIERT
+-- CASE 1 (Anforderung 1): Einziger Admin seiner Firma -> BLOCKIERT
 -- =========================================================
 do $$
 declare v text;
@@ -90,60 +107,36 @@ begin
     when others then v := 'ERROR:'||sqlerrm;
   end;
   execute 'reset role';
-  insert into _lastadmin_results values (2,'Einziger Admin (Firma Solo) bereitet Löschung vor','ERROR:last_admin',v);
-  raise notice 'CASE 2 (solo admin) -> %', v;
+  insert into _lastadmin_results values (1,'Einziger Admin (Firma Solo) bereitet Löschung vor','ERROR:last_admin',v);
+  raise notice 'CASE 1 (solo admin) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 3: Admin X (Firma Duo, hat Admin Y als Kollege) → ERLAUBT
+-- CASE 2 (Anforderung 2): Admin X (Firma Duo, hat Admin Y) -> ERLAUBT,
+-- gibt einen Token zurück (kein NULL/leerer Wert)
 -- =========================================================
 do $$
-declare v text;
+declare v text; v_token uuid;
 begin
   perform set_config('request.jwt.claims','{"sub":"42000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
-    perform public.prepare_self_account_deletion();
-    v := 'ALLOWED';
+    select public.prepare_self_account_deletion() into v_token;
+    v := case when v_token is not null then 'ALLOWED:token' else 'ALLOWED:NULL_TOKEN' end;
   exception
     when others then v := 'ERROR:'||sqlerrm;
   end;
   execute 'reset role';
-  insert into _lastadmin_results values (3,'Admin X (Firma Duo, mit Admin Y aktiv) bereitet vor','ALLOWED',v);
-  raise notice 'CASE 3 (admin X of two) -> %', v;
+  if v_token is not null then
+    insert into _lastadmin_tokens values ('adminX', v_token);
+  end if;
+  insert into _lastadmin_results values (2,'Admin X (Firma Duo) bereitet vor, bekommt Token','ALLOWED:token',v);
+  raise notice 'CASE 2 (admin X of two) -> % (token=%)', v, v_token;
 end $$;
 
 -- =========================================================
--- CASE 4: Admin X wurde reserviert (is_active=false) — eigener Zustand
--- =========================================================
-do $$
-declare active_x boolean; v text;
-begin
-  select is_active into active_x from public.profiles where id='42000000-0000-0000-0000-000000000002';
-  v := case when active_x = false then 'is_active=false' else 'is_active='||coalesce(active_x::text,'null') end;
-  insert into _lastadmin_results values (4,'Admin X ist nach prepare reserviert (is_active=false)','is_active=false',v);
-  raise notice 'CASE 4 (admin X reserved) -> %', v;
-end $$;
-
--- =========================================================
--- CASE 5: Admin Y (fremdes Konto aus Sicht von Admin X) bleibt UNBERÜHRT
--- — belegt, dass prepare_self_account_deletion() ausschließlich auf die
--- eigene Zeile (auth.uid()) wirkt und niemals ein fremdes Konto anfassen
--- kann (es gibt auch keinen user_id-Parameter, der das erlauben würde).
--- =========================================================
-do $$
-declare active_y boolean; v text;
-begin
-  select is_active into active_y from public.profiles where id='43000000-0000-0000-0000-000000000003';
-  v := case when active_y = true then 'is_active=true (unberührt)' else 'is_active='||coalesce(active_y::text,'null')||' (FEHLER: fremdes Konto verändert)' end;
-  insert into _lastadmin_results values (5,'Admin Y bleibt unberührt von Admin X''s prepare-Aufruf','is_active=true (unberührt)',v);
-  raise notice 'CASE 5 (admin Y untouched) -> %', v;
-end $$;
-
--- =========================================================
--- CASE 6: Admin Y bereitet jetzt vor (Admin X bereits reserviert/inaktiv)
--- → BLOCKIERT, da aus Sicht von Y kein anderer AKTIVER Admin mehr existiert
--- (genau der Fall, den die alte SELECT-dann-deleteUser-Logik verpasst hätte)
+-- CASE 3 (Anforderung 3): Admin Y nach Admin X-Reservierung -> BLOCKIERT
+-- (X zählt nicht mehr als "verfügbar", da er einen Token hat)
 -- =========================================================
 do $$
 declare v text;
@@ -157,50 +150,213 @@ begin
     when others then v := 'ERROR:'||sqlerrm;
   end;
   execute 'reset role';
-  insert into _lastadmin_results values (6,'Admin Y nach Admin X-Reservierung -> BLOCKIERT','ERROR:last_admin',v);
-  raise notice 'CASE 6 (admin Y after X reserved) -> %', v;
+  insert into _lastadmin_results values (3,'Admin Y nach Admin X-Reservierung','ERROR:last_admin',v);
+  raise notice 'CASE 3 (admin Y after X reserved) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 7: Rollback stellt Admin X wieder auf is_active=true
+-- CASE 4 (Anforderung 4): Reservierung ändert is_active NICHT
 -- =========================================================
 do $$
-declare v text; active_after boolean;
+declare active_x boolean; v text;
 begin
+  select is_active into active_x from public.profiles where id='42000000-0000-0000-0000-000000000002';
+  v := 'is_active='||coalesce(active_x::text,'null');
+  insert into _lastadmin_results values (4,'Admin X ist nach prepare weiterhin is_active=true','is_active=true',v);
+  raise notice 'CASE 4 (is_active unaffected) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 5 (Anforderung 5): Rollback mit korrektem Token -> ERFOLG
+-- =========================================================
+do $$
+declare v text; v_token uuid; token_after uuid;
+begin
+  select token into v_token from _lastadmin_tokens where who='adminX';
   perform set_config('request.jwt.claims','{"sub":"42000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
-    perform public.rollback_self_account_deletion();
+    perform public.rollback_self_account_deletion(v_token);
     v := 'CALLED';
   exception
     when others then v := 'ERROR:'||sqlerrm;
   end;
   execute 'reset role';
-  select is_active into active_after from public.profiles where id='42000000-0000-0000-0000-000000000002';
+  select account_deletion_token into token_after from public.profiles where id='42000000-0000-0000-0000-000000000002';
   if v = 'CALLED' then
-    v := case when active_after = true then 'is_active=true' else 'is_active='||coalesce(active_after::text,'null') end;
+    v := case when token_after is null then 'OK:token_cleared' else 'FEHLER:token_noch_gesetzt' end;
   end if;
-  insert into _lastadmin_results values (7,'Rollback stellt Admin X auf is_active=true zurück','is_active=true',v);
-  raise notice 'CASE 7 (rollback restores X) -> %', v;
+  insert into _lastadmin_results values (5,'Rollback mit korrektem Token','OK:token_cleared',v);
+  raise notice 'CASE 5 (rollback correct token) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 8: anon kann die RPC NICHT ausführen (BLOCKIERT, insufficient_privilege)
+-- CASE 6 (Anforderung 6): Rollback mit FALSCHEM Token -> FEHLER
+-- (frische Reservierung für Admin X, dann Rollback mit zufälligem Token)
+-- =========================================================
+do $$
+declare v text; v_token uuid;
+begin
+  perform set_config('request.jwt.claims','{"sub":"42000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    select public.prepare_self_account_deletion() into v_token;
+  exception
+    when others then v_token := null;
+  end;
+  begin
+    perform public.rollback_self_account_deletion(gen_random_uuid());
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  if v_token is not null then
+    insert into _lastadmin_tokens values ('adminX', v_token)
+      on conflict (who) do update set token = excluded.token;
+  end if;
+  insert into _lastadmin_results values (6,'Rollback mit falschem/fremdem Token','ERROR:reservation_not_found',v);
+  raise notice 'CASE 6 (rollback wrong token) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 7 (Anforderung 7): Admin Y versucht Rollback von Admin X''s
+-- Reservierung mit dessen ECHTEM Token -> FEHLER (eigene Zeile != X)
+-- =========================================================
+do $$
+declare v text; v_token uuid; token_x_after uuid;
+begin
+  select token into v_token from _lastadmin_tokens where who='adminX';
+  perform set_config('request.jwt.claims','{"sub":"43000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.rollback_self_account_deletion(v_token);
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  select account_deletion_token into token_x_after from public.profiles where id='42000000-0000-0000-0000-000000000002';
+  if token_x_after is distinct from v_token then
+    v := v || ' + FEHLER:X_wurde_veraendert';
+  end if;
+  insert into _lastadmin_results values (7,'Admin Y versucht Rollback von Admin X''s Reservierung','ERROR:reservation_not_found',v);
+  raise notice 'CASE 7 (cross-user rollback blocked) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 8 (Anforderung 8): Administrativ deaktivierter Admin -> BLOCKIERT
 -- =========================================================
 do $$
 declare v text;
 begin
-  execute 'set local role anon';
+  perform set_config('request.jwt.claims','{"sub":"45000000-0000-0000-0000-000000000005","role":"authenticated"}', true);
+  execute 'set local role authenticated';
   begin
     perform public.prepare_self_account_deletion();
     v := 'ALLOWED';
   exception
-    when insufficient_privilege then v := 'BLOCKED(42501)';
-    when others then v := 'ERROR:'||sqlstate||':'||sqlerrm;
+    when others then v := 'ERROR:'||sqlerrm;
   end;
   execute 'reset role';
-  insert into _lastadmin_results values (8,'anon ruft prepare_self_account_deletion() auf','BLOCKED(42501)',v);
-  raise notice 'CASE 8 (anon blocked) -> %', v;
+  insert into _lastadmin_results values (8,'Administrativ deaktivierter Admin bereitet Löschung vor','ERROR:inactive_account',v);
+  raise notice 'CASE 8 (inactive admin blocked) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 9 + 10 (Anforderung 9+10): Recovery entfernt NUR veraltete
+-- Reservierungen (> 15 Min.), frische bleiben unberührt
+-- =========================================================
+do $$
+declare v9 text; v10 text; cleared int;
+begin
+  -- Fixtures direkt setzen (als postgres) statt über prepare(), damit die
+  -- Last-Admin-Logik hier nicht mit hineinspielt — dieser Case testet nur
+  -- recover_stale_account_deletion_reservations() isoliert.
+  update public.profiles
+     set account_deletion_token = gen_random_uuid(),
+         account_deletion_reserved_at = now() - interval '30 minutes'
+   where id = '46000000-0000-0000-0000-000000000006';
+
+  update public.profiles
+     set account_deletion_token = gen_random_uuid(),
+         account_deletion_reserved_at = now()
+   where id = '47000000-0000-0000-0000-000000000007';
+
+  execute 'set local role service_role';
+  select public.recover_stale_account_deletion_reservations() into cleared;
+  execute 'reset role';
+
+  select case when account_deletion_token is null then 'OK:cleared' else 'FEHLER:not_cleared' end
+    into v9
+  from public.profiles where id='46000000-0000-0000-0000-000000000006';
+
+  select case when account_deletion_token is not null then 'OK:kept' else 'FEHLER:cleared' end
+    into v10
+  from public.profiles where id='47000000-0000-0000-0000-000000000007';
+
+  insert into _lastadmin_results values (9,'Recovery entfernt veraltete Reservierung (>15 Min.)','OK:cleared',v9);
+  insert into _lastadmin_results values (10,'Recovery lässt frische Reservierung unberührt','OK:kept',v10);
+  raise notice 'CASE 9 (stale removed) -> % | CASE 10 (fresh kept) -> % | cleared_rows=%', v9, v10, cleared;
+end $$;
+
+-- =========================================================
+-- CASE 11/12/13 (Anforderung 11): Rechte-Matrix via has_function_privilege()
+-- statt eines echten Aufrufs als anon/authenticated.
+--
+-- Hinweis: ein ECHTER Aufruf mit tatsächlich fehlendem EXECUTE-Recht
+-- (SET LOCAL ROLE anon; perform public.<fn>();) bringt den lokalen
+-- Supabase-Postgres-Container auf diesem Rechner reproduzierbar zum Absturz
+-- (SIGSEGV — bestätigt in den Server-Logs, auch mit der bereits vorher
+-- existierenden Funktion current_user_role() nach explizitem REVOKE FROM
+-- anon; ein Docker-Image-/Postgres-Build-Fehler, unabhängig von dieser
+-- Migration). has_function_privilege() prüft dieselbe ACL-Information ohne
+-- die Funktion aufzurufen und ist deshalb hier die sichere Alternative.
+-- =========================================================
+do $$
+declare
+  v11 text; v12 text; v13a text; v13b text;
+begin
+  v11 := case when has_function_privilege('anon','public.prepare_self_account_deletion()','EXECUTE')
+              then 'ALLOWED' else 'BLOCKED' end;
+  v12 := case when has_function_privilege('anon','public.rollback_self_account_deletion(uuid)','EXECUTE')
+              then 'ALLOWED' else 'BLOCKED' end;
+  v13a := case when has_function_privilege('authenticated','public.recover_stale_account_deletion_reservations()','EXECUTE')
+              then 'ALLOWED' else 'BLOCKED' end;
+  v13b := case when has_function_privilege('service_role','public.recover_stale_account_deletion_reservations()','EXECUTE')
+              then 'ALLOWED' else 'BLOCKED' end;
+
+  insert into _lastadmin_results values (11,'anon: EXECUTE auf prepare_self_account_deletion()','BLOCKED',v11);
+  insert into _lastadmin_results values (12,'anon: EXECUTE auf rollback_self_account_deletion(uuid)','BLOCKED',v12);
+  insert into _lastadmin_results values (13,'authenticated: EXECUTE auf recover_stale_...() (muss BLOCKED sein) / service_role (muss ALLOWED sein)','BLOCKED+ALLOWED',v13a||'+'||v13b);
+  raise notice 'CASE 11 -> % | CASE 12 -> % | CASE 13 -> %+%', v11, v12, v13a, v13b;
+end $$;
+
+-- =========================================================
+-- CASE 14 (Anforderung 12): Rollback OHNE laufende Reservierung ändert
+-- weder is_active noch sonst etwas am Profil (Mitarbeiter Z, nie reserviert)
+-- =========================================================
+do $$
+declare v text; active_before boolean; active_after boolean; role_before text; role_after text;
+begin
+  select is_active, role into active_before, role_before from public.profiles where id='44000000-0000-0000-0000-000000000004';
+
+  perform set_config('request.jwt.claims','{"sub":"44000000-0000-0000-0000-000000000004","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.rollback_self_account_deletion(null);
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select is_active, role into active_after, role_after from public.profiles where id='44000000-0000-0000-0000-000000000004';
+  if active_before is distinct from active_after or role_before is distinct from role_after then
+    v := v || ' + FEHLER:Profil_veraendert';
+  end if;
+  insert into _lastadmin_results values (14,'Rollback ohne laufende Reservierung (Mitarbeiter Z)','ERROR:reservation_not_found',v);
+  raise notice 'CASE 14 (rollback without reservation, no-op) -> %', v;
 end $$;
 
 -- =========================================================
@@ -212,8 +368,8 @@ select
   erwartet,
   ergebnis,
   case
+    when ergebnis like (erwartet || '%') then 'PASS'
     when erwartet = ergebnis then 'PASS'
-    when erwartet = 'ALLOWED' and ergebnis = 'ALLOWED' then 'PASS'
     else 'FAIL'
   end as verdikt
 from _lastadmin_results

--- a/supabase/tests/last_admin_deletion_reservation.test.sql
+++ b/supabase/tests/last_admin_deletion_reservation.test.sql
@@ -1,0 +1,223 @@
+-- =========================================================
+-- TEST: prepare_self_account_deletion / rollback_self_account_deletion
+-- (Migration 20260723000000_last_admin_deletion_reservation)
+-- =========================================================
+-- Prüft die atomare Last-Admin-Reservierung für die Kontolöschung: ein
+-- Mitarbeiter darf immer vorbereiten, ein einzelner (letzter) Admin wird
+-- abgelehnt, ein Admin von zweien wird reserviert (is_active=false) ohne
+-- den anderen Admin zu berühren, ein zweiter Admin wird danach korrekt
+-- abgelehnt, rollback stellt den Ausgangszustand wieder her, und weder
+-- anon noch ein anderer Nutzer können die Reservierung für ein fremdes
+-- Konto auslösen.
+--
+-- AUSFÜHREN: im Supabase SQL Editor (läuft als postgres) komplett einfügen
+-- und ausführen. Legt Testdaten an, simuliert Aufrufer über SET ROLE +
+-- request.jwt.claims, macht am Ende ROLLBACK — es bleiben KEINE Testdaten
+-- zurück.
+--
+-- Ergebnis: eine Tabelle am Ende (case_no | beschreibung | erwartet |
+-- ergebnis | verdikt) sowie NOTICE-Meldungen im Messages-/Log-Panel.
+-- =========================================================
+
+begin;
+
+-- Fixe IDs für Lesbarkeit:
+--   Firma Solo (ein Admin)  = 31111111…
+--   Firma Duo  (zwei Admins + ein Mitarbeiter) = 32222222…
+--   adminSolo = 41…1 | adminX = 42…2 | adminY = 43…3 | employeeZ = 44…4
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','41000000-0000-0000-0000-000000000001','authenticated','authenticated','lastadmin-solo@example.test','{"full_name":"Admin Solo"}'),
+    ('00000000-0000-0000-0000-000000000000','42000000-0000-0000-0000-000000000002','authenticated','authenticated','lastadmin-x@example.test','{"full_name":"Admin X"}'),
+    ('00000000-0000-0000-0000-000000000000','43000000-0000-0000-0000-000000000003','authenticated','authenticated','lastadmin-y@example.test','{"full_name":"Admin Y"}'),
+    ('00000000-0000-0000-0000-000000000000','44000000-0000-0000-0000-000000000004','authenticated','authenticated','lastadmin-emp@example.test','{"full_name":"Mitarbeiter Z"}');
+end $$;
+
+insert into public.companies (id, name, slug) values
+  ('31111111-1111-1111-1111-111111111111','Lastadmin Firma Solo','lastadmin-firma-solo'),
+  ('32222222-2222-2222-2222-222222222222','Lastadmin Firma Duo','lastadmin-firma-duo');
+
+update public.profiles set role='admin',    company_id='31111111-1111-1111-1111-111111111111', is_active=true where id='41000000-0000-0000-0000-000000000001';
+update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='42000000-0000-0000-0000-000000000002';
+update public.profiles set role='admin',    company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='43000000-0000-0000-0000-000000000003';
+update public.profiles set role='employee', company_id='32222222-2222-2222-2222-222222222222', is_active=true where id='44000000-0000-0000-0000-000000000004';
+
+create temp table _lastadmin_results (
+  case_no  int,
+  beschreibung text,
+  erwartet text,
+  ergebnis text
+) on commit drop;
+
+-- =========================================================
+-- CASE 1: Mitarbeiter bereitet Löschung vor → ERLAUBT, keine Reservierung
+-- (is_active bleibt true — Mitarbeiter brauchen keine Sperre)
+-- =========================================================
+do $$
+declare v text; active_after boolean;
+begin
+  perform set_config('request.jwt.claims','{"sub":"44000000-0000-0000-0000-000000000004","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.prepare_self_account_deletion();
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  select is_active into active_after from public.profiles where id='44000000-0000-0000-0000-000000000004';
+  if v = 'ALLOWED' and active_after is distinct from true then
+    v := 'ALLOWED_BUT_DEACTIVATED';
+  end if;
+  insert into _lastadmin_results values (1,'Mitarbeiter bereitet Löschung vor','ALLOWED',v);
+  raise notice 'CASE 1 (employee prepares) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 2: Einziger Admin seiner Firma bereitet Löschung vor → BLOCKIERT
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform set_config('request.jwt.claims','{"sub":"41000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.prepare_self_account_deletion();
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  insert into _lastadmin_results values (2,'Einziger Admin (Firma Solo) bereitet Löschung vor','ERROR:last_admin',v);
+  raise notice 'CASE 2 (solo admin) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 3: Admin X (Firma Duo, hat Admin Y als Kollege) → ERLAUBT
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform set_config('request.jwt.claims','{"sub":"42000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.prepare_self_account_deletion();
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  insert into _lastadmin_results values (3,'Admin X (Firma Duo, mit Admin Y aktiv) bereitet vor','ALLOWED',v);
+  raise notice 'CASE 3 (admin X of two) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 4: Admin X wurde reserviert (is_active=false) — eigener Zustand
+-- =========================================================
+do $$
+declare active_x boolean; v text;
+begin
+  select is_active into active_x from public.profiles where id='42000000-0000-0000-0000-000000000002';
+  v := case when active_x = false then 'is_active=false' else 'is_active='||coalesce(active_x::text,'null') end;
+  insert into _lastadmin_results values (4,'Admin X ist nach prepare reserviert (is_active=false)','is_active=false',v);
+  raise notice 'CASE 4 (admin X reserved) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 5: Admin Y (fremdes Konto aus Sicht von Admin X) bleibt UNBERÜHRT
+-- — belegt, dass prepare_self_account_deletion() ausschließlich auf die
+-- eigene Zeile (auth.uid()) wirkt und niemals ein fremdes Konto anfassen
+-- kann (es gibt auch keinen user_id-Parameter, der das erlauben würde).
+-- =========================================================
+do $$
+declare active_y boolean; v text;
+begin
+  select is_active into active_y from public.profiles where id='43000000-0000-0000-0000-000000000003';
+  v := case when active_y = true then 'is_active=true (unberührt)' else 'is_active='||coalesce(active_y::text,'null')||' (FEHLER: fremdes Konto verändert)' end;
+  insert into _lastadmin_results values (5,'Admin Y bleibt unberührt von Admin X''s prepare-Aufruf','is_active=true (unberührt)',v);
+  raise notice 'CASE 5 (admin Y untouched) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 6: Admin Y bereitet jetzt vor (Admin X bereits reserviert/inaktiv)
+-- → BLOCKIERT, da aus Sicht von Y kein anderer AKTIVER Admin mehr existiert
+-- (genau der Fall, den die alte SELECT-dann-deleteUser-Logik verpasst hätte)
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform set_config('request.jwt.claims','{"sub":"43000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.prepare_self_account_deletion();
+    v := 'ALLOWED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  insert into _lastadmin_results values (6,'Admin Y nach Admin X-Reservierung -> BLOCKIERT','ERROR:last_admin',v);
+  raise notice 'CASE 6 (admin Y after X reserved) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 7: Rollback stellt Admin X wieder auf is_active=true
+-- =========================================================
+do $$
+declare v text; active_after boolean;
+begin
+  perform set_config('request.jwt.claims','{"sub":"42000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+  execute 'set local role authenticated';
+  begin
+    perform public.rollback_self_account_deletion();
+    v := 'CALLED';
+  exception
+    when others then v := 'ERROR:'||sqlerrm;
+  end;
+  execute 'reset role';
+  select is_active into active_after from public.profiles where id='42000000-0000-0000-0000-000000000002';
+  if v = 'CALLED' then
+    v := case when active_after = true then 'is_active=true' else 'is_active='||coalesce(active_after::text,'null') end;
+  end if;
+  insert into _lastadmin_results values (7,'Rollback stellt Admin X auf is_active=true zurück','is_active=true',v);
+  raise notice 'CASE 7 (rollback restores X) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 8: anon kann die RPC NICHT ausführen (BLOCKIERT, insufficient_privilege)
+-- =========================================================
+do $$
+declare v text;
+begin
+  execute 'set local role anon';
+  begin
+    perform public.prepare_self_account_deletion();
+    v := 'ALLOWED';
+  exception
+    when insufficient_privilege then v := 'BLOCKED(42501)';
+    when others then v := 'ERROR:'||sqlstate||':'||sqlerrm;
+  end;
+  execute 'reset role';
+  insert into _lastadmin_results values (8,'anon ruft prepare_self_account_deletion() auf','BLOCKED(42501)',v);
+  raise notice 'CASE 8 (anon blocked) -> %', v;
+end $$;
+
+-- =========================================================
+-- Ergebnisübersicht
+-- =========================================================
+select
+  case_no,
+  beschreibung,
+  erwartet,
+  ergebnis,
+  case
+    when erwartet = ergebnis then 'PASS'
+    when erwartet = 'ALLOWED' and ergebnis = 'ALLOWED' then 'PASS'
+    else 'FAIL'
+  end as verdikt
+from _lastadmin_results
+order by case_no;
+
+-- Nichts persistieren — reine Prüfung.
+rollback;

--- a/types/photo.ts
+++ b/types/photo.ts
@@ -6,7 +6,11 @@ export type JobPhoto = {
   id: string;
   jobId: string;
   companyId: string;
-  uploadedBy: string;
+  // uploaded_by ist nullable + on delete set null: verlässt der Uploader
+  // die Firma / löscht sein Konto, bleibt das Foto als Nachweis erhalten,
+  // ist danach aber nicht mehr mit einem Konto verknüpft (siehe
+  // supabase/migrations/20260722000000_fix_job_photos_uploaded_by_on_delete.sql).
+  uploadedBy: string | null;
   storagePath: string;
   fileName: string;
   fileSize: number | null;


### PR DESCRIPTION
## Summary

- Ersetzt den bisherigen `mailto:`-Link zur Kontolöschung durch einen echten In-App-Löschvorgang (DSGVO / Google-Play-Account-Deletion-Policy).
- Neuer vollständiger Bestätigungs-Screen (`features/profile/DeleteAccountScreen.tsx`) mit Erklärung, Checkbox-Bestätigung, nativem Bestätigungsdialog, Loading-/Error-State.
- Neue sichere Edge Function `supabase/functions/delete-account` — löscht ausschließlich das eigene Konto, Service Role bleibt serverseitig.
- Zwei Migrationen zur Behebung von Produktions-Drift bei `job_photos.uploaded_by` (war `RESTRICT` + `NOT NULL` statt dokumentiertem `SET NULL`/nullable) — hätte sonst jede Kontolöschung eines Nutzers mit hochgeladenen Fotos blockiert.
- Last-Admin-Schutz: ein Admin kann sich nicht löschen, wenn er der letzte aktive Admin seiner Firma ist.
- Token-basierte Deletion-Reservation (`account_deletion_token` / `account_deletion_reserved_at`) statt Missbrauch von `is_active` als Reservierungs-Marker.
- Recovery-Mechanismus für hängengebliebene Reservierungen nach Crash/Timeout der Edge Function.
- TypeScript-Nullability-Fix für `JobPhoto.uploadedBy` (kann nach FK-`SET NULL` tatsächlich `null` sein).

## Security

- Identität kommt **ausschließlich** aus `auth.uid()` / `userClient.auth.getUser()` — nie aus dem Request-Body oder einem RPC-Parameter. Kein Endpunkt akzeptiert eine fremde `user_id`.
- Der Service-Role-Key wird **nur** innerhalb der Edge Function verwendet (`Deno.env`) und verlässt sie nie — kein Service-Role-Zugriff aus der React-Native-App (verifiziert per Repo-weitem Grep).
- `prepare_self_account_deletion()` und `rollback_self_account_deletion(uuid)` sind auf `authenticated` beschränkt; `anon` und `public` sind explizit per `revoke` gesperrt (verifiziert via `has_function_privilege()`, nicht nur behauptet).
- `recover_stale_account_deletion_reservations()` ist ausschließlich für `service_role` freigegeben — weder `anon` noch `authenticated` können sie aufrufen.
- Alle drei RPCs nutzen `set search_path = public` (fester, sicherer Search Path); `prepare`/`rollback` sind `SECURITY DEFINER` (nötig, um die eigene Zeile trotz RLS zu ändern), `recover_stale_...` bewusst **ohne** `SECURITY DEFINER` (nicht nötig — `service_role` umgeht RLS bereits über die eigene Rolle).
- **Last-Admin Race Condition** verhindert durch: ein einziges `SELECT ... FOR UPDATE` mit fester, nach `id` sortierter Reihenfolge über alle Admin-Zeilen der Firma (verhindert Deadlocks zwischen zwei gleichzeitig löschenden Admins) + einen committeten Reservation-Token, der bei der "verfügbare Admins"-Zählung berücksichtigt wird.
- `rollback_self_account_deletion()` verlangt den **exakt passenden Token** der eigenen Zeile und fasst `is_active` **nie** an — kann dadurch strukturell nie ein administrativ deaktiviertes Konto reaktivieren (frühere Zwischenversion hatte dieses Risiko, wurde vor diesem PR bereits korrigiert).

## Tests

Tatsächlich ausgeführt (lokaler Supabase-Stack, `supabase db reset` von den Migrationen aus):

- `npx tsc --noEmit` — **pass**
- `npm run lint` — **pass**
- `git diff --check` — **pass**
- `supabase/tests/last_admin_deletion_reservation.test.sql` — **14/14 pass**
- `supabase/tests/admin_status_notifications.test.sql` (bestehend, unverändert) — **16/16 pass**
- `supabase/tests/profile_field_guard.test.sql` (bestehend, unverändert): 4 von 11 Fällen schlagen lokal fehl — **kein Regression dieses PRs**. Ursache ist eine bereits vorher bestehende Lücke der lokalen Baseline-DB (fehlender `auth.users`-Trigger `handle_new_user`, dokumentiert im Projekt-Memory), wodurch die Test-Fixture-Profile lokal gar nicht erst angelegt werden. Mit einer diagnostischen Kopie (nicht committet) und demselben Workaround wie im neuen Testfile bestätigt: **11/11 pass**, sobald die Fixtures existieren.

## Deployment Notes

Der Merge allein reicht **nicht** aus. Nach dem Merge sind separat und manuell erforderlich:

1. Migrationen auf das verlinkte Supabase-Projekt anwenden (`supabase/migrations/2026072*`).
2. Edge Function `delete-account` deployen (`supabase functions deploy delete-account`).
3. `supabase/config.toml` (`[functions.delete-account]`) auf dem Zielprojekt verifizieren.
4. Vor Produktionsfreigabe: Staging-Test des kompletten Lösch-Flows (Employee-Selbstlöschung, Admin mit Kollege, letzter Admin, Rollback-Pfad).
5. In diesem PR wird **nichts** auf Production angewendet oder deployt — reine Code-/Migrations-Änderungen.

## Known Limitations

- Recovery hängengebliebener Reservierungen läuft aktuell **best-effort vor jedem neuen Löschversuch** (Edge Function ruft `recover_stale_account_deletion_reservations()` auf) — kein Cron aktiv.
- Ein `pg_cron`-Job könnte das später ergänzen, ist aber **kein Blocker**: eine hängende Reservierung deaktiviert das betroffene Konto nicht und ändert `is_active` nie — sie verhindert lediglich, dass ein zweiter Admin derselben Firma sich zeitgleich löscht, bis die Reservierung nach 15 Minuten automatisch verfällt oder der nächste Löschversuch sie abräumt.
