### PR TITLE
fix(db): update_job_occurrences nicht-destruktiv (PR-3)

### DIFF
--- a/supabase/migrations/20260723000004_non_destructive_update_job_occurrences.sql
+++ b/supabase/migrations/20260723000004_non_destructive_update_job_occurrences.sql
@@ -1,0 +1,200 @@
+-- =========================================================
+-- MIGRATION: Nicht-destruktives Aktualisieren wiederkehrender Aufträge
+-- Datum: 2026-07-23
+-- Zweck: update_job_occurrences so umbauen, dass eine Regeländerung
+--        KEINE Occurrences mit Historie mehr löscht und KEINE unnötige
+--        Massen-Neuerzeugung (Row-Churn) auslöst.
+-- =========================================================
+-- HINTERGRUND (am deployten Stand verifiziert, nicht aus Migrationen):
+--   Die bisherige Funktion war:
+--       delete from public.jobs
+--       where parent_job_id = parent_job_id_input
+--         and status = 'open' and date >= current_date;
+--       select public.generate_job_occurrences(parent_job_id_input);
+--   Damit löscht JEDE Regeländerung ALLE offenen zukünftigen Occurrences
+--   und erzeugt sie neu. Weil job_comments/job_photos/job_comment_reads per
+--   ON DELETE CASCADE an jobs(id) hängen, gehen dabei Kommentare, Fotos und
+--   Lesestatus dieser Zeilen verloren. Der Client ruft die RPC bei JEDEM
+--   Recurring-Edit auf (auch bei reiner Namensänderung), unabhängig davon,
+--   welches Feld sich geändert hat (services/jobs/jobs.service.ts updateJob).
+--   Produktions-Messung (rein lesend): bis zu 624 Zeilen pro Regel-Edit
+--   gelöscht+neu erzeugt; 5 Lesestatus-Zeilen würden aktuell still verworfen.
+--
+-- NEUES VERHALTEN (mengenbasiert, additiv, gleiche Signatur/Rückgabe):
+--   1) PRUNE  – löscht ausschließlich zukünftige Occurrences, die
+--               NACHWEISLICH unberührt sind UND nicht mehr zur Regel passen.
+--               "Unberührt" heißt: status='open', started_at IS NULL,
+--               completed_at IS NULL, keine Kommentare, keine Fotos, kein
+--               Lesestatus. "Passt nicht mehr" heißt: Wochentag nicht mehr
+--               in recurring_days, ODER start_time geändert, ODER außerhalb
+--               von recurrence_start_date/recurrence_end_date.
+--   2) SYNC   – aktualisiert die Anzeige-/Zuweisungsfelder auf zukünftigen,
+--               NOCH NICHT gestarteten Occurrences (status='open',
+--               started_at IS NULL, completed_at IS NULL), damit
+--               Nicht-Termin-Änderungen (Kunde/Service/Ort/Notizen/aktiv/
+--               Zuweisung) weiterhin ankommen — OHNE Löschen. Rein per
+--               UPDATE, kein Cascade, keine Änderung an date/start_time
+--               (Terminfelder = Aufgabe von PRUNE + GENERATE).
+--   3) GENERATE – ruft die unveränderte generate_job_occurrences auf, um
+--               neu benötigte Termine einzufügen (idempotent via
+--               ON CONFLICT DO NOTHING über idx_jobs_occurrence_unique).
+--
+--   Ergebnis:
+--     - Vergangene Occurrences:                unverändert (date < heute)
+--     - in_progress / completed:               unverändert (nie angefasst)
+--     - zukünftige Occurrences mit Historie:   unverändert erhalten; passen
+--                                              sie nicht mehr zur Regel,
+--                                              bleiben sie als „abgekoppelte"
+--                                              Termine bestehen (siehe unten)
+--     - zukünftige, unberührte, nicht passende: entfernt
+--     - neu benötigte Termine:                 eingefügt
+--     - erneuter Aufruf:                       idempotent, keine Duplikate
+--
+-- BEWUSST KEINE neue Spalte/kein neuer Status:
+--   Eine erhaltene Occurrence, die nicht mehr zur aktuellen Regel passt
+--   (z. B. abgeschlossen zur alten Uhrzeit nach Zeitänderung), ist ein
+--   realer historischer Job und über Vergleich von (Wochentag, start_time)
+--   gegen die aktuelle Regel eindeutig erkennbar. Ein Flag (detached/
+--   superseded/…) ist für die KORREKTHEIT dieser Funktion nicht nötig und
+--   würde die spätere Trennung in job_definitions/job_occurrences zusätzlich
+--   belasten. Empfehlung zur Kennzeichnung: im späteren Display-PR (siehe
+--   Report), nicht hier.
+--
+-- KOMPATIBILITÄT mit der geplanten Trennung Zeitplan/Daueraufträge:
+--   Die Funktion fasst weiterhin nur konkrete Occurrences
+--   (parent_job_id IS NOT NULL, job_type='single') an und lässt die
+--   Parent-Regel unberührt. Kein Feld wird umgedeutet, keine Beziehung
+--   geändert. Der spätere Split kann Occurrences 1:1 in job_occurrences
+--   übernehmen; „abgekoppelte" Zeilen bleiben normale Occurrences.
+--
+-- SECURITY DEFINER — begründet (wie schon in der Vorgängerfunktion):
+--   Employees haben kein direktes DELETE/UPDATE auf jobs (RLS). Die Regel-
+--   pflege ist eine Admin-Operation, die serverseitig unter definierten
+--   Rechten laufen muss. Die Funktion prüft selbst auf Admin-Rolle und
+--   Firmenzugehörigkeit (current_user_role/current_user_company_id) und ist
+--   damit fail-closed. search_path fest gesetzt; EXECUTE bleibt wie bisher
+--   auf authenticated (Admin-Check intern).
+-- =========================================================
+
+create or replace function public.update_job_occurrences(
+  parent_job_id_input uuid
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  parent                public.jobs%rowtype;
+  effective_assigned_to uuid;
+  new_count             int;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can update occurrences';
+  end if;
+
+  -- Parent laden UND sperren: serialisiert konkurrierende Aufrufe für
+  -- dieselbe Regel (Doppel-Submit, Retry nach Netzfehler, paralleler
+  -- Realtime-getriggerter Aufruf). Zweiter Aufruf wartet, sieht das
+  -- Ergebnis des ersten und findet dann nichts mehr zu prunen/erzeugen.
+  select * into parent
+  from public.jobs
+  where id         = parent_job_id_input
+    and company_id = public.current_user_company_id()
+    and job_type   = 'recurring'
+    and parent_job_id is null
+  for update;
+
+  if not found then
+    raise exception 'Recurring parent job not found';
+  end if;
+
+  -- Effektive Zuweisung: inaktiver Mitarbeiter → offen (null), analog zur
+  -- Logik in generate_job_occurrences und zum Trigger enforce_active_assignee.
+  select case
+    when parent.assigned_to is not null
+      and exists (
+        select 1 from public.profiles p
+        where p.id = parent.assigned_to and p.is_active = true
+      )
+    then parent.assigned_to
+    else null
+  end
+  into effective_assigned_to;
+
+  -- ── 1) PRUNE ──────────────────────────────────────────────────────
+  -- Nur zukünftige, nachweislich unberührte Occurrences entfernen, die
+  -- nicht mehr zur Regel passen. Historie (started/completed/Kommentare/
+  -- Fotos/Lesestatus) schützt die Zeile immer vor dem Löschen.
+  delete from public.jobs c
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and not exists (select 1 from public.job_comments      x where x.job_id = c.id)
+    and not exists (select 1 from public.job_photos        x where x.job_id = c.id)
+    and not exists (select 1 from public.job_comment_reads x where x.job_id = c.id)
+    and (
+          -- Wochentag nicht mehr Teil der Regel
+          not (parent.recurring_days @> array[
+            case extract(isodow from c.date)::int
+              when 1 then 'mon' when 2 then 'tue' when 3 then 'wed'
+              when 4 then 'thu' when 5 then 'fri' when 6 then 'sat'
+              when 7 then 'sun'
+            end
+          ])
+          -- Uhrzeit geändert
+          or c.start_time is distinct from parent.start_time
+          -- außerhalb des Gültigkeitszeitraums der Regel
+          or (parent.recurrence_end_date   is not null and c.date > parent.recurrence_end_date)
+          or (parent.recurrence_start_date is not null and c.date < parent.recurrence_start_date)
+        );
+
+  -- ── 2) SYNC ───────────────────────────────────────────────────────
+  -- Nicht-Termin-Felder auf zukünftige, noch nicht gestartete Occurrences
+  -- übertragen. Kein Cascade, keine Änderung an date/start_time. Zeilen mit
+  -- Historie (started/completed) bleiben als Nachweis unverändert; ein
+  -- Kommentar/Foto allein verhindert das reine Feld-Update NICHT, da die
+  -- Zeile noch nicht ausgeführt wurde und weiterhin den aktuellen
+  -- Regelstand zeigen soll. updated_at wird vom bestehenden Trigger gesetzt.
+  update public.jobs c
+  set
+    customer_name    = parent.customer_name,
+    service_name     = parent.service_name,
+    location_address = parent.location_address,
+    notes            = parent.notes,
+    is_active        = parent.is_active,
+    assigned_to      = effective_assigned_to
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and (
+         c.customer_name    is distinct from parent.customer_name
+      or c.service_name     is distinct from parent.service_name
+      or c.location_address is distinct from parent.location_address
+      or c.notes            is distinct from parent.notes
+      or c.is_active        is distinct from parent.is_active
+      or c.assigned_to      is distinct from effective_assigned_to
+    );
+
+  -- ── 3) GENERATE ───────────────────────────────────────────────────
+  -- Neu benötigte Termine einfügen (unveränderte, idempotente Funktion).
+  select public.generate_job_occurrences(parent_job_id_input)
+  into new_count;
+
+  return new_count;
+end;
+$$;
+
+comment on function public.update_job_occurrences(uuid) is
+'Nicht-destruktiv: prunt nur unberührte, nicht mehr passende Zukunfts-Occurrences, '
+'synct Nicht-Termin-Felder auf noch nicht gestartete Zukunfts-Occurrences und '
+'erzeugt fehlende Termine (idempotent). Bewahrt in_progress/completed, '
+'Zeitstempel, Kommentare, Fotos und Lesestatus.';

