### PR TITLE
feat(jobs): kommende Termine in scrollbarem Bereich statt "Mehr anzeigen"

### DIFF
--- a/features/jobs/components/RuleOccurrences.tsx
+++ b/features/jobs/components/RuleOccurrences.tsx
@@ -7,16 +7,21 @@
 // Die Frage „läuft die Regel und was kommt als Nächstes?" war damit unter
 // Historie begraben.
 //
-// Jetzt: kommende Termine zuerst (nächster oben), Vergangenes eingeklappt.
+// Jetzt: kommende Termine zuerst (nächster oben) in einem eigenen, in der
+// Höhe begrenzten Scrollbereich — wie in einer Kalender-App direkt sichtbar
+// und scrollbar, ohne „Mehr anzeigen"-Zwischenschritt. Vergangenes bleibt
+// eingeklappt.
 //
 // SKALIERUNG — bewusst KEINE FlatList: diese Karte hängt im vertikalen
-// ScrollView des JobDetailScreen; eine gleichachsige VirtualizedList darin
-// verliert ihre Virtualisierung (RN-Warnung „VirtualizedLists should never
-// be nested inside plain ScrollViews with the same orientation") und würde
-// zusätzlich das Keyboard-Handling der Kommentare stören. Stattdessen
-// begrenzte Seiten: initial 5 kommende Termine, Vergangenes eingeklappt,
-// danach je 10 weitere pro Tipp. Gerendert wird also immer nur, was der
-// Nutzer explizit angefordert hat — nie hunderte Zeilen auf einmal.
+// ScrollView des JobDetailScreen. Eine gleichachsige, scrollbare
+// VirtualizedList darin meldet in __DEV__ zuverlässig
+// `console.error("VirtualizedLists should never be nested inside plain
+// ScrollViews with the same orientation …")` — auch mit fester Höhe, denn
+// die Prüfung in VirtualizedList kennt nur ScrollView-Context + Orientierung
+// (react-native/…/VirtualizedList.js). Die kommenden Termine sind durch den
+// rollierenden Generierungs-Horizont ohnehin begrenzt (~90 Tage) und liegen
+// bereits vollständig im Speicher, deshalb reicht hier ein ScrollView mit
+// maxHeight. Die unbegrenzt wachsende Historie bleibt seitenweise.
 
 import { StatusBadge } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
@@ -25,11 +30,24 @@ import type { Job } from "@/types/job";
 import { formatDateISO } from "@/utils/date";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
-const INITIAL_UPCOMING = 5;
 const INITIAL_PAST = 5;
 const PAGE_SIZE = 10;
+
+// Höhe des Scrollbereichs für kommende Termine: gut 4 Zeilen — genug, damit
+// die Liste als eigener Bereich erkennbar ist und scrollbar wirkt, ohne die
+// darunterliegenden Abschnitte (Vergangenes, Fotos, Kommentare) zu verdrängen.
+// maxHeight statt height: kurze Listen bleiben in ihrer natürlichen Höhe und
+// zeigen dann gar keinen Scrollbalken.
+const UPCOMING_MAX_HEIGHT = 360;
 
 const WEEKDAY_SHORT = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
 
@@ -54,7 +72,6 @@ export function RuleOccurrences({ occurrences, loading, onOpen }: Props) {
 
   const todayKey = useMemo(() => formatDateISO(new Date()) ?? "", []);
 
-  const [upcomingLimit, setUpcomingLimit] = useState(INITIAL_UPCOMING);
   const [pastOpen, setPastOpen] = useState(false);
   const [pastLimit, setPastLimit] = useState(INITIAL_PAST);
 
@@ -73,9 +90,7 @@ export function RuleOccurrences({ occurrences, loading, onOpen }: Props) {
     return { upcoming: up, past: old };
   }, [occurrences, todayKey]);
 
-  const visibleUpcoming = upcoming.slice(0, upcomingLimit);
   const visiblePast = pastOpen ? past.slice(0, pastLimit) : [];
