### PR TITLE
fix(security): harden client key validation and SQL guard tests

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient } from "@supabase/supabase-js";
 import { Platform } from "react-native";
+import { classifyClientKey } from "./supabaseKeyGuard";
 
 // Supabase URL und Key aus den Env Variablen holen
 // (!) bedeutet: wir gehen davon aus, dass sie sicher vorhanden sind
@@ -8,46 +9,33 @@ const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
 
 // ─────────────────────────────────────────────────────────────────
-// SICHERHEITS-GUARD: Im Client darf AUSSCHLIESSLICH ein Publishable-/Anon-Key
-// stehen — niemals ein Secret-/Service-Role-Key. Ein Secret-Key im Client
-// (EXPO_PUBLIC_ landet im App-Bundle) würde RLS für alle Nutzer aushebeln.
-// Hintergrund: EXPO_PUBLIC_SUPABASE_ANON_KEY enthielt versehentlich einen
-// sb_secret_-Key. Dieser Guard erkennt den Fehler früh beim App-Start.
-// Es wird NIEMALS der Key-Wert geloggt.
+// SICHERHEITS-GUARD (FAIL CLOSED): Im Client darf AUSSCHLIESSLICH ein
+// Publishable-/Legacy-anon-Key stehen — niemals ein Secret-/Service-Role-Key.
+// Ein Secret-Key im Client (EXPO_PUBLIC_ landet im App-Bundle) würde RLS für
+// ALLE Nutzer aushebeln. Hintergrund: EXPO_PUBLIC_SUPABASE_ANON_KEY enthielt
+// versehentlich einen sb_secret_-Key.
+//
+// Verhalten (Dev UND Produktion identisch): Ist der Key kein sicher als
+// öffentlich erkannter Key, wird der Supabase-Client GAR NICHT erst erzeugt,
+// sondern ein klarer Fehler geworfen. Lieber ein App-Start-Fehler als ein
+// weltweit offengelegter Secret-Key. Der Key-Wert wird NIEMALS geloggt —
+// nur die Klassifikation (public/secret/unknown/missing).
+//
+// Die reine Klassifikationslogik liegt in ./supabaseKeyGuard (seiteneffektfrei,
+// isoliert testbar). Hier passiert nur die App-weite Konsequenz (throw).
 // ─────────────────────────────────────────────────────────────────
-function jwtRoleClaim(key: string): string | null {
-  const parts = key.split(".");
-  if (parts.length !== 3) return null;
-  try {
-    let b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    while (b64.length % 4) b64 += "=";
-    const g = globalThis as { atob?: (s: string) => string };
-    const json = typeof g.atob === "function" ? g.atob(b64) : "";
-    const m = json.match(/"role"\s*:\s*"([^"]+)"/);
-    return m ? m[1] : null;
-  } catch {
-    return null;
-  }
+const keyVerdict = classifyClientKey(supabaseAnonKey);
+if (keyVerdict === "secret" || keyVerdict === "unknown") {
+  // Der geworfene Fehler enthält nur die Klassifikation, nie den Key-Wert.
+  throw new Error(
+    "SICHERHEIT: EXPO_PUBLIC_SUPABASE_ANON_KEY ist kein zulässiger öffentlicher " +
+      `Client-Key (erkannt als: ${keyVerdict}). Im Client sind ausschließlich ` +
+      "Publishable-Keys (sb_publishable_…) oder der Legacy-anon-Key erlaubt. " +
+      "Secret-/Service-Role-Keys gehören ausschließlich serverseitig (Edge Functions).",
+  );
 }