--- a/supabase/tests/non_destructive_update_job_occurrences.test.sql
+++ b/supabase/tests/non_destructive_update_job_occurrences.test.sql
@@ -1,0 +1,437 @@
+-- =========================================================
+-- TEST: update_job_occurrences (nicht-destruktiv)
+-- (Migration 20260723000004_non_destructive_update_job_occurrences)
+-- =========================================================
+-- Weist nach, dass eine Regeländerung Historie bewahrt (completed/
+-- in_progress/Zeitstempel/Kommentare/Fotos/Lesestatus), Nicht-Termin-
+-- Felder auf noch nicht gestartete Zukunfts-Occurrences synct, nur
+-- unberührte, nicht mehr passende Zukunfts-Occurrences entfernt, fehlende
+-- Termine einfügt, idempotent bleibt und Firmen isoliert.
+--
+-- Aufrufe laufen als 'authenticated' Admin (SET ROLE + request.jwt.claims),
+-- also über denselben Pfad wie services/jobs/jobs.service.ts updateJob →
+-- rpc('update_job_occurrences').
+--
+-- AUSFÜHREN lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/non_destructive_update_job_occurrences.test.sql
+-- Legt Testdaten an, macht am Ende ROLLBACK — KEINE Rückstände, KEINE
+-- Produktionsdaten.
+--
+-- Ergebnis: Tabelle (case_no | beschreibung | erwartet | ergebnis |
+-- verdikt) + NOTICE-Meldungen. Schlägt ein Fall fehl, bricht der Lauf
+-- am Ende LAUT ab (Exit-Code != 0).
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = a1…1 (Haupttests) | Firma B = a1…2 (Isolation)
+-- Admin A  = a2…1 | Mitarbeiter A = a2…2 | Admin B = a2…3
+-- Heute ist Referenz; recurring_days werden dynamisch aus konkreten Daten
+-- abgeleitet, damit der Test wochentagsunabhängig reproduzierbar ist.
+
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-000000000001','authenticated','authenticated','ndupd-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-000000000002','authenticated','authenticated','ndupd-empA@example.test','{"full_name":"Mitarbeiter A"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-000000000003','authenticated','authenticated','ndupd-adminB@example.test','{"full_name":"Admin B"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('a2000000-0000-0000-0000-000000000001','Admin A'),
+  ('a2000000-0000-0000-0000-000000000002','Mitarbeiter A'),
+  ('a2000000-0000-0000-0000-000000000003','Admin B')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('a1000000-0000-0000-0000-000000000001','ND Firma A','nd-firma-a-test'),
+  ('a1000000-0000-0000-0000-000000000002','ND Firma B','nd-firma-b-test');
+
+update public.profiles set company_id='a1000000-0000-0000-0000-000000000001', role='admin',    is_active=true where id='a2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='a1000000-0000-0000-0000-000000000001', role='employee', is_active=true where id='a2000000-0000-0000-0000-000000000002';
+update public.profiles set company_id='a1000000-0000-0000-0000-000000000002', role='admin',    is_active=true where id='a2000000-0000-0000-0000-000000000003';
+
+-- Helfer: JWT-Claims für einen Aufrufer setzen
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub', uid::text, 'role','authenticated')::text, true);
+end $f$;
+
+-- Ergebnis-Sammler
+create temporary table _nd_results (
+  case_no int, beschreibung text, erwartet text, ergebnis text
+) on commit drop;
+
+
+-- =========================================================
+-- FIXTURE: Regel R1 (Firma A), Wochentage = die der beiden Zukunftstage
+--   d_future1 = heute+7  (Occurrence mit Historie/Anhängen, „geschützt")
+--   d_future2 = heute+14 (unberührte, passende Occurrence)
+-- Zusätzlich:
+--   d_past    = heute-7  (completed, Vergangenheit)
+--   d_today_ip= heute    (in_progress)
+-- Start-/Endzeitraum großzügig, Uhrzeit 08:00.
+-- =========================================================
+do $$
+declare
+  d_past    date := current_date - 7;
+  d_today   date := current_date;
+  d_future1 date := current_date + 7;
+  d_future2 date := current_date + 14;
+  wd_f1 text;
+  wd_f2 text;
+  wd_today text;
+begin
+  wd_f1    := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_future1)::int + 1];
+  wd_f2    := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_future2)::int + 1];
+  wd_today := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_today)::int + 1];
+
+  -- Parent-Regel R1 (deckt zunächst die Wochentage von f1, f2 und heute ab)
+  insert into public.jobs
+    (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+     status, job_type, recurring_days, start_time, is_active,
+     recurrence_start_date, recurrence_end_date)
+  values
+    ('a3000000-0000-0000-0000-000000000001','a1000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000002',
+     'Kunde Alt','Unterhaltsreinigung','Altweg 1',
+     'open','recurring', array[wd_f1, wd_f2, wd_today]::text[], '08:00', true,
+     current_date - 30, current_date + 365);
+
+  -- Occurrences an R1
+  insert into public.jobs
+    (id, company_id, parent_job_id, created_by, assigned_to, customer_name, service_name,
+     location_address, status, job_type, date, start_time, is_active, started_at, completed_at)
+  values
+    -- completed (Vergangenheit) + Timesheet-Zeitstempel
+    ('a4000000-0000-0000-0000-000000000001','a1000000-0000-0000-0000-000000000001',
+     'a3000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000002','Kunde Alt','Unterhaltsreinigung','Altweg 1',
+     'completed','single', d_past, '08:00', true,
+     timestamptz '2026-07-10 08:03:00+00', timestamptz '2026-07-10 10:12:00+00'),
+    -- in_progress (heute) + started_at
+    ('a4000000-0000-0000-0000-000000000002','a1000000-0000-0000-0000-000000000001',
+     'a3000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000002','Kunde Alt','Unterhaltsreinigung','Altweg 1',
+     'in_progress','single', d_today, '08:00', true,
+     timestamptz '2026-07-23 08:05:00+00', null),
+    -- zukünftig, unberührt, PASSEND (bleibt erhalten, kein Churn)
+    ('a4000000-0000-0000-0000-000000000003','a1000000-0000-0000-0000-000000000001',
+     'a3000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000002','Kunde Alt','Unterhaltsreinigung','Altweg 1',
+     'open','single', d_future2, '08:00', true, null, null),
+    -- zukünftig, OFFEN aber mit Anhängen (Kommentar+Foto+Lesestatus) → geschützt
+    ('a4000000-0000-0000-0000-000000000004','a1000000-0000-0000-0000-000000000001',
+     'a3000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000002','Kunde Alt','Unterhaltsreinigung','Altweg 1',
+     'open','single', d_future1, '08:00', true, null, null);
+
+  -- Anhänge an die geschützte offene Zukunfts-Occurrence a4…4
+  insert into public.job_comments (id, company_id, job_id, author_id, message)
+  values ('a5000000-0000-0000-0000-000000000001','a1000000-0000-0000-0000-000000000001',
+          'a4000000-0000-0000-0000-000000000004','a2000000-0000-0000-0000-000000000002','Bitte Schlüssel abholen.');
+  insert into public.job_photos (id, job_id, company_id, uploaded_by, storage_path, file_name)
+  values ('a6000000-0000-0000-0000-000000000001','a4000000-0000-0000-0000-000000000004',
+          'a1000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000002','a1/a4/vorab.jpg','vorab.jpg');
+  insert into public.job_comment_reads (job_id, user_id)
+  values ('a4000000-0000-0000-0000-000000000004','a2000000-0000-0000-0000-000000000002');
+
+  -- Firma B: eigene Regel + Occurrence (Isolation)
+  insert into public.jobs
+    (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+     status, job_type, recurring_days, start_time, is_active, recurrence_start_date)
+  values
+    ('a3000000-0000-0000-0000-0000000000B1','a1000000-0000-0000-0000-000000000002',
+     'a2000000-0000-0000-0000-000000000003', null,
+     'Fremdkunde','Glasreinigung','Fremdweg 9',
+     'open','recurring', array[wd_f1]::text[], '09:00', true, current_date - 10);
+  insert into public.jobs
+    (id, company_id, parent_job_id, created_by, customer_name, service_name,
+     location_address, status, job_type, date, start_time, is_active)
+  values
+    ('a4000000-0000-0000-0000-0000000000B1','a1000000-0000-0000-0000-000000000002',
+     'a3000000-0000-0000-0000-0000000000B1','a2000000-0000-0000-0000-000000000003',
+     'Fremdkunde','Glasreinigung','Fremdweg 9','open','single', d_future1, '09:00', true);
+
+  -- Normaler Single-Job Firma A (kein Parent) — darf nie berührt werden
+  insert into public.jobs
+    (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+     status, job_type, date, start_time, is_active)
+  values
+    ('a4000000-0000-0000-0000-0000000000AA','a1000000-0000-0000-0000-000000000001',
+     'a2000000-0000-0000-0000-000000000001','a2000000-0000-0000-0000-000000000002',
+     'Einzelkunde','Grundreinigung','Einzelweg 3','open','single', d_future1, '15:00', true);
+end $$;
+
+
+-- =========================================================
+-- EDIT 1: Nicht-Termin-Änderung (Kunde/Service/Ort) + Enddatum unverändert.
+-- Regel R1: Kunde Alt -> Kunde Neu, Service -> Fensterreinigung.
+-- Erwartung nach update_job_occurrences:
+--   * completed/in_progress/past: Felder UNVERÄNDERT (Historie)
+--   * offene Zukunft (a4…3, a4…4): Kunde/Service SYNCED
+--   * a4…4 behält Kommentar/Foto/Lesestatus (nicht gelöscht)
+--   * kein Churn: a4…3 und a4…4 behalten ihre id
+-- =========================================================
+do $$
+declare
+  ret int;
+begin
+  update public.jobs set customer_name='Kunde Neu', service_name='Fensterreinigung'
+   where id='a3000000-0000-0000-0000-000000000001';
+
+  perform pg_temp.act_as('a2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('a3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+end $$;
+
+-- CASE 1: completed Occurrence erhalten
+insert into _nd_results
+select 1, 'completed Occurrence bleibt erhalten', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000001' and status='completed')
+       then 'PRESERVED' else 'WEG' end;
+
+-- CASE 2: in_progress Occurrence erhalten
+insert into _nd_results
+select 2, 'in_progress Occurrence bleibt erhalten', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000002' and status='in_progress')
+       then 'PRESERVED' else 'WEG' end;
+
+-- CASE 3: started_at/completed_at unverändert
+insert into _nd_results
+select 3, 'Zeitstempel started_at/completed_at unverändert', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where id='a4000000-0000-0000-0000-000000000001'
+      and started_at = timestamptz '2026-07-10 08:03:00+00'
+      and completed_at = timestamptz '2026-07-10 10:12:00+00'
+  ) and exists (
+    select 1 from public.jobs
+    where id='a4000000-0000-0000-0000-000000000002'
+      and started_at = timestamptz '2026-07-23 08:05:00+00'
+  ) then 'OK' else 'GEAENDERT' end;
+
+-- CASE 4: Kommentar erhalten
+insert into _nd_results
+select 4, 'Kommentar der offenen Zukunfts-Occurrence erhalten', 'OK',
+  case when exists (select 1 from public.job_comments where id='a5000000-0000-0000-0000-000000000001') then 'OK' else 'WEG' end;
+
+-- CASE 5: Foto erhalten
+insert into _nd_results
+select 5, 'Foto der offenen Zukunfts-Occurrence erhalten', 'OK',
+  case when exists (select 1 from public.job_photos where id='a6000000-0000-0000-0000-000000000001') then 'OK' else 'WEG' end;
+
+-- CASE 6: Lesestatus erhalten
+insert into _nd_results
+select 6, 'Lesestatus der offenen Zukunfts-Occurrence erhalten', 'OK',
+  case when exists (select 1 from public.job_comment_reads where job_id='a4000000-0000-0000-0000-000000000004') then 'OK' else 'WEG' end;
+
+-- CASE 7: Timesheet-relevante Daten (completed + beide Zeitstempel) intakt
+insert into _nd_results
+select 7, 'Timesheet-Datensatz (completed + Zeitstempel) intakt', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where id='a4000000-0000-0000-0000-000000000001'
+      and status='completed' and started_at is not null and completed_at is not null
+  ) then 'OK' else 'DEFEKT' end;
+
+-- CASE 8: offene Zukunfts-Occurrence MIT Kommentar bleibt erhalten (a4…4)
+insert into _nd_results
+select 8, 'Offene Zukunfts-Occurrence mit Kommentar bleibt erhalten', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000004') then 'PRESERVED' else 'WEG' end;
+
+-- CASE 9: offene Zukunfts-Occurrence MIT Foto bleibt erhalten (dieselbe Zeile a4…4)
+insert into _nd_results
+select 9, 'Offene Zukunfts-Occurrence mit Foto bleibt erhalten', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000004') then 'PRESERVED' else 'WEG' end;
+
+-- CASE 16 (hier prüfbar): Sync ändert Anzeige der offenen Zukunft, nicht der Historie
+insert into _nd_results
+select 16, 'Sync: offene Zukunft = Kunde Neu, Historie = Kunde Alt', 'OK',
+  case when (select customer_name from public.jobs where id='a4000000-0000-0000-0000-000000000003') = 'Kunde Neu'
+        and (select customer_name from public.jobs where id='a4000000-0000-0000-0000-000000000004') = 'Kunde Neu'
+        and (select customer_name from public.jobs where id='a4000000-0000-0000-0000-000000000001') = 'Kunde Alt'
+        and (select customer_name from public.jobs where id='a4000000-0000-0000-0000-000000000002') = 'Kunde Alt'
+       then 'OK' else 'FALSCH' end;
+
+-- CASE 17: normaler Single-Job unberührt
+insert into _nd_results
+select 17, 'Normaler Single-Job unberührt', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where id='a4000000-0000-0000-0000-0000000000AA' and customer_name='Einzelkunde' and service_name='Grundreinigung'
+  ) then 'OK' else 'GEAENDERT' end;
+
+-- CASE 18: Firma B unberührt (Isolation)
+insert into _nd_results
+select 18, 'Firma B Occurrence unberührt (Isolation)', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where id='a4000000-0000-0000-0000-0000000000B1' and customer_name='Fremdkunde'
+  ) then 'OK' else 'BEEINFLUSST' end;
+
+
+-- =========================================================
+-- EDIT 2: Uhrzeit ändern 08:00 -> 09:30. Danach:
+--   * a4…3 (unberührt, passend zur alten Zeit) → jetzt nicht passend →
+--     PRUNE entfernt sie
+--   * a4…4 (mit Anhängen, alte Zeit) → nicht passend ABER geschützt → bleibt
+--   * neue 09:30-Occurrences werden erzeugt (CASE 14)
+-- =========================================================
+do $$
+declare ret int;
+begin
+  update public.jobs set start_time='09:30' where id='a3000000-0000-0000-0000-000000000001';
+  perform pg_temp.act_as('a2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('a3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+end $$;
+
+-- CASE 10: unberührte, nicht mehr passende Zukunfts-Occurrence entfernt (a4…3, alte Zeit 08:00)
+insert into _nd_results
+select 10, 'Unberührte, nicht passende Zukunfts-Occurrence entfernt', 'REMOVED',
+  case when not exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000003')
+       then 'REMOVED' else 'NOCH_DA' end;
+
+-- CASE 8b: geschützte a4…4 (alte Zeit, aber mit Anhängen) NICHT entfernt
+insert into _nd_results
+select 21, 'Nicht passende ABER geschützte Occurrence bleibt (abgekoppelt)', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000004' and start_time='08:00')
+       then 'PRESERVED' else 'WEG' end;
+
+-- CASE 14: nach Zeitänderung existieren neue 09:30-Occurrences
+insert into _nd_results
+select 14, 'Zeitänderung erzeugt neue 09:30-Occurrences', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where parent_job_id='a3000000-0000-0000-0000-000000000001'
+      and start_time='09:30' and date >= current_date
+  ) then 'OK' else 'FEHLT' end;
+
+-- CASE 11: neu benötigte Occurrence eingefügt (mind. eine 09:30 an einem Regeltag)
+insert into _nd_results
+select 11, 'Neu benötigte Occurrence eingefügt', 'OK',
+  case when (select count(*) from public.jobs
+             where parent_job_id='a3000000-0000-0000-0000-000000000001'
+               and start_time='09:30') > 0
+       then 'OK' else 'FEHLT' end;
+
+
+-- =========================================================
+-- EDIT 3: Idempotenz — identischer Aufruf ohne Regeländerung darf keine
+-- Duplikate erzeugen und die Zeilenzahl nicht verändern.
+-- =========================================================
+do $$
+declare
+  before_cnt int; after_cnt int; ret int;
+begin
+  select count(*) into before_cnt from public.jobs where parent_job_id='a3000000-0000-0000-0000-000000000001';
+  perform pg_temp.act_as('a2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('a3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+  select count(*) into after_cnt from public.jobs where parent_job_id='a3000000-0000-0000-0000-000000000001';
+
+  insert into _nd_results values
+    (12, 'Erneuter Aufruf erzeugt keine Duplikate (Zeilenzahl stabil)', 'STABLE',
+     case when before_cnt = after_cnt then 'STABLE' else 'CHANGED('||before_cnt||'->'||after_cnt||')' end);
+
+  -- keine doppelten (date,start_time) an derselben Regel
+  insert into _nd_results
+  select 22, 'Keine doppelten (date,start_time) an der Regel', 'OK',
+    case when not exists (
+      select 1 from public.jobs
+      where parent_job_id='a3000000-0000-0000-0000-000000000001'
+      group by date, start_time having count(*) > 1
+    ) then 'OK' else 'DUPLIKAT' end;
+end $$;
+
+
+-- =========================================================
+-- EDIT 4: Wochentage ändern — nur noch der Wochentag von d_future2.
+-- Prüft "korrekte Zukunftsplanung": es entstehen nur Occurrences an diesem
+-- Wochentag, und unberührte an anderen Wochentagen verschwinden.
+-- =========================================================
+do $$
+declare
+  wd_keep text; ret int; wrong_day int;
+  d_future2 date := current_date + 14;
+begin
+  wd_keep := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_future2)::int + 1];
+  update public.jobs set recurring_days = array[wd_keep]::text[]
+   where id='a3000000-0000-0000-0000-000000000001';
+
+  perform pg_temp.act_as('a2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('a3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+
+  -- Zukunfts-Occurrences OHNE Historie dürfen nur noch am erlaubten Wochentag liegen
+  select count(*) into wrong_day
+  from public.jobs c
+  where c.parent_job_id='a3000000-0000-0000-0000-000000000001'
+    and c.date >= current_date
+    and c.started_at is null and c.completed_at is null
+    and not exists (select 1 from public.job_comments x where x.job_id=c.id)
+    and not exists (select 1 from public.job_photos x where x.job_id=c.id)
+    and not exists (select 1 from public.job_comment_reads x where x.job_id=c.id)
+    and (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from c.date)::int + 1] <> wd_keep;
+
+  insert into _nd_results values
+    (13, 'Wochentagsänderung: unberührte Zukunft nur am erlaubten Tag', 'OK',
+     case when wrong_day = 0 then 'OK' else 'FALSCHER_TAG('||wrong_day||')' end);
+end $$;
+
+
+-- =========================================================
+-- EDIT 5: recurrence_end_date verkürzen — darf geschützte Historie nicht
+-- anfassen. completed/in_progress bleiben, auch wenn sie (theoretisch)
+-- außerhalb lägen. Hier bereits in Vergangenheit/heute → immer geschützt.
+-- =========================================================
+do $$
+declare ret int;
+begin
+  update public.jobs set recurrence_end_date = current_date + 3
+   where id='a3000000-0000-0000-0000-000000000001';
+  perform pg_temp.act_as('a2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('a3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+end $$;
+
+insert into _nd_results
+select 15, 'Enddatum-Verkürzung lässt geschützte Historie unberührt', 'OK',
+  case when exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000001' and status='completed')
+        and exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000002' and status='in_progress')
+        and exists (select 1 from public.jobs where id='a4000000-0000-0000-0000-000000000004')
+       then 'OK' else 'HISTORIE_BESCHAEDIGT' end;
+
+-- CASE 19/20 (Negativ-Kontrolle) wird separat außerhalb dieses Files gefahren
+-- (siehe Report / Runner): dort wird die alte destruktive Funktion
+-- eingespielt und CASE 4/5/6/8 schlagen fehl. Hier als Platzhalter der
+-- positive Nachweis, dass die aktuelle Implementierung greift.
+
+
+-- =========================================================
+-- Ergebnisübersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _nd_results order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _nd_results where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'NON-DESTRUCTIVE UPDATE TEST: % Fall/Fälle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE FÄLLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
## Problem (am deployten Stand verifiziert, nicht aus Migrationen)

Die deployte `update_job_occurrences(uuid)` war:

```sql
delete from public.jobs
where parent_job_id = parent_job_id_input
  and status = 'open' and date >= current_date;
select public.generate_job_occurrences(parent_job_id_input);
```

Jede Regeländerung löscht damit **alle** offenen zukünftigen Occurrences und erzeugt sie neu. Weil `job_comments`, `job_photos` und `job_comment_reads` per `ON DELETE CASCADE` an `jobs(id)` hängen, gehen dabei Kommentare, Fotos und Lesestatus dieser Zeilen verloren. Der Client ([services/jobs/jobs.service.ts](services/jobs/jobs.service.ts) `updateJob`) ruft die RPC bei **jedem** Recurring-Edit auf — auch bei reiner Namensänderung, unabhängig vom geänderten Feld.

Produktionsmessung (rein lesend):

| Regel | Zukunft-offen gelöscht+neu | geschützt (unberührt) |
|---|---|---|
| injoy volmital | **624** | completed 2 / past-open 1 |
| شركة عصير | 20 | completed 1 / past-open 7 |
| Fitness Gym | 7 | protected 4 / past-open 6 |
| Müller GmbH | 2 | protected 2 / past-open 5 |

Aktuell exponiert: **653 Zeilen** Churn gesamt, **5 Lesestatus**-Zeilen würden still verworfen (Kommentare/Fotos derzeit 0 auf Zukunft-offen, aber der Mechanismus zerstört sie).

## Lösung — mengenbasiert, additiv, gleiche Signatur

`CREATE OR REPLACE FUNCTION update_job_occurrences(uuid)` in drei Schritten:

1. **PRUNE** — löscht nur zukünftige Occurrences, die **nachweislich unberührt** sind (`status='open'`, `started_at IS NULL`, `completed_at IS NULL`, keine Kommentare/Fotos/Lesestatus) **und** nicht mehr zur Regel passen (Wochentag nicht mehr in `recurring_days`, `start_time` geändert, außerhalb `recurrence_start/end_date`).
2. **SYNC** — überträgt Nicht-Termin-Felder (Kunde/Service/Ort/Notizen/`is_active`/Zuweisung) per `UPDATE` auf noch nicht gestartete Zukunfts-Occurrences, damit Änderungen ohne Löschen ankommen. Kein Cascade, keine Änderung an `date`/`start_time`.
3. **GENERATE** — ruft die unveränderte, idempotente `generate_job_occurrences` zum Einfügen neu benötigter Termine auf.

Ergebnis:
- Vergangene, `in_progress`, `completed` Occurrences: **unangetastet**
- Zukünftige Occurrences mit Historie: **erhalten** (passen sie nicht mehr, bleiben sie als abgekoppelte Termine bestehen)
- Nur unberührte, nicht passende Zukunft: entfernt
- Neu benötigte Termine: eingefügt
- Erneuter Aufruf: **idempotent, keine Duplikate** (`idx_jobs_occurrence_unique` + `ON CONFLICT`)

**Concurrency:** `FOR UPDATE` auf der Parent-Zeile serialisiert konkurrierende Aufrufe (Doppel-Submit, Retry nach Netzfehler, Realtime-getriggerter Aufruf).

**Kein neuer Index nötig** — Query-Plan gegen Produktion verifiziert: Prune nutzt `Index Scan using idx_jobs_parent_job_id` + Anti-Joins auf bestehende Kind-Indizes.

**Bewusst keine neue Spalte/kein Status** für abgekoppelte Occurrences: für die Korrektheit dieser Funktion nicht nötig; eine erhaltene Occurrence, die nicht mehr passt, ist über `(Wochentag, start_time)` vs. Regel erkennbar. Ein Flag würde die spätere `job_definitions`/`job_occurrences`-Trennung zusätzlich belasten → Empfehlung an den Display-PR.

### `SECURITY DEFINER` — begründet
Wie in der Vorgängerfunktion: Employees haben kein direktes DELETE/UPDATE auf `jobs` (RLS); Regelpflege ist eine Admin-Operation. Die Funktion prüft selbst Admin-Rolle + Firmenzugehörigkeit (fail-closed), `search_path` fest gesetzt.

## Kompatibilität mit Zeitplan/Daueraufträge-Split
Die Funktion fasst weiterhin nur konkrete Occurrences an und lässt die Parent-Regel unberührt. Kein Feld umgedeutet, keine Beziehung geändert. Der spätere Split kann Occurrences 1:1 in `job_occurrences` übernehmen; abgekoppelte Zeilen bleiben normale Occurrences.

## Bewusst NICHT Teil dieses PRs
Zeitplan-/Daueraufträge-UI, Dashboard-/Realtime-/Pagination-/Offline-Redesign, Notifications, `job_definitions`/`job_occurrences`-Migration, unrelated Refactoring, Kunden-/Service-Entity-Migration. `generate_job_occurrences` unverändert. Kein Client-Code geändert (RPC-Signatur identisch).

## Tests — 20 Fälle, alle PASS

`supabase/tests/non_destructive_update_job_occurrences.test.sql`, transaktional (`BEGIN … ROLLBACK`), keine Rückstände, Aufrufe als `authenticated` Admin.

Erhalt: completed (1), in_progress (2), Zeitstempel (3), Kommentar (4), Foto (5), Lesestatus (6), Timesheet (7), offene Zukunft mit Kommentar (8) / Foto (9); Entfernen unberührter nicht-passender Zukunft (10); Einfügen neuer Termine (11); Idempotenz/keine Duplikate (12, 22); korrekte Zukunftsplanung bei Wochentags- (13) und Uhrzeitänderung (14); Enddatum-Verkürzung schützt Historie (15); Sync nur Zukunft, nicht Historie (16); normaler Single-Job (17) und Firma B/Isolation (18) unberührt; abgekoppelte geschützte Occurrence bleibt (21).

**Negativ-Kontrolle:** wird die alte destruktive Funktion in die Test-Transaktion injiziert, schlagen Fälle **4/5/6/8/9/15/16/21** fehl (Kommentar/Foto/Lesestatus WEG, Historie beschädigt), `psql` Exit-Code **3**. Der Test erkennt den Originaldefekt nachweislich.

**Weiteres lokal:** `supabase db reset` (alle 16 Migrationen von Null), Migration zweimal ausgeführt → idempotent (`CREATE OR REPLACE`), `npm run lint` → 0, `npx tsc --noEmit` → 0.

## Bekannte Grenzen
- Abgekoppelte Occurrences (Historie zur alten Zeit nach Zeitänderung) sind noch **nicht als solche gekennzeichnet** — der Display-PR sollte ein Badge einführen. In der aktuellen Liste können dadurch am selben Tag zwei Karten (alte + neue Zeit) erscheinen; das ist gewolltes Verhalten (Historie + neuer Termin), aber optisch erklärungsbedürftig bis zum UI-Split.
- Der Client ruft die RPC weiterhin bei **jedem** Recurring-Edit (kein Feld-Diff). Der Churn ist jetzt aber minimal (nur nicht-passende unberührte Zeilen) statt destruktiv.

## Deployment
⚠️ **Nicht** auf Production ausgeführt. Alle Produktionszugriffe in diesem PR waren **rein lesend** (`EXPLAIN` ohne `ANALYZE`, Katalog-/Zählabfragen). `supabase db push --linked` bleibt dem Review/Approval vorbehalten.

Rollback: vorherige Funktionsversion per `CREATE OR REPLACE` wiederherstellen (Body im Migrationskommentar dokumentiert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)