-  const moreUpcoming = upcoming.length - visibleUpcoming.length;
   const morePast = past.length - visiblePast.length;
 
   return (
@@ -103,32 +118,34 @@ export function RuleOccurrences({ occurrences, loading, onOpen }: Props) {
             Kommende Termine ({upcoming.length})
           </Text>
 
-          {visibleUpcoming.length === 0 ? (
+          {upcoming.length === 0 ? (
             <Text style={styles.emptyText}>
               Keine kommenden Termine im generierten Zeitraum.
             </Text>
           ) : (
-            visibleUpcoming.map((occ) => (
-              <OccurrenceRow
-                key={occ.id}
-                occurrence={occ}
-                isToday={(occ.date?.slice(0, 10) ?? "") === todayKey}
-                past={false}
-                onPress={() => onOpen(occ)}
-                styles={styles}
-                theme={theme}
-              />
-            ))
+            // Eigener Scrollbereich: alle kommenden Termine sind sofort da,
+            // gescrollt wird direkt in der Liste. `nestedScrollEnabled` ist
+            // auf Android nötig, damit die innere Liste die Geste bekommt;
+            // iOS macht das von Haus aus. Die Seite darum scrollt weiter
+            // normal, sobald der innere Bereich am Ende ist.
+            <ScrollView
+              style={styles.upcomingScroll}
+              nestedScrollEnabled
+              keyboardShouldPersistTaps="handled"
+            >
+              {upcoming.map((occ) => (
+                <OccurrenceRow
+                  key={occ.id}
+                  occurrence={occ}
+                  isToday={(occ.date?.slice(0, 10) ?? "") === todayKey}
+                  past={false}
+                  onPress={() => onOpen(occ)}
+                  styles={styles}
+                  theme={theme}
+                />
+              ))}
+            </ScrollView>
           )}
-
-          {moreUpcoming > 0 ? (
-            <MoreButton
-              label={`Mehr anzeigen (${moreUpcoming} weitere)`}
-              onPress={() => setUpcomingLimit((n) => n + PAGE_SIZE)}
-              styles={styles}
-              theme={theme}
-            />
-          ) : null}
 
           {/* ── Vergangene Termine (eingeklappt) ── */}
           {past.length > 0 ? (
@@ -304,6 +321,12 @@ function createStyles(theme: AppTheme) {
       fontFamily: theme.typography.family.regular,
       color: theme.colors.onSurfaceVariant,
       paddingVertical: 4,
+    },
+    // flexGrow: 0 verhindert, dass der ScrollView bei wenigen Zeilen auf die
+    // maxHeight aufgeblasen wird — kurze Listen bleiben kompakt.
+    upcomingScroll: {
+      maxHeight: UPCOMING_MAX_HEIGHT,
+      flexGrow: 0,
     },
 
     row: {


### PR DESCRIPTION
## Warum

Der `Mehr anzeigen`-Zwischenschritt kostete eine Interaktion, ohne etwas zu lösen. Wer einen Dauerauftrag öffnet, will die kommenden Termine sehen und durch sie scrollen — wie in einer Kalender-App.

## Was sich ändert

Die kommenden Termine stehen jetzt **vollständig** in einem eigenen, in der Höhe begrenzten Scrollbereich. Kein Auf-/Zuklappen mehr.

Entfernt:
- `upcomingLimit`-State
- der `Mehr anzeigen`-Button der kommenden Termine samt Handler
- die Konstante `INITIAL_UPCOMING`

Neu: `UPCOMING_MAX_HEIGHT = 360` (gut vier Zeilen) — groß genug, dass die Liste als eigener Bereich erkennbar ist, klein genug, dass „Vergangene Termine", Fotos und Kommentare darunter nicht weggedrückt werden.

**`maxHeight` statt `height`** plus `flexGrow: 0`: bei wenigen Terminen bleibt der Bereich in seiner natürlichen Höhe, es erscheint gar kein Scrollbalken. Erst wenn der Inhalt 360 px überschreitet, wird gescrollt.

Die Seite darum scrollt normal weiter — `nestedScrollEnabled` gibt der inneren Liste auf Android die Geste (iOS macht das von Haus aus).

## ScrollView statt FlatList — bewusst

`FlatList` wäre der performantere Default, ist hier aber die falsche Wahl. Die Karte hängt im vertikalen `ScrollView` des `JobDetailScreen`; eine gleichachsige, scroll-enabled `VirtualizedList` darin löst in `__DEV__` zuverlässig

> VirtualizedLists should never be nested inside plain ScrollViews with the same orientation …

aus — **auch mit fester Höhe**. Die Prüfung in `VirtualizedList.js` (RN 0.81) schaut nur auf ScrollView-Context, Orientierung und `scrollEnabled`, nicht auf die Höhe. Der einzige saubere Weg zu einer FlatList wäre, den kompletten Screen auf eine `SectionList` umzubauen, was das Keyboard-/Auto-Scroll-Verhalten der Kommentare gefährdet.

Der Trade-off ist hier klein: die kommenden Termine sind durch den rollierenden Generierungs-Horizont begrenzt (~90 Tage) und liegen nach `getJobOccurrences` bereits vollständig im Speicher. Die unbegrenzt wachsende Historie bleibt im Abschnitt „Vergangene Termine" und wird weiterhin seitenweise nachgeladen.

## Unverändert

Zeilendesign, StatusBadges, Heute-Hervorhebung, Navigation in den Einzeltermin, Sortierung (nächster oben), Regel-Informationen, Header, Aktions-Menü — und „Vergangene Termine" verhält sich exakt wie bisher (eingeklappt, je 10 weitere pro Tipp).

## Geänderte Dateien

- `features/jobs/components/RuleOccurrences.tsx` (einzige Datei, +57/−34)

## Validierung

- `npx tsc --noEmit` — grün
- `npm run lint` — grün
- CI „Typecheck & Lint" — siehe Checks
- Keine Laufzeit-Prüfung am Gerät (Screen liegt hinter dem Admin-Login); insbesondere die konkrete Höhe von 360 px und das Scrollgefühl innen/außen sollten am Simulator gegengeprüft werden

## Hinweis: ersetzt #48

Dieser PR entfernt genau den Umschalter, den #48 einführt — #48 ist damit hinfällig und sollte **ungemerged geschlossen** werden. Falls #48 doch zuerst gemerged wird, braucht dieser PR eine kleine Konfliktauflösung in derselben Region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)