### PR TITLE
fix(android): wire up Firebase config for expo-notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ yarn-error.*
 # local env files
 .env*.local
 
+# Firebase Android client config (public repo: keep out of git history,
+# supply via EAS file environment variable or place locally per developer)
+google-services.json
+
 # typescript
 *.tsbuildinfo
 

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,10 @@
+const appJson = require("./app.json");
+
+module.exports = {
+  ...appJson.expo,
+  android: {
+    ...appJson.expo.android,
+    googleServicesFile:
+      process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+  },
+};

--- a/app.config.js
+++ b/app.config.js
@@ -1,10 +1,8 @@
-const appJson = require("./app.json");
-
-module.exports = {
-  ...appJson.expo,
+module.exports = ({ config }) => ({
+  ...config,
   android: {
-    ...appJson.expo.android,
+    ...config.android,
     googleServicesFile:
       process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
   },
-};
+});

--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "permissions": ["android.permission.RECORD_AUDIO"],
-      "package": "com.ferash.taskopsmanager"
+      "package": "com.ferash.taskopsmanager",
+      "googleServicesFile": "./google-services.json"
     },
     "web": {
       "output": "static",
@@ -55,7 +56,8 @@
         }
       ],
       "expo-font",
-      "expo-web-browser"
+      "expo-web-browser",
+      "expo-notifications"
     ],
     "experiments": {
       "typedRoutes": true


### PR DESCRIPTION
## Summary
- Android push registration fails with `Default FirebaseApp is not initialized in this process com.ferash.taskopsmanager` because `app.json` had no `expo-notifications` config plugin entry and no `android.googleServicesFile` reference — native Firebase was never wired into the Android build.
- Adds `"expo-notifications"` to `plugins` and sets `android.googleServicesFile` to `./google-services.json`.
- Gitignores `google-services.json` (this repo is public; the file is Firebase *client* config, not a secret in Google's model, but keeping it out of git history is the safer default for a public repo — supply it per-developer locally or via an EAS file environment variable for cloud builds).
- **No backend/dispatcher changes, no notification architecture changes, no job-assignment behavior changes** — scope is strictly the native Android Firebase init gap, per `ANDROID_PUSH_NOTIFICATION_DIAGNOSIS.md`.

## google-services.json status
**Not available in this environment** — not created, not faked, not committed. The `android.googleServicesFile` path is configured, but the file itself must be added manually before any Android build (dev or prod) will succeed. See "Manual steps required" below.

## EAS environment variable gap (separate, pre-existing issue — not fixed here)
`eas env:list development` currently returns **"No variables found for this environment."** `lib/supabase.ts` reads `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` directly from `process.env` at build time, so a cloud EAS build for the `development` profile will bundle these as `undefined` unless they're added to the EAS `development` environment. This is the same class of warning already seen on the iOS development build. **Not changed in this PR** (no EAS secrets were touched, per scope) — flagged here for a maintainer decision.

## Manual steps required before building
1. Firebase Console → open (or create) the Firebase project → Project settings → Android app.
2. Confirm/register an Android app with package name **exactly** `com.ferash.taskopsmanager`.
3. Download that app's `google-services.json` and place it at the repo root (path referenced by `app.json`). It's gitignored, so it won't be committed automatically.
4. For EAS cloud builds, alternatively upload it as an EAS file environment variable so `eas build` can inject it without it ever touching the repo.
5. Separately (not part of this PR): confirm an Android **FCM V1 service-account** credential is registered in EAS (`eas credentials -p android`, interactive) — this is server-side push-delivery credential material, distinct from `google-services.json`, and still unverified per the diagnosis report.
6. Once the file is in place: run `eas build --profile development --platform android` (or a local prebuild) to produce a new Android development build — **a new build is required**, this cannot be delivered as a JS/OTA update.
7. Decide whether `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` need to be added to the EAS `development` environment (see above).

## Validation
- `npx expo config --type public` — resolved config confirmed: `android.package` = `com.ferash.taskopsmanager` (unchanged), `android.googleServicesFile` = `./google-services.json`, `expo-notifications` present in `plugins`, `extra.eas.projectId` unchanged (`e746276f-fbd7-49bd-aab6-dc3176e7661a`).
- `npx expo-doctor` — 17/18 passed, same single pre-existing failure as before this change (`buildNumber` at the top level of `app.json` instead of nested under `ios`) — unrelated to this fix, intentionally left out of scope.
- `npx tsc --noEmit` — no errors (no `typecheck` script exists in `package.json`, used this as the equivalent).
- `npm run lint` — passed, no output.
- No EAS build was run (real `google-services.json` not available yet, per scope constraints).

## Test plan
- [ ] Add real `google-services.json` (package `com.ferash.taskopsmanager`) locally or via EAS file env var
- [ ] `eas build --profile development --platform android` (or local prebuild) to produce a new dev client
- [ ] Install on an Android device, grant notification permission
- [ ] Confirm no `FirebaseApp is not initialized` error and `Notifications.getExpoPushTokenAsync` resolves
- [ ] Confirm token is persisted via `update_my_push_token` (read-only DB check)
- [ ] Send a manual Expo push to the new token to confirm end-to-end delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)