-
-function assertClientKeyIsPublic(key: string | undefined): void {
-  if (!key) return;
-  const looksLikeSecret =
-    key.startsWith("sb_secret_") || jwtRoleClaim(key) === "service_role";
-  if (!looksLikeSecret) return;
-
-  const message =
-    "SICHERHEIT: EXPO_PUBLIC_SUPABASE_ANON_KEY ist ein Secret-/Service-Role-Key. " +
-    "Im Client ausschließlich den Publishable-/Anon-Key verwenden (Service-Key nur serverseitig).";
-  // Dev: harter Abbruch. Produktion: fail-closed-Hinweis ohne die App komplett
-  // zu bricken (das Problem muss aber vor dem Release behoben werden).
-  if (__DEV__) {
-    throw new Error(message);
-  }
-  console.error(message);
-}
-
-assertClientKeyIsPublic(supabaseAnonKey);
+// "missing" wird bewusst nicht hier abgefangen: createClient wirft dafür
+// bereits einen eindeutigen "supabaseKey is required"-Fehler.
 
 // Supabase Client erstellen (wird in der ganzen App verwendet)
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {

--- a/lib/supabaseKeyGuard.ts
+++ b/lib/supabaseKeyGuard.ts
@@ -1,0 +1,76 @@
+// ─────────────────────────────────────────────────────────────────
+// SICHERHEITS-GUARD (reine Logik, ohne Seiteneffekte): Klassifiziert den
+// Supabase-Client-Key anhand SEINES WERTS — nicht anhand des Variablennamens.
+//
+// Warum ein eigenes Modul: Diese Funktionen sind absichtlich SEITENEFFEKTFREI
+// (kein Client-Aufbau, kein Logging, kein throw). So lassen sie sich später
+// ohne Test-Framework isoliert prüfen. Das App-weite Fail-Closed-Verhalten
+// (throw + KEIN createClient) liegt bewusst in lib/supabase.ts, nicht hier.
+//
+// Es wird an KEINER Stelle der Key-Wert (oder ein Teil davon) zurückgegeben
+// oder geloggt — ausschließlich die Klassifikation.
+// ─────────────────────────────────────────────────────────────────
+
+// Ergebnis der Klassifikation:
+//   "public"  → zulässiger Client-Key (Publishable- oder Legacy-anon-Key)
+//   "secret"  → Secret-/Service-Role-Key → im Client VERBOTEN
+//   "unknown" → unbekanntes Format → fail-closed abgelehnt (könnte ein Secret sein)
+//   "missing" → kein Key gesetzt → Konfigurationsfehler (createClient meldet ihn)
+export type ClientKeyVerdict = "public" | "secret" | "unknown" | "missing";
+
+// Akzeptierte öffentliche Key-Formate im Projekt:
+//   1. Neues Publishable-Format: Präfix "sb_publishable_"
+//      (aktuell in .env verwendet, siehe .env.example).
+//   2. Legacy-anon-Key: JWT (3 Teile) mit role-Claim "anon".
+// Verbotene Formate:
+//   - Neues Secret-Format: Präfix "sb_secret_"
+//   - Legacy-service_role-Key: JWT mit role-Claim "service_role"
+const PUBLISHABLE_PREFIX = "sb_publishable_";
+const SECRET_PREFIX = "sb_secret_";
+
+// Extrahiert den role-Claim aus einem JWT, ohne eine Krypto-Lib.
+// Gibt den role-String zurück oder null, wenn der Key kein dekodierbares
+// JWT mit role-Claim ist. Dekodiert NUR den Payload-Teil (Base64URL) und
+// sucht das role-Feld — es findet keine Signaturprüfung statt (nicht nötig:
+// wir klassifizieren nur das Format, nicht die Echtheit).
+export function jwtRoleClaim(key: string): string | null {
+  const parts = key.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    let b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    while (b64.length % 4) b64 += "=";
+    const g = globalThis as { atob?: (s: string) => string };
+    const json = typeof g.atob === "function" ? g.atob(b64) : "";
+    const m = json.match(/"role"\s*:\s*"([^"]+)"/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+// Klassifiziert einen Client-Key anhand seines Werts (fail-closed:
+// alles nicht sicher als "public" Erkannte gilt als nicht verwendbar).
+export function classifyClientKey(key: string | undefined | null): ClientKeyVerdict {
+  const trimmed = typeof key === "string" ? key.trim() : "";
+  if (trimmed.length === 0) return "missing";
+
+  // Neue Formate sind eindeutig am Präfix erkennbar.
+  if (trimmed.startsWith(SECRET_PREFIX)) return "secret";
+  if (trimmed.startsWith(PUBLISHABLE_PREFIX)) return "public";
+
+  // Legacy-JWT-Formate über den role-Claim unterscheiden.
+  const role = jwtRoleClaim(trimmed);
+  if (role === "service_role") return "secret";
+  if (role === "anon") return "public";
+
+  // Weder ein bekanntes öffentliches Präfix noch ein eindeutiger anon-JWT:
+  // bewusst NICHT durchlassen. Ein nicht dekodierbarer service_role-JWT
+  // (oder ein künftiges Secret-Format) darf niemals als "public" gelten.
+  return "unknown";
+}
+
+// True, wenn der Key im Client verwendet werden darf. Nur "public" ist
+// erlaubt — "secret", "unknown" und "missing" sind es NICHT.
+export function isAcceptablePublicClientKey(key: string | undefined | null): boolean {
+  return classifyClientKey(key) === "public";
+}

--- a/supabase/migrations/20260723000002_harden_rpc_execute_grants.sql
+++ b/supabase/migrations/20260723000002_harden_rpc_execute_grants.sql
@@ -1,0 +1,90 @@
+-- =========================================================
+-- HARDENING: EXECUTE-Grants auf clientseitig aufrufbaren RPCs
+-- =========================================================
+-- Ausgangslage (aus dem 20260713000000-Baseline geerbt): Die unten stehenden
+-- RPCs tragen noch ein EXECUTE-Recht für PUBLIC und/oder anon. Alle diese
+-- Funktionen setzen intern zwingend eine eingeloggte Identität voraus
+-- (auth.uid()-basiert) und sind daher für einen anonymen Aufrufer nutzlos —
+-- das Recht ist überflüssig und widerspricht dem Least-Privilege-Prinzip, das
+-- das Projekt für neuere Funktionen bereits konsequent anwendet
+-- (siehe 20260717000001_harden_dispatcher_grants.sql und
+-- 20260723000001_account_deletion_reservation_tokens.sql).
+--
+-- KEINE aktive Lücke: Jede dieser Funktionen bricht ohne gültige Session
+-- serverseitig ab (auth.uid() IS NULL / current_user_role() IS NULL). Diese
+-- Migration ist Defense-in-Depth: sie entfernt das nutzlose anon/PUBLIC-Recht,
+-- damit die Angriffsfläche der DB dem tatsächlichen Bedarf entspricht.
+--
+-- WARUM "from public" UND "from anon": Das Baseline-Recht liegt bei PUBLIC
+-- (proacl-Eintrag "=X/postgres"). Ein bloßes "revoke from anon" bliebe wirkungslos,
+-- weil anon das Recht über PUBLIC weiter erbt — exakt die Lehre aus der
+-- Dispatcher-Härtung. Deshalb wird von PUBLIC UND anon entzogen und danach
+-- authenticated + service_role explizit (re-)granted.
+--
+-- BEWUSST NICHT ANGEFASST:
+--   * current_user_role() / current_user_company_id(): werden in ~79 RLS-
+--     USING/WITH-CHECK-Klauseln aufgerufen. Diese Auswertung läuft auch für
+--     anon-Requests (die die Zeilen anschließend herausfiltern). Ohne anon-
+--     EXECUTE würde eine anon-Query auf jobs/profiles/... mit
+--     "permission denied for function" FEHLSCHLAGEN statt leer zurückzukommen.
+--     Ihr anon-Recht ist also FUNKTIONAL ERFORDERLICH und bleibt bestehen.
+--   * Trigger-Funktionen (enforce_profile_field_guard, enforce_active_assignee,
+--     clear_push_token_on_deactivate, handle_new_user): Trigger prüfen KEIN
+--     EXECUTE-Recht des auslösenden Rollenkontexts — ihre Grants sind für die
+--     Sicherheit irrelevant und werden nicht verändert.
+--   * Kontolöschung (prepare_/rollback_self_account_deletion) sowie Dispatcher-
+--     RPCs: bereits korrekt gehärtet (anon entzogen bzw. service_role-only).
+--
+-- CALL-SITES (vor dem Entzug verifiziert — alle mit aktiver Session):
+--   start_own_job / complete_own_job ....... services/jobs/jobs.service.ts (Mitarbeiter)
+--   get_unread_comment_job_ids ............. services/comments/comments.service.ts
+--   generate_/update_job_occurrences ....... services/jobs/jobs.service.ts (Admin);
+--                                            update_ ruft generate_ intern als
+--                                            SECURITY DEFINER (postgres) auf.
+--   setup_company_for_admin ................ services/company/setupCompanyForAdmin.ts (nach Login)
+--   register_admin_with_company ............ admin-panel app/register/page.tsx (nach signUp/Session)
+--   update_my_push_token / clear_my_push_token  context/AuthContext.tsx
+--   accept_own_invite ...................... features/auth/AcceptInviteScreen.tsx (nach updateUser)
+--
+-- Additiv & idempotent: nur GRANT/REVOKE, keine Signatur-/Logikänderung.
+-- =========================================================
+
+-- start_own_job(uuid, timestamptz)
+revoke execute on function public.start_own_job(uuid, timestamptz) from public, anon;
+grant  execute on function public.start_own_job(uuid, timestamptz) to authenticated, service_role;
+
+-- complete_own_job(uuid, timestamptz)
+revoke execute on function public.complete_own_job(uuid, timestamptz) from public, anon;
+grant  execute on function public.complete_own_job(uuid, timestamptz) to authenticated, service_role;
+
+-- get_unread_comment_job_ids()
+revoke execute on function public.get_unread_comment_job_ids() from public, anon;
+grant  execute on function public.get_unread_comment_job_ids() to authenticated, service_role;
+
+-- generate_job_occurrences(uuid)
+revoke execute on function public.generate_job_occurrences(uuid) from public, anon;
+grant  execute on function public.generate_job_occurrences(uuid) to authenticated, service_role;
+
+-- update_job_occurrences(uuid)
+revoke execute on function public.update_job_occurrences(uuid) from public, anon;
+grant  execute on function public.update_job_occurrences(uuid) to authenticated, service_role;
+
+-- setup_company_for_admin(text)
+revoke execute on function public.setup_company_for_admin(text) from public, anon;
+grant  execute on function public.setup_company_for_admin(text) to authenticated, service_role;
+
+-- register_admin_with_company(text, text, text)
+revoke execute on function public.register_admin_with_company(text, text, text) from public, anon;
+grant  execute on function public.register_admin_with_company(text, text, text) to authenticated, service_role;
+
+-- update_my_push_token(text)
+revoke execute on function public.update_my_push_token(text) from public, anon;
+grant  execute on function public.update_my_push_token(text) to authenticated, service_role;
+
+-- clear_my_push_token()
+revoke execute on function public.clear_my_push_token() from public, anon;
+grant  execute on function public.clear_my_push_token() to authenticated, service_role;
+
+-- accept_own_invite()
+revoke execute on function public.accept_own_invite() from public, anon;
+grant  execute on function public.accept_own_invite() to authenticated, service_role;

--- a/supabase/tests/profile_field_guard.test.sql
+++ b/supabase/tests/profile_field_guard.test.sql
@@ -6,13 +6,30 @@
 -- aber weiter nutzen können und service_role/Edge-Function-Pfade frei
 -- bleiben.
 --
--- AUSFÜHREN: im Supabase SQL Editor (läuft als postgres) einfach komplett
--- einfügen und ausführen. Das Skript legt Testdaten an, simuliert die
+-- AUSFÜHREN: gegen eine lokale Supabase-DB (docker psql / supabase db) ODER
+-- im Supabase SQL Editor. Das Skript legt Testdaten an, simuliert die
 -- verschiedenen Aufrufer über SET ROLE + request.jwt.claims und macht am
 -- Ende ROLLBACK — es bleiben KEINE Testdaten zurück.
 --
--- Ergebnis: eine Tabelle am Ende (case_no | beschreibung | erwartet |
--- ergebnis | verdikt) sowie NOTICE-Meldungen im Messages-/Log-Panel.
+-- ROBUSTHEIT (Fix gegenüber der Vorversion):
+--   * Die Vorversion legte KEINE profiles-Zeilen explizit an, sondern verließ
+--     sich auf den auth.users→profiles-Trigger (handle_new_user). Auf einer
+--     frischen lokalen Baseline ohne diesen Trigger trafen die Setup-UPDATEs
+--     dann 0 Zeilen, und weil die BLOCKED-Fälle nur "keine Exception" prüften,
+--     meldeten sie fälschlich ALLOWED (false pass) bzw. FAIL (false fail) —
+--     ganz ohne echte Guard-Aussage.
+--   * Diese Version legt alle profiles-Zeilen EXPLIZIT an (insert ... on
+--     conflict do update, unabhängig vom Trigger), prüft die Seed-Zeilenzahl
+--     hart ab (raise bei Abweichung) und wertet in jedem Fall ROW_COUNT aus:
+--       - ALLOWED  gilt nur bei tatsächlich ≥1 betroffener Zeile.
+--       - TRIGGER_BLOCK gilt nur bei echter 42501-Exception (nicht bei 0 rows).
+--       - RLS_NOOP gilt bei 0 Zeilen ODER permission-denied (RLS/Grant).
+--   * Am Ende schlägt das Skript LAUT fehl (raise exception), falls irgendein
+--     Fall nicht PASS ist — die Ergebnistabelle wird vorher noch ausgegeben.
+--
+-- Ergebnis: eine Tabelle (case_no | beschreibung | erwartet | ergebnis |
+-- verdikt) plus NOTICE-Meldungen; bei einem Fehlschlag zusätzlich eine
+-- Exception, sodass CI/psql (-v ON_ERROR_STOP=1) einen Fehler signalisiert.
 -- =========================================================
 
 begin;
@@ -20,35 +37,90 @@ begin;
 -- Fixe IDs für Lesbarkeit
 --   Firma A = 111…  | Firma B = 222…
 --   adminA  = a0…1  | empA (aktiv) = e0…2 | empDeact (inaktiv) = d0…3
-do $$
-begin
-  -- Testnutzer in auth.users anlegen. Der handle_new_user-Trigger legt
-  -- dazu automatisch die zugehörige profiles-Zeile an (role=employee,
-  -- is_active=true, company_id=null).
-  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
-  values
-    ('00000000-0000-0000-0000-000000000000','a0000000-0000-0000-0000-000000000001','authenticated','authenticated','guardtest-admin@example.test','{"full_name":"Admin A"}'),
-    ('00000000-0000-0000-0000-000000000000','e0000000-0000-0000-0000-000000000002','authenticated','authenticated','guardtest-emp@example.test','{"full_name":"Mitarbeiter A"}'),
-    ('00000000-0000-0000-0000-000000000000','d0000000-0000-0000-0000-000000000003','authenticated','authenticated','guardtest-deact@example.test','{"full_name":"Mitarbeiter Deaktiviert"}'),
-    ('00000000-0000-0000-0000-000000000000','b0000000-0000-0000-0000-000000000004','authenticated','authenticated','guardtest-adminb@example.test','{"full_name":"Admin B"}'),
-    ('00000000-0000-0000-0000-000000000000','f0000000-0000-0000-0000-000000000005','authenticated','authenticated','guardtest-fresh1@example.test','{"full_name":"Fresh User 1"}'),
-    ('00000000-0000-0000-0000-000000000000','f0000000-0000-0000-0000-000000000006','authenticated','authenticated','guardtest-fresh2@example.test','{"full_name":"Fresh User 2"}');
-end $$;
+--   adminB  = b0…4  | fresh1 = f0…5 | fresh2 = f0…6
+insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+values
+  ('00000000-0000-0000-0000-000000000000','a0000000-0000-0000-0000-000000000001','authenticated','authenticated','guardtest-admin@example.test','{"full_name":"Admin A"}'),
+  ('00000000-0000-0000-0000-000000000000','e0000000-0000-0000-0000-000000000002','authenticated','authenticated','guardtest-emp@example.test','{"full_name":"Mitarbeiter A"}'),
+  ('00000000-0000-0000-0000-000000000000','d0000000-0000-0000-0000-000000000003','authenticated','authenticated','guardtest-deact@example.test','{"full_name":"Mitarbeiter Deaktiviert"}'),
+  ('00000000-0000-0000-0000-000000000000','b0000000-0000-0000-0000-000000000004','authenticated','authenticated','guardtest-adminb@example.test','{"full_name":"Admin B"}'),
+  ('00000000-0000-0000-0000-000000000000','f0000000-0000-0000-0000-000000000005','authenticated','authenticated','guardtest-fresh1@example.test','{"full_name":"Fresh User 1"}'),
+  ('00000000-0000-0000-0000-000000000000','f0000000-0000-0000-0000-000000000006','authenticated','authenticated','guardtest-fresh2@example.test','{"full_name":"Fresh User 2"}')
+on conflict (id) do nothing;
 
 -- Firmen anlegen (als postgres → vom Guard ausgenommen)
 insert into public.companies (id, name, slug) values
   ('11111111-1111-1111-1111-111111111111','Guardtest Firma A','guardtest-firma-a'),
-  ('22222222-2222-2222-2222-222222222222','Guardtest Firma B','guardtest-firma-b');
+  ('22222222-2222-2222-2222-222222222222','Guardtest Firma B','guardtest-firma-b')
+on conflict (id) do nothing;
 
--- Profile in den Zielzustand bringen (als postgres → erlaubt/ausgenommen)
-update public.profiles set role='admin',    company_id='11111111-1111-1111-1111-111111111111', is_active=true  where id='a0000000-0000-0000-0000-000000000001';
-update public.profiles set role='employee', company_id='11111111-1111-1111-1111-111111111111', is_active=true  where id='e0000000-0000-0000-0000-000000000002';
-update public.profiles set role='employee', company_id='11111111-1111-1111-1111-111111111111', is_active=false where id='d0000000-0000-0000-0000-000000000003';
-update public.profiles set role='admin',    company_id='22222222-2222-2222-2222-222222222222', is_active=true  where id='b0000000-0000-0000-0000-000000000004';
--- Fresh User 1 + 2 bleiben bewusst wie von handle_new_user angelegt:
--- role='employee', company_id=NULL, is_active=true (für Registrierung/Setup-Test).
+-- Profile EXPLIZIT in den Zielzustand bringen. on conflict do update deckt
+-- BEIDE Baselines ab: mit handle_new_user-Trigger (Zeile existiert schon →
+-- update) und ohne Trigger (Zeile wird hier erst angelegt → insert).
+insert into public.profiles (id, company_id, full_name, role, is_active) values
+  ('a0000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','Admin A','admin',   true),
+  ('e0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','Mitarbeiter A','employee', true),
+  ('d0000000-0000-0000-0000-000000000003','11111111-1111-1111-1111-111111111111','Mitarbeiter Deaktiviert','employee', false),
+  ('b0000000-0000-0000-0000-000000000004','22222222-2222-2222-2222-222222222222','Admin B','admin',   true),
+  -- fresh1/fresh2: bewusst ohne Firma (company_id=NULL) für Registrierung/Setup.
+  ('f0000000-0000-0000-0000-000000000005', null, 'Fresh User 1','employee', true),
+  ('f0000000-0000-0000-0000-000000000006', null, 'Fresh User 2','employee', true)
+on conflict (id) do update set
+  company_id = excluded.company_id,
+  full_name  = excluded.full_name,
+  role       = excluded.role,
+  is_active  = excluded.is_active;
 
--- Ergebnis-Sammeltabelle
+-- SETUP-ASSERTION: bricht laut ab, falls der Seed nicht exakt stimmt. Damit
+-- kann kein Fall auf einer falsch vorbereiteten Basis "grün" werden.
+do $$
+declare n int;
+begin
+  select count(*) into n from public.profiles
+   where id in (
+     'a0000000-0000-0000-0000-000000000001',
+     'e0000000-0000-0000-0000-000000000002',
+     'd0000000-0000-0000-0000-000000000003',
+     'b0000000-0000-0000-0000-000000000004',
+     'f0000000-0000-0000-0000-000000000005',
+     'f0000000-0000-0000-0000-000000000006'
+   );
+  if n <> 6 then
+    raise exception 'SETUP FEHLGESCHLAGEN: erwartet 6 Seed-Profile, gefunden %', n;
+  end if;
+
+  perform 1 from public.profiles
+   where id='a0000000-0000-0000-0000-000000000001' and role='admin'
+     and company_id='11111111-1111-1111-1111-111111111111' and is_active;
+  if not found then raise exception 'SETUP FEHLGESCHLAGEN: adminA nicht korrekt'; end if;
+
+  perform 1 from public.profiles
+   where id='e0000000-0000-0000-0000-000000000002' and role='employee'
+     and company_id='11111111-1111-1111-1111-111111111111' and is_active;
+  if not found then raise exception 'SETUP FEHLGESCHLAGEN: empA nicht korrekt'; end if;
+
+  perform 1 from public.profiles
+   where id='d0000000-0000-0000-0000-000000000003' and role='employee'
+     and company_id='11111111-1111-1111-1111-111111111111' and is_active = false;
+  if not found then raise exception 'SETUP FEHLGESCHLAGEN: empDeact nicht korrekt'; end if;
+
+  perform 1 from public.profiles
+   where id='b0000000-0000-0000-0000-000000000004' and role='admin'
+     and company_id='22222222-2222-2222-2222-222222222222' and is_active;
+  if not found then raise exception 'SETUP FEHLGESCHLAGEN: adminB nicht korrekt'; end if;
+
+  perform 1 from public.profiles
+   where id='f0000000-0000-0000-0000-000000000005' and company_id is null;
+  if not found then raise exception 'SETUP FEHLGESCHLAGEN: fresh1 sollte ohne Firma sein'; end if;
+
+  raise notice 'SETUP OK: 6 Profile korrekt vorbereitet';
+end $$;
+
+-- Ergebnis-Sammeltabelle. erwartet kodiert die erwartete ART des Ergebnisses:
+--   ALLOWED       = UPDATE muss ≥1 Zeile treffen (kein Block)
+--   TRIGGER_BLOCK = Guard muss mit 42501 werfen
+--   RLS_NOOP      = RLS/Grant blockt → 0 Zeilen oder permission-denied
+--   DEFINER_OK    = SECURITY DEFINER-RPC läuft durch UND hat Wirkung
 create temp table _guard_results (
   case_no  int,
   beschreibung text,
@@ -57,16 +129,17 @@ create temp table _guard_results (
 ) on commit drop;
 
 -- =========================================================
--- CASE 1: Mitarbeiter ändert seinen Namen → ERLAUBT
+-- CASE 1: Mitarbeiter ändert seinen Namen (self) → ERLAUBT
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"e0000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set full_name='Mitarbeiter A (neu)' where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
@@ -77,76 +150,80 @@ begin
 end $$;
 
 -- =========================================================
--- CASE 2: Mitarbeiter setzt sich selbst auf role='admin' → BLOCKIERT
+-- CASE 2: Mitarbeiter setzt sich selbst auf role='admin' → BLOCKIERT (Trigger)
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"e0000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set role='admin' where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (2,'Mitarbeiter setzt role=admin (self)','BLOCKED',v);
+  insert into _guard_results values (2,'Mitarbeiter setzt role=admin (self)','TRIGGER_BLOCK',v);
   raise notice 'CASE 2 (self role=admin) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 3: Mitarbeiter ändert company_id → BLOCKIERT
+-- CASE 3: Mitarbeiter ändert company_id (self) → BLOCKIERT (Trigger)
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"e0000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set company_id='22222222-2222-2222-2222-222222222222' where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (3,'Mitarbeiter ändert company_id (self)','BLOCKED',v);
+  insert into _guard_results values (3,'Mitarbeiter ändert company_id (self)','TRIGGER_BLOCK',v);
   raise notice 'CASE 3 (self company_id) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 4: Deaktivierter Mitarbeiter setzt is_active=true → BLOCKIERT
+-- CASE 4: Deaktivierter Mitarbeiter setzt is_active=true (self) → BLOCKIERT (Trigger)
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"d0000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set is_active=true where id='d0000000-0000-0000-0000-000000000003';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (4,'Deaktivierter Mitarbeiter reaktiviert sich (self)','BLOCKED',v);
+  insert into _guard_results values (4,'Deaktivierter Mitarbeiter reaktiviert sich (self)','TRIGGER_BLOCK',v);
   raise notice 'CASE 4 (deactivated self-reactivate) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 5: Admin deaktiviert einen Mitarbeiter → ERLAUBT
+-- CASE 5: Admin deaktiviert einen Mitarbeiter (gleiche Firma) → ERLAUBT
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"a0000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set is_active=false, expo_push_token=null where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
@@ -157,16 +234,17 @@ begin
 end $$;
 
 -- =========================================================
--- CASE 6: Admin reaktiviert einen Mitarbeiter → ERLAUBT
+-- CASE 6: Admin reaktiviert einen Mitarbeiter (gleiche Firma) → ERLAUBT
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"a0000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     update public.profiles set is_active=true where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
@@ -180,12 +258,13 @@ end $$;
 -- CASE 7: service_role (Edge Function) ändert geschütztes Feld → ERLAUBT
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   execute 'set local role service_role';
   begin
     update public.profiles set is_active=false where id='e0000000-0000-0000-0000-000000000002';
-    v := 'ALLOWED';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
@@ -196,8 +275,7 @@ begin
 end $$;
 
 -- =========================================================
--- CASE 8: Admin einer FREMDEN Firma ändert Mitarbeiter → BLOCKIERT
--- (RLS filtert die Zeile → 0 Zeilen; zusätzlich würde der Trigger greifen)
+-- CASE 8: Admin einer FREMDEN Firma ändert Mitarbeiter → BLOCKIERT (RLS 0 rows)
 -- =========================================================
 do $$
 declare v text; rc int;
@@ -207,13 +285,13 @@ begin
   begin
     update public.profiles set is_active=false where id='e0000000-0000-0000-0000-000000000002';
     get diagnostics rc = row_count;
-    if rc = 0 then v := 'NOOP(0 rows/RLS)'; else v := 'ALLOWED'; end if;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (8,'Admin fremde Firma ändert Mitarbeiter','BLOCKED',v);
+  insert into _guard_results values (8,'Admin fremde Firma ändert Mitarbeiter','RLS_NOOP',v);
   raise notice 'CASE 8 (cross-company admin) -> %', v;
 end $$;
 
@@ -232,7 +310,7 @@ begin
     update public.profiles set is_active=true, expo_push_token=null
       where id='e0000000-0000-0000-0000-000000000002' and role='employee';
     get diagnostics rc = row_count;
-    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED'; end if;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
@@ -243,45 +321,72 @@ begin
 end $$;
 
 -- =========================================================
--- CASE 10: Registrierung via register_admin_with_company → ERLAUBT
--- (SECURITY DEFINER → current_user=postgres → vom Guard ausgenommen)
+-- CASE 10: Anonymer Nutzer (kein Login) versucht ein Profil zu ändern → BLOCKIERT
+-- request.jwt.claims wird geleert ({}), damit auth.uid() NULL ist.
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
+begin
+  perform set_config('request.jwt.claims','{}', true);
+  execute 'set local role anon';
+  begin
+    update public.profiles set is_active=false where id='e0000000-0000-0000-0000-000000000002';
+    get diagnostics rc = row_count;
+    if rc = 0 then v := 'NOOP(0 rows)'; else v := 'ALLOWED('||rc||' rows)'; end if;
+  exception
+    when insufficient_privilege then v := 'BLOCKED(42501)';
+    when others then v := 'ERROR:'||sqlstate;
+  end;
+  execute 'reset role';
+  insert into _guard_results values (10,'Anonymer Nutzer ändert Profil','RLS_NOOP',v);
+  raise notice 'CASE 10 (anon update) -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 11: Registrierung register_admin_with_company → ERLAUBT (DEFINER-Pfad)
+-- (SECURITY DEFINER → current_user=postgres → vom Guard ausgenommen)
+-- Post-Bedingung: fresh1 hat danach eine Firma.
+-- =========================================================
+do $$
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"f0000000-0000-0000-0000-000000000005","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     perform public.register_admin_with_company('Test Owner','Guardtest Firma C','guardtest-firma-c');
-    v := 'ALLOWED';
+    select count(*) into rc from public.profiles
+      where id='f0000000-0000-0000-0000-000000000005' and company_id is not null;
+    if rc = 1 then v := 'DEFINER_OK'; else v := 'NO_EFFECT(rc='||rc||')'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (10,'Registrierung register_admin_with_company','ALLOWED',v);
-  raise notice 'CASE 10 (register_admin_with_company) -> %', v;
+  insert into _guard_results values (11,'register_admin_with_company (DEFINER)','DEFINER_OK',v);
+  raise notice 'CASE 11 (register_admin_with_company) -> %', v;
 end $$;
 
 -- =========================================================
--- CASE 11: setup_company_for_admin (User ohne Firma) → ERLAUBT
--- (SECURITY DEFINER → current_user=postgres → vom Guard ausgenommen)
+-- CASE 12: setup_company_for_admin (User ohne Firma) → ERLAUBT (DEFINER-Pfad)
+-- Post-Bedingung: fresh2 hat danach eine Firma.
 -- =========================================================
 do $$
-declare v text;
+declare v text; rc int;
 begin
   perform set_config('request.jwt.claims','{"sub":"f0000000-0000-0000-0000-000000000006","role":"authenticated"}', true);
   execute 'set local role authenticated';
   begin
     perform public.setup_company_for_admin('Guardtest Firma D');
-    v := 'ALLOWED';
+    select count(*) into rc from public.profiles
+      where id='f0000000-0000-0000-0000-000000000006' and company_id is not null and role='admin';
+    if rc = 1 then v := 'DEFINER_OK'; else v := 'NO_EFFECT(rc='||rc||')'; end if;
   exception
     when insufficient_privilege then v := 'BLOCKED(42501)';
     when others then v := 'ERROR:'||sqlstate;
   end;
   execute 'reset role';
-  insert into _guard_results values (11,'setup_company_for_admin (User ohne Firma)','ALLOWED',v);
-  raise notice 'CASE 11 (setup_company_for_admin) -> %', v;
+  insert into _guard_results values (12,'setup_company_for_admin (DEFINER)','DEFINER_OK',v);
+  raise notice 'CASE 12 (setup_company_for_admin) -> %', v;
 end $$;
 
 -- =========================================================
@@ -293,12 +398,32 @@ select
   erwartet,
   ergebnis,
   case
-    when erwartet = 'ALLOWED' and ergebnis = 'ALLOWED' then 'PASS'
-    when erwartet = 'BLOCKED' and (ergebnis like 'BLOCKED%' or ergebnis like 'NOOP%') then 'PASS'
+    when erwartet = 'ALLOWED'       and ergebnis like 'ALLOWED(%'                                then 'PASS'
+    when erwartet = 'TRIGGER_BLOCK' and ergebnis = 'BLOCKED(42501)'                              then 'PASS'
+    when erwartet = 'RLS_NOOP'      and (ergebnis = 'NOOP(0 rows)' or ergebnis like 'BLOCKED%')  then 'PASS'
+    when erwartet = 'DEFINER_OK'    and ergebnis = 'DEFINER_OK'                                  then 'PASS'
     else 'FAIL'
   end as verdikt
 from _guard_results
 order by case_no;
+
+-- LAUTER Fehlschlag, falls irgendein Fall nicht PASS ist (nachdem die Tabelle
+-- oben bereits ausgegeben wurde). So bricht psql (-v ON_ERROR_STOP=1) / CI ab.
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _guard_results r
+  where not (
+    (r.erwartet = 'ALLOWED'       and r.ergebnis like 'ALLOWED(%')
+    or (r.erwartet = 'TRIGGER_BLOCK' and r.ergebnis = 'BLOCKED(42501)')
+    or (r.erwartet = 'RLS_NOOP'      and (r.ergebnis = 'NOOP(0 rows)' or r.ergebnis like 'BLOCKED%'))
+    or (r.erwartet = 'DEFINER_OK'    and r.ergebnis = 'DEFINER_OK')
+  );
+  if fails > 0 then
+    raise exception 'PROFILE FIELD GUARD TEST: % Fall/Fälle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 12 FÄLLE PASS';
+end $$;
 
 -- Nichts persistieren — reine Prüfung.
 rollback;


### PR DESCRIPTION
## Zweck

Kleine, gezielte Sicherheits-/Test-Härtung vor dem nächsten iOS-TestFlight-Build — **keine** neuen Features, kein `Multiple Employees`. Schließt die drei in der vorherigen Stabilitäts-Prüfung gefundenen Lücken.

## Änderungen

### 1. `fix(security): fail closed on non-public Supabase client key`
- **Vorher:** Der Guard warf nur in `__DEV__`. In einem Produktions-Build wurde bei einem Secret-/Service-Role-Key nur `console.error` geloggt und der Supabase-Client **trotzdem erzeugt** → RLS wäre im ausgelieferten Build vollständig ausgehebelt.
- **Jetzt:** Der Client wird nur erzeugt, wenn der Key als *public* klassifiziert ist (Präfix `sb_publishable_` **oder** ein Legacy-anon-JWT). Ein Secret-/`unknown`-Key wirft beim Modul-Load in **Dev UND Produktion**, `createClient` läuft nie mit einem unsicheren Key. Der Key-Wert wird **nie** geloggt — nur die Klassifikation.
- Die Klassifikation liegt als **reine, seiteneffektfreie Funktion** in `lib/supabaseKeyGuard.ts` (Allowlist nach *Wert*, nicht nach Env-Variablennamen), isoliert testbar. Der App-weite `throw` bleibt in `lib/supabase.ts`.
- **Test:** Es existiert kein JS-Test-Runner im Projekt (nur `tsc` + `expo lint`); ein Framework wäre für einen Security-Fix zu viel. Deshalb reine Funktion. Logik gegengeprüft (Wegwerf-Transpile + node): 10/10 Fälle korrekt — `sb_publishable_`→public, `sb_secret_`→secret, Legacy-anon-JWT→public, service_role-JWT→secret, fremder/unbekannter Wert→unknown (fail closed), leer→missing.

### 2. `test(security): make profile field-guard test self-contained and loud`
- **Root Cause:** Auf einer frischen lokalen Baseline fehlt der `auth.users→profiles`-Trigger. Die alten Setup-UPDATEs trafen dann 0 Zeilen, und die BLOCKED-Fälle prüften nur „keine Exception" → **falsche PASS/FAIL**, ohne den Guard je zu testen.
- **Jetzt:** profiles werden explizit geseedet (`insert … on conflict do update`, triggerunabhängig), der Seed wird hart geprüft, jeder Fall wertet `ROW_COUNT` aus (ALLOWED nur bei ≥1 Zeile; Block nur echte 42501 bzw. 0-rows/permission-denied). Fehlender **Anon-Fall** ergänzt. Am Ende **lauter** `raise` bei jedem Nicht-PASS.
- **Verifiziert:** 12/12 PASS lokal; eine absichtlich verfälschte Erwartung → Exit ≠ 0 (loud fail funktioniert).

### 3. `fix(security): revoke anon/PUBLIC EXECUTE from authenticated-only RPCs`
- Neue Migration `20260723000002_harden_rpc_execute_grants.sql`. Zehn clientseitige RPCs trugen noch `EXECUTE` für PUBLIC/anon aus dem Baseline. Alle setzen intern eine Session voraus → das anon-Recht ist nutzlos (Least-Privilege). **Keine aktive Lücke**, reine Defense-in-Depth.
- Weil das Recht auf **PUBLIC** liegt (`proacl "=X/postgres"`), ist ein bloßes `revoke from anon` wirkungslos → entzogen von **PUBLIC + anon**, dann `authenticated + service_role` explizit re-granted.
- **Betroffen:** `start_own_job`, `complete_own_job`, `get_unread_comment_job_ids`, `generate_job_occurrences`, `update_job_occurrences`, `setup_company_for_admin`, `register_admin_with_company`, `update_my_push_token`, `clear_my_push_token`, `accept_own_invite`.
- **Bewusst NICHT angefasst:** `current_user_role()` / `current_user_company_id()` (werden in ~79 RLS-Klauseln auch bei anon-Requests ausgewertet — ein Entzug würde leere Ergebnisse in `permission denied` verwandeln) sowie Trigger-Funktionen (Grants irrelevant).
- Alle Call-Sites zuvor als *authenticated* verifiziert (Mobile, Admin-Panel, Edge Functions).

## Verifikation (lokal, keine Prod-Änderung)

| Check | Ergebnis |
|---|---|
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run lint` | ✅ exit 0 |
| `git diff --check` | ✅ exit 0 |
| `profile_field_guard.test.sql` | ✅ 12/12 PASS (exit 0); Negativ-Kontrolle exit ≠ 0 |
| `last_admin_deletion_reservation.test.sql` | ✅ 14/14 PASS |
| `admin_status_notifications.test.sql` | ✅ 16/16 PASS |
| Grants-Migration lokal angewandt | ✅ anon=false / authenticated=true / service_role=true; anon-RLS-Reads weiterhin leer |
| Secret-Scan des Diffs | ✅ keine Key-Werte |

## Bewusst NICHT getan
Keine Prod-Migration, kein Edge-Function-Deploy, kein EAS-Build/-Update, kein Merge, keine Secrets geändert, keine Prod-Daten verändert. `supabase/.branches/` (lokales CLI-Artefakt) ist **nicht** committet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
