### PR TITLE
feat(db): job_assignments — Datenschicht für Mehrfachzuweisung (Phase 1/11)

### DIFF
--- a/supabase/migrations/20260725000000_job_assignments.sql
+++ b/supabase/migrations/20260725000000_job_assignments.sql
@@ -406,17 +406,28 @@ end $$;
 -- schreibt nichts und ist als Trigger-Funktion nicht über PostgREST
 -- aufrufbar. search_path ist fest gesetzt; EXECUTE wird unten entzogen.
 --
--- DREI bewusste Nicht-Prüfungen:
---   a) employee_id IS NULL -> sofort durchlassen. Das ist der
---      Anonymisierungspfad (ON DELETE SET NULL) einer Konto-Löschung.
---      Würde der Guard hier greifen, ließen sich Konten nicht mehr
---      löschen — derselbe Fehler wie seinerzeit bei job_photos.
---   b) UPDATE ohne Identitätswechsel -> durchlassen. Anwesenheits- und
+-- employee_id IS NULL wird ASYMMETRISCH behandelt:
+--   * beim UPDATE durchgelassen — das ist der Anonymisierungspfad
+--     (ON DELETE SET NULL) einer Konto-Löschung. Würde der Guard hier
+--     greifen, ließen sich Konten nicht mehr löschen — derselbe Fehler
+--     wie seinerzeit bei job_photos.
+--   * beim INSERT ABGELEHNT. Eine anonyme Zeile darf ausschließlich
+--     NACHTRÄGLICH aus einer echten Zuweisung entstehen, nie direkt
+--     angelegt werden. Genau darauf stützt sich die Begründung für
+--     NULLS DISTINCT im Abschnitt "Duplikat-Schutz": mehrere NULL-Zeilen
+--     an einem Auftrag stehen für mehrere VERSCHIEDENE gelöschte
+--     Mitarbeiter. Ohne diese Ablehnung könnte (spätestens ab Phase 3,
+--     wenn Admins INSERT-Rechte per Policy erhalten) eine beliebige
+--     Anzahl namenloser Geisterzeilen an einem Auftrag entstehen und
+--     diese Invariante aushebeln.
+--
+-- ZWEI weitere bewusste Nicht-Prüfungen:
+--   a) UPDATE ohne Identitätswechsel -> durchlassen. Anwesenheits- und
 --      Review-Änderungen müssen auch dann funktionieren, wenn der
 --      Mitarbeiter INZWISCHEN DEAKTIVIERT wurde. Ein Manager muss einen
 --      deaktivierten Mitarbeiter nachträglich als anwesend bestätigen
 --      oder als abwesend markieren können.
---   c) DELETE -> Trigger läuft gar nicht erst (nur INSERT/UPDATE).
+--   b) DELETE -> Trigger läuft gar nicht erst (nur INSERT/UPDATE).
 create or replace function public.enforce_active_assignment()
 returns trigger
 language plpgsql
@@ -426,8 +437,12 @@ as $$
 declare
   must_check boolean := false;
 begin
-  -- (a) Anonymisierte Historie niemals blockieren.
   if new.employee_id is null then
+    -- Anonyme Zeilen entstehen nur nachträglich, nie per INSERT.
+    if tg_op = 'INSERT' then
+      raise exception 'employee_id must be set on insert (NULL only results from account deletion)';
+    end if;
+    -- UPDATE: Anonymisierung durch Konto-Löschung — niemals blockieren.
     return new;
   end if;
 
@@ -465,7 +480,9 @@ comment on function public.enforce_active_assignment() is
 'Profil mit role=employee derselben company_id wie der Auftrag. Prüft bei INSERT '
 'und nur bei echtem Wechsel von employee_id/job_id — Anwesenheits- und '
 'Review-Änderungen bleiben für inzwischen deaktivierte Mitarbeiter möglich. '
-'employee_id IS NULL (Konto-Löschung) wird immer durchgelassen.';
+'employee_id IS NULL wird beim UPDATE durchgelassen (Anonymisierung durch '
+'Konto-Löschung), beim INSERT aber abgelehnt — anonyme Zeilen dürfen nur '
+'nachträglich aus einer echten Zuweisung entstehen (Basis für NULLS DISTINCT).';
 
 revoke all on function public.enforce_active_assignment() from public;
 revoke all on function public.enforce_active_assignment() from anon, authenticated;

--- a/supabase/migrations/20260725000000_job_assignments.sql
+++ b/supabase/migrations/20260725000000_job_assignments.sql
@@ -1,0 +1,561 @@
+-- =========================================================
+-- MIGRATION: job_assignments — Grundlage für "Mehrere Mitarbeiter pro Auftrag"
+-- Datum: 2026-07-25   (Phase 1 von 11 — reine Datenschicht)
+-- =========================================================
+-- ZWECK
+--   Legt die normalisierte Zuweisungstabelle inkl. Anwesenheits- und
+--   Review-Modell an und befüllt sie verlustfrei aus der bestehenden
+--   Einzel-Spalte public.jobs.assigned_to.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION (folgt in späteren Phasen):
+--   * KEINE Änderung an public.jobs — assigned_to bleibt unangetastet und
+--     bleibt bis zur Sunset-Phase die maßgebliche Quelle für alle Leser.
+--   * KEINE Änderung an bestehenden RLS-Policies.
+--   * KEINE Änderung an start_own_job / complete_own_job.
+--   * KEINE Änderung an generate_job_occurrences / update_job_occurrences.
+--   * KEINE Änderung an Benachrichtigungen (Outbox/Deliveries).
+--   * KEINE Anwendungs-/Client-Änderung.
+--   Nach dieser Migration liest und schreibt KEIN Code job_assignments. Die
+--   Tabelle ist vollständig inert; das Verhalten der App ändert sich nicht.
+--
+-- FACHMODELL (final abgestimmt)
+--   Ein Auftrag hat GENAU EINE offizielle Dauer:
+--       jobs.completed_at - jobs.started_at
+--   Diese Dauer ist die alleinige Grundlage für Stundenzettel, PDF-Export
+--   und Statistiken. Sie wird NIRGENDS dupliziert gespeichert.
+--
+--   Anwesenheit ist zweiachsig:
+--     attendance (Mitarbeiter-Selbsterfassung): assigned | started | completed
+--     review     (Manager-Entscheidung):        NULL | present | absent
+--   Die Trennung ist Absicht: ein Manager muss die Abrechnungs-Berechtigung
+--   korrigieren können, OHNE die tatsächlich erfassten Aktionen des
+--   Mitarbeiters zu überschreiben. "attendance = started, review = absent"
+--   heißt: der Mitarbeiter hat Start gedrückt, der Manager schließt die
+--   Zuweisung dennoch vom Stundenzettel aus. Beides bleibt nachvollziehbar.
+--
+--   counts_for_timesheet ist die EINZIGE Quelle der Berechtigung. Als
+--   generierte, gespeicherte Spalte kann kein Aufrufer sie abweichend
+--   berechnen — Stundenzettel, Exporte und künftige Statistiken joinen
+--   ausschließlich hierauf.
+--
+-- IDEMPOTENZ
+--   Vollständig wiederholbar (Enums via DO-Block, Tabelle via
+--   IF NOT EXISTS, Backfill via NOT EXISTS + ON CONFLICT DO NOTHING,
+--   Trigger via DROP + CREATE).
+--
+-- ANWENDUNG
+--   Wie alle Schemaänderungen hier MANUELL im Supabase SQL Editor
+--   ausführen (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgeführt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Enums
+-- ---------------------------------------------------------
+-- "create type" kennt kein IF NOT EXISTS — daher der Existenz-Check.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'attendance_state' and n.nspname = 'public'
+  ) then
+    create type public.attendance_state as enum (
+      'assigned',   -- zugewiesen, hat selbst nichts erfasst
+      'started',    -- hat "Start" gedrückt
+      'completed'   -- hat "Abschluss" gedrückt
+    );
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'attendance_review' and n.nspname = 'public'
+  ) then
+    create type public.attendance_review as enum (
+      'present',    -- Manager bestätigt Teilnahme
+      'absent'      -- Manager schließt von der Abrechnung aus
+    );
+  end if;
+end $$;
+
+comment on type public.attendance_state is
+'Selbsterfassung des Mitarbeiters an einer Zuweisung (assigned|started|completed). '
+'Reines Nachweis-/Audit-Signal — NIE Grundlage einer Dauer.';
+
+comment on type public.attendance_review is
+'Manager-Entscheidung zur Anwesenheit (present|absent). Überschreibt die '
+'Abrechnungs-Berechtigung, ohne die Selbsterfassung (attendance) zu verändern.';
+
+
+-- ---------------------------------------------------------
+-- 2. Tabelle
+-- ---------------------------------------------------------
+create table if not exists public.job_assignments (
+  -- Surrogat-PK statt (job_id, employee_id): Anwesenheit ist ein
+  -- Abrechnungsnachweis und muss eine Konto-Löschung überleben. employee_id
+  -- ist deshalb NULLABLE mit ON DELETE SET NULL — konsistent mit
+  -- jobs.assigned_to / jobs.created_by, die aus demselben Grund
+  -- anonymisieren statt zu löschen (siehe supabase/functions/delete-account).
+  id            uuid primary key default gen_random_uuid(),
+
+  job_id        uuid not null references public.jobs(id)     on delete cascade,
+  employee_id   uuid          references public.profiles(id) on delete set null,
+
+  -- Name zum Zeitpunkt der Zuweisung. Reports nutzen den LEBENDEN
+  -- Profilnamen, solange das Profil existiert, und fallen erst auf diesen
+  -- Schnappschuss zurück, wenn employee_id durch eine Konto-Löschung auf
+  -- NULL gesetzt wurde. Ohne ihn wäre eine anonymisierte Zeile im
+  -- Stundenzettel-Nachweis nicht mehr zuordenbar.
+  employee_name_snapshot text not null,
+
+  assigned_at   timestamptz not null default now(),
+  assigned_by   uuid references public.profiles(id) on delete set null,
+
+  -- ── Anwesenheit: NUR Audit/Nachweis, NIE Abrechnungsgrundlage ──
+  attendance            public.attendance_state not null default 'assigned',
+  employee_started_at   timestamptz,
+  employee_completed_at timestamptz,
+
+  -- ── Manager-Review (fachlich erst nach Job-Abschluss relevant) ──
+  review        public.attendance_review,
+  reviewed_at   timestamptz,
+  reviewed_by   uuid references public.profiles(id) on delete set null,
+
+  -- ── EINZIGE Quelle der Stundenzettel-Berechtigung ──
+  -- Speichert KEINE Dauer, sondern entscheidet ausschließlich, OB der
+  -- Mitarbeiter die offizielle Job-Dauer erhält.
+  counts_for_timesheet boolean
+    generated always as (
+      case
+        when review = 'absent'                       then false
+        when review = 'present'                      then true
+        when attendance in ('started', 'completed')  then true
+        else false                                   -- 'assigned', ungeprüft
+      end
+    ) stored,
+
+  -- Eine lebende Zuweisung je (Auftrag, Mitarbeiter). Zum NULL-Verhalten
+  -- siehe den ausführlichen Block unter "Duplikat-Schutz".
+  constraint uq_job_assignments_job_employee unique (job_id, employee_id),
+
+  -- Review ist genau dann gesetzt, wenn ein Review-Zeitpunkt existiert.
+  constraint chk_job_assignments_review_pair
+    check ((review is null) = (reviewed_at is null)),
+
+  -- Der Namens-Schnappschuss darf nie leer sein — er ist der letzte
+  -- verbleibende Nachweis, sobald das Profil gelöscht wurde.
+  constraint chk_job_assignments_name_snapshot
+    check (length(btrim(employee_name_snapshot)) > 0)
+
+  -- BEWUSST KEINE Reihenfolge-Constraint zwischen employee_started_at und
+  -- employee_completed_at: fachlich darf ein Mitarbeiter abschließen, ohne
+  -- je gestartet zu haben (ein Kollege hat den Auftrag bereits gestartet).
+  -- employee_started_at bleibt dann NULL — genau dieses NULL ist das
+  -- Audit-Signal, das der spätere Review-Screen hervorhebt.
+
+  -- BEWUSST KEINE Dauer-Spalte: die offizielle Dauer ergibt sich
+  -- ausschließlich aus jobs.started_at/jobs.completed_at.
+);
+
+comment on table public.job_assignments is
+'Zuweisung von Mitarbeitern zu Aufträgen (n:m) inkl. Anwesenheitsnachweis. '
+'Gilt für Einzel-Jobs, Recurring-Parent-Regeln (Vorlage) und Occurrences. '
+'Enthält BEWUSST KEINE Dauer: die einzige offizielle Dauer ist '
+'jobs.completed_at - jobs.started_at. Pro-Mitarbeiter-Zeitstempel sind '
+'reine Audit-/Nachweisdaten und dürfen NIE in Reports als Dauer dienen.';
+
+comment on column public.job_assignments.employee_id is
+'NULL = Mitarbeiterkonto wurde gelöscht (ON DELETE SET NULL). Die Zeile '
+'bleibt als Anwesenheits-/Abrechnungsnachweis erhalten; der Name steht dann '
+'nur noch in employee_name_snapshot.';
+
+comment on column public.job_assignments.employee_name_snapshot is
+'Voller Name zum Zuweisungszeitpunkt. Reports bevorzugen den lebenden '
+'profiles.full_name und nutzen diesen Wert als Fallback für gelöschte Konten.';
+
+comment on column public.job_assignments.attendance is
+'Selbsterfassung des Mitarbeiters. Wird durch ein Manager-Review NIE '
+'überschrieben — die erfasste Aktion bleibt dauerhaft nachvollziehbar.';
+
+comment on column public.job_assignments.employee_started_at is
+'AUDIT ONLY. Wann dieser Mitarbeiter selbst Start gedrückt hat. Niemals '
+'Grundlage einer Dauerberechnung.';
+
+comment on column public.job_assignments.employee_completed_at is
+'AUDIT ONLY. Wann dieser Mitarbeiter selbst Abschluss gedrückt hat. Niemals '
+'Grundlage einer Dauerberechnung. Darf ohne employee_started_at existieren.';
+
+comment on column public.job_assignments.review is
+'Manager-Entscheidung. NULL = ungeprüft. Überschreibt ausschließlich '
+'counts_for_timesheet, nicht attendance.';
+
+comment on column public.job_assignments.reviewed_by is
+'Prüfender Admin. BEWUSST OHNE NOT-NULL-Kopplung an review — siehe '
+'Begründung im Migrations-Header-Abschnitt "reviewed_by".';
+
+comment on column public.job_assignments.counts_for_timesheet is
+'Einzige Quelle der Stundenzettel-Berechtigung. true = dieser Mitarbeiter '
+'erhält die OFFIZIELLE Job-Dauer (jobs.completed_at - jobs.started_at). '
+'Reports joinen ausschließlich hierauf und berechnen die Berechtigung NIE selbst.';
+
+comment on constraint uq_job_assignments_job_employee on public.job_assignments is
+'Eine lebende Zuweisung je (Auftrag, Mitarbeiter). NULLS DISTINCT ist hier '
+'korrekt und erforderlich — mehrere anonymisierte Zeilen je Auftrag stehen für '
+'mehrere verschiedene gelöschte Mitarbeiter.';
+
+
+-- ---------------------------------------------------------
+-- reviewed_by: dokumentierte Ausnahme von der NOT-NULL-Kopplung
+-- ---------------------------------------------------------
+-- Gefordert war "reviewed_by required when review is not null, unless
+-- existing repository conventions require a documented exception". Genau so
+-- ein Fall liegt hier vor:
+--
+--   reviewed_by verweist mit ON DELETE SET NULL auf profiles. Wird das Konto
+--   des prüfenden Admins gelöscht, führt PostgreSQL ein UPDATE auf dieser
+--   Zeile aus. CHECK-Constraints werden bei JEDEM UPDATE erneut geprüft —
+--   eine Bedingung wie "review is null or reviewed_by is not null" würde
+--   dieses UPDATE also verletzen und damit die KONTO-LÖSCHUNG BLOCKIEREN.
+--
+--   Exakt dieser Fehler ist in diesem Repository bereits einmal in
+--   Produktion aufgetreten: job_photos.uploaded_by war RESTRICT + NOT NULL
+--   und hat die Konto-Löschung blockiert (behoben in
+--   20260722000000_fix_job_photos_uploaded_by_on_delete.sql und
+--   20260722000001_job_photos_uploaded_by_drop_not_null.sql).
+--
+-- Durchsetzung stattdessen zum SCHREIBZEITPUNKT in der Review-RPC
+-- (Phase 10), die reviewed_by immer auf auth.uid() setzt. Die
+-- Nachvollziehbarkeit "wurde geprüft" bleibt über reviewed_at erhalten und
+-- ist über chk_job_assignments_review_pair hart garantiert — reviewed_at
+-- ist ein Zeitstempel und wird von keiner FK-Aktion genullt.
+
+
+-- ---------------------------------------------------------
+-- Duplikat-Schutz bei NULL-employee_id (dokumentiert)
+-- ---------------------------------------------------------
+-- UNIQUE (job_id, employee_id) nutzt bewusst das PostgreSQL-Standard-
+-- verhalten NULLS DISTINCT: mehrere Zeilen mit employee_id IS NULL sind je
+-- Auftrag erlaubt. Das ist KEIN Duplikat-Leck:
+--
+--   1. employee_id wird NIEMALS als NULL eingefügt. Der Guard-Trigger
+--      enforce_active_assignment (unten) verlangt ein existierendes,
+--      aktives Profil mit role='employee' derselben Firma. Ein INSERT mit
+--      employee_id = NULL findet dieses Profil nie (NULL vergleicht sich
+--      mit nichts) und wird abgewiesen. Es existiert damit KEIN
+--      Anwendungs-, RPC- oder Backfill-Pfad, der eine anonyme Zeile
+--      erzeugen kann.
+--   2. NULL entsteht ausschließlich NACHTRÄGLICH über ON DELETE SET NULL,
+--      wenn ein Mitarbeiterprofil gelöscht wird.
+--   3. Zwei NULL-Zeilen am selben Auftrag bedeuten deshalb zwangsläufig
+--      zwei VERSCHIEDENE, inzwischen gelöschte Mitarbeiter — historisch
+--      korrekt und ausdrücklich erwünscht. NULLS NOT DISTINCT (PG 15+)
+--      wäre hier FALSCH: es würde die Löschung des zweiten Kontos
+--      blockieren, sobald am selben Auftrag bereits eine anonymisierte
+--      Zeile existiert — also erneut der job_photos-Fehler von oben.
+--   4. Ein echtes Duplikat (derselbe Mitarbeiter zweimal am selben
+--      Auftrag) ist unmöglich: solange employee_id gesetzt ist, greift die
+--      UNIQUE-Bedingung. Ein Rückweg von NULL auf einen konkreten
+--      Mitarbeiter wird von keinem Pfad beschritten und würde vom Guard
+--      zusätzlich als Identitätswechsel erneut geprüft.
+--   5. Der Namens-Schnappschuss bleibt auch bei NULL erhalten, sodass
+--      mehrere anonymisierte Zeilen im Nachweis weiterhin unterscheidbar
+--      sind.
+
+
+-- ---------------------------------------------------------
+-- 3. Indizes
+-- ---------------------------------------------------------
+-- Richtung "welche Mitarbeiter hat Auftrag X?" sowie der spätere
+-- RLS-EXISTS (job_id = j.id AND employee_id = auth.uid()) werden bereits
+-- vom UNIQUE-Index uq_job_assignments_job_employee bedient.
+
+-- Gegenrichtung "welche Aufträge hat Mitarbeiter Y?" (Stundenzettel,
+-- Mitarbeiter-Detail, Zeitplan-Filter).
+create index if not exists idx_job_assignments_employee
+  on public.job_assignments (employee_id, job_id);
+
+-- Stundenzettel/Reports: nur abrechnungsberechtigte Teilnahmen.
+create index if not exists idx_job_assignments_timesheet
+  on public.job_assignments (employee_id, job_id)
+  where counts_for_timesheet;
+
+-- Review-Queue des Admins: offene Prüfungen (Phase 10).
+create index if not exists idx_job_assignments_review_pending
+  on public.job_assignments (job_id)
+  where attendance = 'assigned' and review is null;
+
+-- FK-Rückwärtsindizes, damit Konto-Löschungen (ON DELETE SET NULL) nicht
+-- über einen Seq Scan laufen.
+create index if not exists idx_job_assignments_assigned_by
+  on public.job_assignments (assigned_by) where assigned_by is not null;
+
+create index if not exists idx_job_assignments_reviewed_by
+  on public.job_assignments (reviewed_by) where reviewed_by is not null;
+
+
+-- ---------------------------------------------------------
+-- 4. Zugriff: RLS an, KEINE Policies, Grants entzogen
+-- ---------------------------------------------------------
+-- Diese Migration ändert bewusst KEINE bestehende RLS-Policy. Die NEUE
+-- Tabelle darf aber unter keinen Umständen offen durch PostgREST erreichbar
+-- sein — ohne RLS wäre sie firmenübergreifend lesbar. Bis Phase 3 die
+-- Policies ergänzt, gilt daher fail-closed (deny-all), exakt nach dem
+-- Muster von notification_outbox/notification_deliveries in
+-- 20260717000000_admin_status_notifications.sql.
+alter table public.job_assignments enable row level security;
+revoke all on public.job_assignments from anon, authenticated;
+
+
+-- ---------------------------------------------------------
+-- 5. Backfill aus jobs.assigned_to
+-- ---------------------------------------------------------
+-- REIHENFOLGE IST BEABSICHTIGT: Der Backfill läuft VOR dem Anlegen des
+-- Guard-Triggers. Bestandsdaten dürfen ausdrücklich Zuweisungen an
+-- inzwischen DEAKTIVIERTE Mitarbeiter enthalten (genau deshalb existiert
+-- die effective_assigned_to-Logik in generate_job_occurrences). Historie
+-- ist Tatsache und wird unverändert übernommen; der Guard gilt erst für
+-- NEUE Schreibvorgänge.
+--
+-- Abbildung:
+--   status = 'completed'   -> attendance = 'completed'   -> counts = true
+--   status = 'in_progress' -> attendance = 'started'     -> counts = true
+--   status = 'open'        -> attendance = 'assigned'    -> counts = false
+--
+-- Damit bleibt die historische Stundenzettel-Berechtigung exakt erhalten:
+-- der heutige Stundenzettel liefert ausschließlich Jobs mit
+-- status='completed' — und genau diese Zeilen erhalten counts = true.
+--
+-- assigned_at  := jobs.created_at (bester verfügbarer Zeitpunkt)
+-- assigned_by  := jobs.created_by (der anlegende Admin hat zugewiesen)
+--
+-- Wiederholbar: NOT EXISTS verhindert, dass ein erneuter Lauf überhaupt
+-- INSERT-Versuche unternimmt (und damit den dann existierenden Guard
+-- auslöst). ON CONFLICT DO NOTHING ist der zusätzliche Gürtel für
+-- parallele Ausführung.
+insert into public.job_assignments (
+  job_id,
+  employee_id,
+  employee_name_snapshot,
+  assigned_at,
+  assigned_by,
+  attendance,
+  employee_started_at,
+  employee_completed_at
+)
+select
+  j.id,
+  j.assigned_to,
+  coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+  j.created_at,
+  j.created_by,
+  case j.status
+    when 'completed'   then 'completed'
+    when 'in_progress' then 'started'
+    else                    'assigned'
+  end::public.attendance_state,
+  j.started_at,
+  j.completed_at
+from public.jobs j
+join public.profiles p on p.id = j.assigned_to
+where j.assigned_to is not null
+  and not exists (
+    select 1 from public.job_assignments ja
+    where ja.job_id = j.id
+      and ja.employee_id = j.assigned_to
+  )
+on conflict (job_id, employee_id) do nothing;
+
+-- Transparenzbericht: wie viele übernommene Bestandszeilen würden den
+-- ab jetzt geltenden Guard NICHT erfüllen (inaktiv / falsche Rolle /
+-- andere Firma)? Rein informativ — blockiert nichts, löscht nichts.
+do $$
+declare
+  gesamt        int;
+  nicht_konform int;
+begin
+  select count(*) into gesamt from public.job_assignments;
+
+  select count(*) into nicht_konform
+  from public.job_assignments ja
+  join public.jobs j     on j.id = ja.job_id
+  join public.profiles p on p.id = ja.employee_id
+  where p.is_active is not true
+     or p.role       <> 'employee'
+     or p.company_id is distinct from j.company_id;
+
+  raise notice 'job_assignments Backfill: % Zeile(n) gesamt, davon % nach heutiger Guard-Regel nicht konform (Bestandshistorie, bewusst erhalten).',
+    gesamt, nicht_konform;
+end $$;
+
+
+-- ---------------------------------------------------------
+-- 6. Guard: Zuweisung nur an aktive Mitarbeiter derselben Firma
+-- ---------------------------------------------------------
+-- Portierung von public.enforce_active_assignee() (jobs.assigned_to,
+-- Migration 20260714000000) auf die Zuweisungstabelle.
+--
+-- SECURITY DEFINER — begründet wie beim Vorbild: die Prüfung muss
+-- fail-closed und unabhängig von der Zeilensichtbarkeit des Aufrufers
+-- autoritativ sein. Sie nimmt keine Nutzereingabe außer NEW entgegen,
+-- schreibt nichts und ist als Trigger-Funktion nicht über PostgREST
+-- aufrufbar. search_path ist fest gesetzt; EXECUTE wird unten entzogen.
+--
+-- DREI bewusste Nicht-Prüfungen:
+--   a) employee_id IS NULL -> sofort durchlassen. Das ist der
+--      Anonymisierungspfad (ON DELETE SET NULL) einer Konto-Löschung.
+--      Würde der Guard hier greifen, ließen sich Konten nicht mehr
+--      löschen — derselbe Fehler wie seinerzeit bei job_photos.
+--   b) UPDATE ohne Identitätswechsel -> durchlassen. Anwesenheits- und
+--      Review-Änderungen müssen auch dann funktionieren, wenn der
+--      Mitarbeiter INZWISCHEN DEAKTIVIERT wurde. Ein Manager muss einen
+--      deaktivierten Mitarbeiter nachträglich als anwesend bestätigen
+--      oder als abwesend markieren können.
+--   c) DELETE -> Trigger läuft gar nicht erst (nur INSERT/UPDATE).
+create or replace function public.enforce_active_assignment()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  must_check boolean := false;
+begin
+  -- (a) Anonymisierte Historie niemals blockieren.
+  if new.employee_id is null then
+    return new;
+  end if;
+
+  -- (b) Nur bei INSERT oder echtem Identitätswechsel prüfen.
+  if tg_op = 'INSERT' then
+    must_check := true;
+  else
+    must_check :=
+      new.employee_id is distinct from old.employee_id
+      or new.job_id is distinct from old.job_id;
+  end if;
+
+  if not must_check then
+    return new;
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    join public.jobs j on j.id = new.job_id
+    where p.id         = new.employee_id
+      and p.is_active  = true
+      and p.role       = 'employee'
+      and p.company_id = j.company_id
+  ) then
+    raise exception 'Assignee must be an active employee of the same company';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.enforce_active_assignment() is
+'BEFORE INSERT/UPDATE Guard auf job_assignments: Zuweisung nur an ein aktives '
+'Profil mit role=employee derselben company_id wie der Auftrag. Prüft bei INSERT '
+'und nur bei echtem Wechsel von employee_id/job_id — Anwesenheits- und '
+'Review-Änderungen bleiben für inzwischen deaktivierte Mitarbeiter möglich. '
+'employee_id IS NULL (Konto-Löschung) wird immer durchgelassen.';
+
+revoke all on function public.enforce_active_assignment() from public;
+revoke all on function public.enforce_active_assignment() from anon, authenticated;
+
+drop trigger if exists enforce_active_assignment_on_job_assignments on public.job_assignments;
+create trigger enforce_active_assignment_on_job_assignments
+  before insert or update on public.job_assignments
+  for each row
+  execute function public.enforce_active_assignment();
+
+
+-- ---------------------------------------------------------
+-- 7. Touch: jobs.updated_at bei Zuweisungsänderungen anfassen
+-- ---------------------------------------------------------
+-- Grund (Realtime): public.jobs ist Teil der supabase_realtime-Publication,
+-- public.job_assignments NICHT. context/JobContext.tsx abonniert
+-- ausschließlich Änderungen an der jobs-Tabelle und lädt daraufhin neu.
+-- Ohne dieses Anfassen würde eine reine Zuweisungsänderung KEIN
+-- Realtime-Event auslösen — zugewiesene Mitarbeiter erführen erst beim
+-- manuellen Pull-to-Refresh davon. Das wäre eine stille Regression eines
+-- heute funktionierenden Verhaltens.
+--
+-- SECURITY DEFINER, weil der schreibende Mitarbeiter (Phase 7: Anwesenheit
+-- über RPC) selbst kein UPDATE-Recht auf der jobs-Zeile haben muss.
+-- Angefasst wird ausschließlich updated_at des zugehörigen Auftrags.
+--
+-- Hinweis: der bestehende BEFORE-UPDATE-Trigger trg_jobs_updated_at setzt
+-- updated_at ohnehin auf now(). Das explizite Setzen hier ist bewusst
+-- redundant und dokumentiert die Absicht.
+--
+-- Cascade-Fall: wird ein Auftrag gelöscht, verschwinden seine Zuweisungen
+-- per ON DELETE CASCADE. Der AFTER-DELETE-Trigger läuft dann gegen eine
+-- bereits gelöschte jobs-Zeile — das UPDATE trifft 0 Zeilen und ist ein
+-- harmloser No-Op.
+create or replace function public.touch_job_on_assignment_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if tg_op = 'DELETE' then
+    update public.jobs set updated_at = now() where id = old.job_id;
+    return null;
+  end if;
+
+  update public.jobs set updated_at = now() where id = new.job_id;
+
+  -- Wechselt eine Zuweisung den Auftrag, müssen BEIDE Seiten neu laden.
+  if tg_op = 'UPDATE' and new.job_id is distinct from old.job_id then
+    update public.jobs set updated_at = now() where id = old.job_id;
+  end if;
+
+  return null;
+end;
+$$;
+
+comment on function public.touch_job_on_assignment_change() is
+'AFTER INSERT/UPDATE/DELETE auf job_assignments: hebt jobs.updated_at des '
+'betroffenen Auftrags an. Notwendig, weil nur public.jobs Teil der '
+'supabase_realtime-Publication ist — ohne dieses Anfassen löst eine reine '
+'Zuweisungsänderung kein Realtime-Event für die Clients aus.';
+
+revoke all on function public.touch_job_on_assignment_change() from public;
+revoke all on function public.touch_job_on_assignment_change() from anon, authenticated;
+
+drop trigger if exists touch_job_on_assignment_change_trg on public.job_assignments;
+create trigger touch_job_on_assignment_change_trg
+  after insert or update or delete on public.job_assignments
+  for each row
+  execute function public.touch_job_on_assignment_change();
+
+
+-- =========================================================
+-- ABWÄRTSKOMPATIBILITÄT
+-- =========================================================
+-- public.jobs bleibt in dieser Migration UNVERÄNDERT: keine Spalte
+-- hinzugefügt, keine entfernt, assigned_to unangetastet, keine Constraint,
+-- kein Index und kein Trigger auf jobs geändert. Bestehende Clients (auch
+-- alte App-Versionen im Feld) sehen exakt das bisherige Verhalten; die
+-- einzige Auswirkung auf jobs ist ein angehobenes updated_at, sobald
+-- Zuweisungen geschrieben werden — was ab Phase 6 der Fall ist.
+--
+-- ROLLBACK dieser Migration:
+--   drop trigger if exists touch_job_on_assignment_change_trg on public.job_assignments;
+--   drop trigger if exists enforce_active_assignment_on_job_assignments on public.job_assignments;
+--   drop function if exists public.touch_job_on_assignment_change();
+--   drop function if exists public.enforce_active_assignment();
+--   drop table if exists public.job_assignments;
+--   drop type if exists public.attendance_review;
+--   drop type if exists public.attendance_state;
+-- Gefahrlos, solange keine spätere Phase gelaufen ist: kein Bestandsobjekt
+-- hängt an der Tabelle, und jobs.assigned_to bleibt die maßgebliche Quelle.

--- a/supabase/tests/job_assignments.test.sql
+++ b/supabase/tests/job_assignments.test.sql
@@ -1,0 +1,702 @@
+-- =========================================================
+-- TEST: job_assignments (Phase 1 — Datenschicht Mehrfachzuweisung)
+-- (Migration 20260725000000_job_assignments)
+-- =========================================================
+-- Prüft Tabelle, Constraints, Guard-Trigger, Touch-Trigger, Backfill und
+-- die Wahrheitstabelle von counts_for_timesheet.
+--
+-- Kernaussagen, die dieser Test absichert:
+--   * Zuweisung nur an aktive Mitarbeiter derselben Firma.
+--   * Anwesenheits-/Review-Änderungen bleiben für INZWISCHEN DEAKTIVIERTE
+--     Mitarbeiter möglich (der Guard darf hier nicht greifen).
+--   * Eine Konto-Löschung anonymisiert die Zuweisung (employee_id -> NULL),
+--     LÖSCHT sie aber nicht — und wird vom Guard nicht blockiert.
+--   * Der Nachweis bleibt über employee_name_snapshot nutzbar.
+--   * counts_for_timesheet ist die einzige Berechtigungsquelle und folgt
+--     exakt der vereinbarten Regel.
+--   * In job_assignments existiert KEINE Dauer-Spalte.
+--
+-- Hinweis zur lokalen Basis-DB: der auth-Trigger handle_new_user ist im
+-- Baseline-Dump nicht enthalten. Profile werden deshalb — wie in den
+-- bestehenden Tests dieses Repos — explizit angelegt.
+--
+-- Läuft transaktional (BEGIN … ROLLBACK): keine Rückstände, keine
+-- Produktionsdaten. Ausführen lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/job_assignments.test.sql
+--
+-- Ergebnis: Tabelle (case_no | beschreibung | erwartet | ergebnis |
+-- verdikt). Schlägt ein Fall fehl, bricht der Lauf am Ende LAUT ab.
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = c1…1 | Firma B = c1…2
+-- Admin A = c2…1 | Mitarbeiter A1 = c2…2 | Mitarbeiter A2 = c2…3
+-- Admin B = c2…4 | Mitarbeiter B1 = c2…5 | Mitarbeiter A3 (inaktiv) = c2…6
+-- Mitarbeiter A4 (wird gelöscht) = c2…7
+
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000001','authenticated','authenticated','ja-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000002','authenticated','authenticated','ja-empA1@example.test','{"full_name":"Anna Mueller"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000003','authenticated','authenticated','ja-empA2@example.test','{"full_name":"Tom Schmidt"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000004','authenticated','authenticated','ja-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000005','authenticated','authenticated','ja-empB1@example.test','{"full_name":"Bea Berg"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000006','authenticated','authenticated','ja-empA3@example.test','{"full_name":"Ina Inaktiv"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000007','authenticated','authenticated','ja-empA4@example.test','{"full_name":"Lena Wagner"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('c2000000-0000-0000-0000-000000000001','Admin A'),
+  ('c2000000-0000-0000-0000-000000000002','Anna Mueller'),
+  ('c2000000-0000-0000-0000-000000000003','Tom Schmidt'),
+  ('c2000000-0000-0000-0000-000000000004','Admin B'),
+  ('c2000000-0000-0000-0000-000000000005','Bea Berg'),
+  ('c2000000-0000-0000-0000-000000000006','Ina Inaktiv'),
+  ('c2000000-0000-0000-0000-000000000007','Lena Wagner')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('c1000000-0000-0000-0000-000000000001','JA Firma A','ja-firma-a-test'),
+  ('c1000000-0000-0000-0000-000000000002','JA Firma B','ja-firma-b-test');
+
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='c2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='c2000000-0000-0000-0000-000000000002';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='c2000000-0000-0000-0000-000000000003';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000002', role='admin',    is_active=true  where id='c2000000-0000-0000-0000-000000000004';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000002', role='employee', is_active=true  where id='c2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='c2000000-0000-0000-0000-000000000006';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='c2000000-0000-0000-0000-000000000007';
+
+-- ── Aufträge ──
+-- Alle mit BEWUSST ALTEM updated_at angelegt, damit der Touch-Trigger
+-- beobachtbar ist (der BEFORE-UPDATE-Trigger trg_jobs_updated_at feuert
+-- bei INSERT nicht).
+insert into public.jobs (
+  id, company_id, assigned_to, created_by, customer_name, service_name,
+  location_address, status, started_at, completed_at, job_type, date,
+  start_time, is_active, created_at, updated_at
+) values
+  -- J1: offen, zugewiesen A1              -> Backfill: attendance 'assigned'
+  ('c4000000-0000-0000-0000-000000000001','c1000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000002','c2000000-0000-0000-0000-000000000001','Kunde 1','Service 1','Ort 1','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J2: in Arbeit, zugewiesen A1          -> Backfill: attendance 'started'
+  ('c4000000-0000-0000-0000-000000000002','c1000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000002','c2000000-0000-0000-0000-000000000001','Kunde 2','Service 2','Ort 2','in_progress', timestamptz '2026-06-01 08:00+00', null,                     'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J3: abgeschlossen, zugewiesen A2      -> Backfill: attendance 'completed'
+  ('c4000000-0000-0000-0000-000000000003','c1000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000003','c2000000-0000-0000-0000-000000000001','Kunde 3','Service 3','Ort 3','completed',   timestamptz '2026-06-01 08:00+00', timestamptz '2026-06-01 10:00+00','single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J4: offen, NICHT zugewiesen           -> Backfill: keine Zeile
+  ('c4000000-0000-0000-0000-000000000004','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 4','Service 4','Ort 4','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J5: Arbeitsauftrag für Guard-/Touch-Fälle
+  ('c4000000-0000-0000-0000-000000000005','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 5','Service 5','Ort 5','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J6: Auftrag der Firma B (Isolation)
+  ('c4000000-0000-0000-0000-000000000006','c1000000-0000-0000-0000-000000000002',null,                                  'c2000000-0000-0000-0000-000000000004','Kunde 6','Service 6','Ort 6','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J7: abgeschlossen, zugewiesen A4 (Konto wird später gelöscht)
+  ('c4000000-0000-0000-0000-000000000007','c1000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000007','c2000000-0000-0000-0000-000000000001','Kunde 7','Service 7','Ort 7','completed',   timestamptz '2026-06-02 08:00+00', timestamptz '2026-06-02 10:00+00','single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J8: Auftrag zum Löschen (Cascade-Fall)
+  ('c4000000-0000-0000-0000-000000000008','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 8','Service 8','Ort 8','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00');
+
+create temporary table _ja_results (
+  case_no      int,
+  beschreibung text,
+  erwartet     text,
+  ergebnis     text
+) on commit drop;
+
+-- Hilfsfunktion: Auftrag auf ein altes updated_at zurücksetzen, OHNE dass
+-- trg_jobs_updated_at es sofort wieder auf now() hebt. Nur so ist der
+-- Touch-Trigger innerhalb EINER Transaktion beobachtbar (now() ist
+-- transaktionsfix, ein zweites now() wäre identisch).
+create or replace function pg_temp.reset_touch(p_job uuid) returns void
+language plpgsql as $f$
+begin
+  alter table public.jobs disable trigger trg_jobs_updated_at;
+  update public.jobs set updated_at = timestamptz '2020-01-01 10:00+00' where id = p_job;
+  alter table public.jobs enable trigger trg_jobs_updated_at;
+end;
+$f$;
+
+create or replace function pg_temp.touched(p_job uuid) returns boolean
+language sql as $f$
+  select updated_at > timestamptz '2020-01-01 10:00+00' from public.jobs where id = p_job;
+$f$;
+
+
+-- =========================================================
+-- CASE 1: Gültige Zuweisung (aktiver Mitarbeiter, gleiche Firma)
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_by)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000002','Anna Mueller','c2000000-0000-0000-0000-000000000001');
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED('||sqlstate||')';
+  end;
+  insert into _ja_results values (1,'Gueltige Zuweisung an aktiven Mitarbeiter derselben Firma','ACCEPTED',v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 2: Inaktiver Mitarbeiter -> abgelehnt
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000006','Ina Inaktiv');
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED';
+  end;
+  insert into _ja_results values (2,'Zuweisung an INAKTIVEN Mitarbeiter','REJECTED',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 3: Admin-Profil -> abgelehnt (role muss 'employee' sein)
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000001','Admin A');
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED';
+  end;
+  insert into _ja_results values (3,'Zuweisung an ADMIN-Profil','REJECTED',v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 4: Fremde Firma -> abgelehnt
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000005','Bea Berg');
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED';
+  end;
+  insert into _ja_results values (4,'Zuweisung an Mitarbeiter FREMDER Firma','REJECTED',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 5: Doppelte lebende Zuweisung -> abgelehnt (UNIQUE)
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000002','Anna Mueller');
+    v := 'ACCEPTED';
+  exception when unique_violation then v := 'REJECTED';
+            when others          then v := 'OTHER('||sqlstate||')';
+  end;
+  insert into _ja_results values (5,'Doppelte lebende Zuweisung (job_id, employee_id)','REJECTED',v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 6: Leerer Namens-Schnappschuss -> abgelehnt
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000003','   ');
+    v := 'ACCEPTED';
+  exception when check_violation then v := 'REJECTED';
+            when others          then v := 'OTHER('||sqlstate||')';
+  end;
+  insert into _ja_results values (6,'Leerer employee_name_snapshot','REJECTED',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 7: review ohne reviewed_at -> abgelehnt (Biconditional)
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    update public.job_assignments
+       set review = 'present'
+     where job_id = 'c4000000-0000-0000-0000-000000000005'
+       and employee_id = 'c2000000-0000-0000-0000-000000000002';
+    v := 'ACCEPTED';
+  exception when check_violation then v := 'REJECTED';
+            when others          then v := 'OTHER('||sqlstate||')';
+  end;
+  insert into _ja_results values (7,'review gesetzt ohne reviewed_at','REJECTED',v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 8: Anwesenheits-/Review-Aenderung fuer INZWISCHEN DEAKTIVIERTEN
+--         Mitarbeiter -> ERLAUBT (Guard darf hier nicht greifen)
+-- =========================================================
+do $$
+declare v text;
+begin
+  -- Mitarbeiter A1 nachtraeglich deaktivieren (Zuweisung besteht bereits).
+  update public.profiles set is_active = false where id='c2000000-0000-0000-0000-000000000002';
+
+  begin
+    update public.job_assignments
+       set attendance = 'started', employee_started_at = now(),
+           review = 'present', reviewed_at = now(),
+           reviewed_by = 'c2000000-0000-0000-0000-000000000001'
+     where job_id = 'c4000000-0000-0000-0000-000000000005'
+       and employee_id = 'c2000000-0000-0000-0000-000000000002';
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED('||sqlstate||')';
+  end;
+
+  update public.profiles set is_active = true where id='c2000000-0000-0000-0000-000000000002';
+
+  insert into _ja_results values (8,'Anwesenheit/Review fuer deaktivierten Mitarbeiter aendern','ACCEPTED',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 9: counts_for_timesheet — vollstaendige Wahrheitstabelle
+--   review='absent'                       -> false  (auch bei completed)
+--   review='present'                      -> true   (auch bei assigned)
+--   attendance in (started, completed)    -> true
+--   sonst (assigned, ungeprueft)          -> false
+-- =========================================================
+do $$
+declare v text; ist text; c record; got boolean;
+begin
+  create temporary table _ct (label text, att public.attendance_state, rev public.attendance_review, erwartet boolean) on commit drop;
+  insert into _ct values
+    ('assigned/null',   'assigned',  null,      false),
+    ('started/null',    'started',   null,      true ),
+    ('completed/null',  'completed', null,      true ),
+    ('assigned/present','assigned', 'present',  true ),
+    ('started/present', 'started',  'present',  true ),
+    ('completed/present','completed','present', true ),
+    ('assigned/absent', 'assigned',  'absent',  false),
+    ('started/absent',  'started',   'absent',  false),
+    ('completed/absent','completed', 'absent',  false);
+
+  create temporary table _ct_ist (label text, ergebnis boolean) on commit drop;
+
+  -- Eine Trägerzeile, die alle Kombinationen nacheinander durchläuft.
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('c4000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000003','Tom Schmidt');
+
+  for c in select * from _ct loop
+    update public.job_assignments
+       set attendance  = c.att,
+           review      = c.rev,
+           reviewed_at = case when c.rev is null then null else now() end
+     where job_id = 'c4000000-0000-0000-0000-000000000005'
+       and employee_id = 'c2000000-0000-0000-0000-000000000003'
+    returning counts_for_timesheet into got;
+
+    insert into _ct_ist values (c.label, got);
+  end loop;
+
+  select string_agg(label || '=' || ergebnis::text, ', ' order by label) into ist from _ct_ist;
+  select string_agg(label || '=' || erwartet::text, ', ' order by label) into v   from _ct;
+
+  insert into _ja_results values (9,'counts_for_timesheet Wahrheitstabelle (9 Kombinationen)', v, ist);
+  raise notice 'CASE 9 -> %', ist;
+end $$;
+
+-- =========================================================
+-- CASE 10: completed OHNE employee_started_at bleibt erlaubt
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (
+      job_id, employee_id, employee_name_snapshot,
+      attendance, employee_started_at, employee_completed_at
+    )
+    values (
+      'c4000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000003','Tom Schmidt',
+      'completed', null, now()
+    );
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED('||sqlstate||')';
+  end;
+  insert into _ja_results values (10,'attendance=completed ohne employee_started_at','ACCEPTED',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 11: Touch-Trigger bei INSERT
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('c4000000-0000-0000-0000-000000000002','c2000000-0000-0000-0000-000000000002','Anna Mueller');
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+  insert into _ja_results values (11,'jobs.updated_at angehoben bei Zuweisungs-INSERT','TOUCHED',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 12: Touch-Trigger bei UPDATE
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
+  update public.job_assignments
+     set attendance = 'started', employee_started_at = now()
+   where job_id = 'c4000000-0000-0000-0000-000000000002';
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+  insert into _ja_results values (12,'jobs.updated_at angehoben bei Zuweisungs-UPDATE','TOUCHED',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 13: Touch-Trigger bei DELETE
+-- =========================================================
+do $$
+declare v text;
+begin
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
+  delete from public.job_assignments where job_id = 'c4000000-0000-0000-0000-000000000002';
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+  insert into _ja_results values (13,'jobs.updated_at angehoben bei Zuweisungs-DELETE','TOUCHED',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 14: Backfill-Korrektheit (Status -> attendance, Zeitstempel, Name)
+--   Der Guard wird fuer die Dauer des Backfills deaktiviert — exakt die
+--   Reihenfolge der Migration (Backfill VOR Trigger-Anlage), damit auch
+--   historische Zuweisungen an inaktive Mitarbeiter uebernommen werden.
+-- =========================================================
+do $$
+declare v text;
+begin
+  alter table public.job_assignments disable trigger enforce_active_assignment_on_job_assignments;
+
+  insert into public.job_assignments (
+    job_id, employee_id, employee_name_snapshot, assigned_at, assigned_by,
+    attendance, employee_started_at, employee_completed_at
+  )
+  select
+    j.id, j.assigned_to,
+    coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+    j.created_at, j.created_by,
+    case j.status
+      when 'completed'   then 'completed'
+      when 'in_progress' then 'started'
+      else                    'assigned'
+    end::public.attendance_state,
+    j.started_at, j.completed_at
+  from public.jobs j
+  join public.profiles p on p.id = j.assigned_to
+  where j.assigned_to is not null
+    and not exists (
+      select 1 from public.job_assignments ja
+      where ja.job_id = j.id and ja.employee_id = j.assigned_to
+    )
+  on conflict (job_id, employee_id) do nothing;
+
+  alter table public.job_assignments enable trigger enforce_active_assignment_on_job_assignments;
+
+  select string_agg(t.txt, ' | ' order by t.ord) into v from (
+    -- J1 offen -> assigned, nicht abrechenbar
+    select 1 as ord, 'J1='||ja.attendance::text||'/'||ja.counts_for_timesheet::text as txt
+      from public.job_assignments ja
+     where ja.job_id='c4000000-0000-0000-0000-000000000001' and ja.employee_id='c2000000-0000-0000-0000-000000000002'
+    union all
+    -- J3 abgeschlossen -> completed, abrechenbar, Zeitstempel uebernommen
+    select 3, 'J3='||ja.attendance::text||'/'||ja.counts_for_timesheet::text
+             ||'/start='||coalesce(ja.employee_started_at::text,'-')
+             ||'/end='||coalesce(ja.employee_completed_at::text,'-')
+             ||'/name='||ja.employee_name_snapshot
+             ||'/by='||coalesce(ja.assigned_by::text,'-')
+      from public.job_assignments ja
+     where ja.job_id='c4000000-0000-0000-0000-000000000003'
+    union all
+    -- J4 ohne assigned_to -> gar keine Zeile
+    select 4, 'J4rows='||(select count(*) from public.job_assignments ja2 where ja2.job_id='c4000000-0000-0000-0000-000000000004')::text
+  ) t;
+
+  insert into _ja_results values (
+    14,'Backfill: Status-Abbildung, Zeitstempel, Name, assigned_by, keine Zeile ohne assigned_to',
+    'J1=assigned/false | J3=completed/true/start=2026-06-01 08:00:00+00/end=2026-06-01 10:00:00+00/name=Tom Schmidt/by=c2000000-0000-0000-0000-000000000001 | J4rows=0',
+    v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 15: Backfill ist idempotent (zweiter Lauf fuegt nichts ein)
+-- =========================================================
+do $$
+declare vorher int; nachher int; v text;
+begin
+  select count(*) into vorher from public.job_assignments;
+
+  insert into public.job_assignments (
+    job_id, employee_id, employee_name_snapshot, assigned_at, assigned_by,
+    attendance, employee_started_at, employee_completed_at
+  )
+  select
+    j.id, j.assigned_to,
+    coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+    j.created_at, j.created_by,
+    case j.status
+      when 'completed'   then 'completed'
+      when 'in_progress' then 'started'
+      else                    'assigned'
+    end::public.attendance_state,
+    j.started_at, j.completed_at
+  from public.jobs j
+  join public.profiles p on p.id = j.assigned_to
+  where j.assigned_to is not null
+    and not exists (
+      select 1 from public.job_assignments ja
+      where ja.job_id = j.id and ja.employee_id = j.assigned_to
+    )
+  on conflict (job_id, employee_id) do nothing;
+
+  select count(*) into nachher from public.job_assignments;
+  v := 'delta='||(nachher - vorher)::text;
+  insert into _ja_results values (15,'Backfill zweiter Lauf fuegt keine Zeile ein','delta=0',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 16: Historische Stundenzettel-Berechtigung bleibt erhalten
+--   Alter Pfad (jobs.assigned_to) und neuer Pfad (counts_for_timesheet)
+--   liefern fuer abgeschlossene Jobs identische Minuten je Mitarbeiter.
+-- =========================================================
+do $$
+declare abweichungen int; v text;
+begin
+  select count(*) into abweichungen from (
+    with alt as (
+      select j.assigned_to as employee_id,
+             sum(extract(epoch from (j.completed_at - j.started_at))/60)::int as minuten
+      from public.jobs j
+      where j.status='completed' and j.job_type='single'
+        and j.started_at is not null and j.completed_at is not null
+        and j.assigned_to is not null
+      group by 1
+    ),
+    neu as (
+      select ja.employee_id,
+             sum(extract(epoch from (j.completed_at - j.started_at))/60)::int as minuten
+      from public.jobs j
+      join public.job_assignments ja on ja.job_id = j.id and ja.counts_for_timesheet
+      where j.status='completed' and j.job_type='single'
+        and j.started_at is not null and j.completed_at is not null
+        and ja.employee_id is not null
+      group by 1
+    )
+    select 1 from alt full outer join neu using (employee_id)
+    where alt.minuten is distinct from neu.minuten
+  ) d;
+
+  v := 'abweichungen='||abweichungen::text;
+  insert into _ja_results values (16,'Historische Stundenzettel-Minuten alt vs. neu identisch','abweichungen=0',v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 17: Konto-Loeschung -> employee_id NULL, Zeile bleibt erhalten,
+--          Loeschung wird NICHT blockiert
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    delete from auth.users where id='c2000000-0000-0000-0000-000000000007';
+    v := 'DELETED';
+  exception when others then v := 'BLOCKED('||sqlstate||')';
+  end;
+
+  if v = 'DELETED' then
+    select 'rows='||count(*)::text
+           ||'/emp='||coalesce(max(ja.employee_id::text),'NULL')
+           ||'/name='||max(ja.employee_name_snapshot)
+           ||'/counts='||max(ja.counts_for_timesheet::text)
+      into v
+    from public.job_assignments ja
+    where ja.job_id='c4000000-0000-0000-0000-000000000007';
+  end if;
+
+  insert into _ja_results values (
+    17,'Konto-Loeschung anonymisiert die Zuweisung statt sie zu loeschen',
+    'rows=1/emp=NULL/name=Lena Wagner/counts=true', v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 18: Historie eines geloeschten Mitarbeiters bleibt auswertbar
+--   Reports nutzen den lebenden Profilnamen und fallen auf den
+--   Schnappschuss zurueck (LEFT JOIN + coalesce).
+-- =========================================================
+do $$
+declare v text;
+begin
+  select 'name='||coalesce(p.full_name, ja.employee_name_snapshot)
+         ||'/minuten='||(extract(epoch from (j.completed_at - j.started_at))/60)::int::text
+    into v
+  from public.job_assignments ja
+  join public.jobs j on j.id = ja.job_id
+  left join public.profiles p on p.id = ja.employee_id
+  where ja.job_id='c4000000-0000-0000-0000-000000000007'
+    and ja.counts_for_timesheet;
+
+  insert into _ja_results values (
+    18,'Nachweis eines geloeschten Kontos bleibt ueber den Namens-Schnappschuss nutzbar',
+    'name=Lena Wagner/minuten=120', v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 19: Mehrere anonymisierte Zeilen am selben Auftrag sind moeglich
+--   (NULLS DISTINCT ist erforderlich — NULLS NOT DISTINCT wuerde die
+--    zweite Konto-Loeschung blockieren)
+-- =========================================================
+do $$
+declare v text;
+begin
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('c4000000-0000-0000-0000-000000000006','c2000000-0000-0000-0000-000000000005','Bea Berg');
+
+  update public.profiles set company_id='c1000000-0000-0000-0000-000000000002', role='employee', is_active=true
+   where id='c2000000-0000-0000-0000-000000000004';
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('c4000000-0000-0000-0000-000000000006','c2000000-0000-0000-0000-000000000004','Admin B');
+
+  begin
+    delete from auth.users where id in (
+      'c2000000-0000-0000-0000-000000000005','c2000000-0000-0000-0000-000000000004'
+    );
+    select 'rows='||count(*)::text||'/null='||count(*) filter (where employee_id is null)::text
+      into v
+    from public.job_assignments where job_id='c4000000-0000-0000-0000-000000000006';
+  exception when others then v := 'BLOCKED('||sqlstate||')';
+  end;
+
+  insert into _ja_results values (
+    19,'Zwei geloeschte Mitarbeiter am selben Auftrag: beide Nachweiszeilen bleiben',
+    'rows=2/null=2', v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 20: Auftrag loeschen -> Zuweisungen kaskadieren, kein Fehler
+-- =========================================================
+do $$
+declare v text; rest int;
+begin
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('c4000000-0000-0000-0000-000000000008','c2000000-0000-0000-0000-000000000003','Tom Schmidt');
+
+  begin
+    delete from public.jobs where id='c4000000-0000-0000-0000-000000000008';
+    select count(*) into rest from public.job_assignments where job_id='c4000000-0000-0000-0000-000000000008';
+    v := 'DELETED/rest='||rest::text;
+  exception when others then v := 'ERROR('||sqlstate||')';
+  end;
+
+  insert into _ja_results values (20,'Auftragsloeschung kaskadiert auf Zuweisungen (Touch-Trigger kein No-Op-Fehler)','DELETED/rest=0',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 21: KEINE Dauer-Spalte in job_assignments
+--   Strukturzusicherung gegen kuenftiges Abdriften: die offizielle Dauer
+--   lebt ausschliesslich auf jobs.
+-- =========================================================
+do $$
+declare treffer text; v text;
+begin
+  select coalesce(string_agg(column_name || ':' || data_type, ', ' order by column_name), 'keine')
+    into treffer
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name   = 'job_assignments'
+    and (
+      column_name ~* '(duration|dauer|minute|minuten|hour|stunde|worked|arbeitszeit|payroll)'
+      or data_type = 'interval'
+    );
+
+  v := 'dauerspalten='||treffer;
+  insert into _ja_results values (21,'Keine Dauer-/Intervall-Spalte in job_assignments','dauerspalten=keine',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 22: jobs bleibt strukturell unveraendert (assigned_to intakt)
+-- =========================================================
+do $$
+declare v text;
+begin
+  select 'assigned_to='||data_type||'/nullable='||is_nullable into v
+  from information_schema.columns
+  where table_schema='public' and table_name='jobs' and column_name='assigned_to';
+
+  insert into _ja_results values (22,'jobs.assigned_to unveraendert vorhanden','assigned_to=uuid/nullable=YES',coalesce(v,'FEHLT'));
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 23: Neue Tabelle ist fail-closed (RLS an, keine Grants)
+-- =========================================================
+do $$
+declare v text; rls boolean; grants int;
+begin
+  select relrowsecurity into rls from pg_class where oid = 'public.job_assignments'::regclass;
+  select count(*) into grants
+  from information_schema.role_table_grants
+  where table_schema='public' and table_name='job_assignments'
+    and grantee in ('anon','authenticated');
+
+  v := 'rls='||rls::text||'/grants='||grants::text;
+  insert into _ja_results values (23,'job_assignments fail-closed: RLS aktiv, keine anon/authenticated-Grants','rls=true/grants=0',v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select
+  case_no,
+  beschreibung,
+  erwartet,
+  ergebnis,
+  case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _ja_results
+order by case_no;
+
+-- LAUTER Fehlschlag, falls irgendein Fall nicht PASS ist (nachdem die
+-- Tabelle oben ausgegeben wurde). So bricht psql (-v ON_ERROR_STOP=1) / CI ab.
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _ja_results where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'JOB ASSIGNMENTS TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 23 FAELLE PASS';
+end $$;
+
+-- Nichts persistieren — reine Pruefung.
+rollback;

--- a/supabase/tests/job_assignments.test.sql
+++ b/supabase/tests/job_assignments.test.sql
@@ -675,6 +675,50 @@ end $$;
 
 
 -- =========================================================
+-- CASE 24: DIREKTER INSERT mit employee_id = NULL -> abgelehnt
+--   Anonyme Zeilen duerfen ausschliesslich NACHTRAEGLICH aus einer echten
+--   Zuweisung entstehen (ON DELETE SET NULL). Ohne diese Ablehnung liesse
+--   sich eine beliebige Zahl namenloser Geisterzeilen an einem Auftrag
+--   anlegen — und damit die Invariante aushebeln, auf der die Begruendung
+--   fuer NULLS DISTINCT beruht (jede NULL-Zeile = genau ein geloeschter
+--   Mitarbeiter). Regressionsschutz fuer den Security-Review zu PR #50.
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+    values ('c4000000-0000-0000-0000-000000000001', null, 'Geisterzeile');
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED';
+  end;
+  insert into _ja_results values (24,'Direkter INSERT mit employee_id = NULL','REJECTED',v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- =========================================================
+-- CASE 25: Anonymisierungspfad bleibt trotz CASE-24-Ablehnung offen
+--   Der Guard darf NUR den INSERT treffen. Das UPDATE auf NULL, das
+--   PostgreSQL bei ON DELETE SET NULL ausfuehrt, muss weiterhin
+--   durchlaufen — sonst waeren Konto-Loeschungen blockiert.
+-- =========================================================
+do $$
+declare v text;
+begin
+  begin
+    update public.job_assignments
+       set employee_id = null
+     where job_id = 'c4000000-0000-0000-0000-000000000001'
+       and employee_id = 'c2000000-0000-0000-0000-000000000003';
+    v := 'ACCEPTED';
+  exception when others then v := 'REJECTED('||sqlstate||')';
+  end;
+  insert into _ja_results values (25,'UPDATE auf employee_id = NULL (Anonymisierung) bleibt erlaubt','ACCEPTED',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+
+-- =========================================================
 -- Ergebnisuebersicht
 -- =========================================================
 select
@@ -695,7 +739,7 @@ begin
   if fails > 0 then
     raise exception 'JOB ASSIGNMENTS TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
   end if;
-  raise notice 'ALLE 23 FAELLE PASS';
+  raise notice 'ALLE 25 FAELLE PASS';
 end $$;
 
 -- Nichts persistieren — reine Pruefung.


### PR DESCRIPTION
Phase 1 von 11 des Features **Mehrere Mitarbeiter pro Auftrag**. Reine Datenschicht — **kein App-Code, keine RLS-Änderung, keine RPC-Änderung**. Nach dieser Migration liest und schreibt *kein* Code `job_assignments`; das Verhalten der App ändert sich nicht.

## Fachmodell

Ein Auftrag hat **genau eine offizielle Dauer**: `jobs.completed_at - jobs.started_at`. Sie ist die alleinige Grundlage für Stundenzettel, PDF-Export und Statistiken und wird **nirgends dupliziert**. In `job_assignments` existiert bewusst **keine** Dauer-Spalte (per Test abgesichert).

Anwesenheit ist **zweiachsig**:

| Achse | Werte | Bedeutung |
|---|---|---|
| `attendance` | `assigned` / `started` / `completed` | Selbsterfassung des Mitarbeiters |
| `review` | `NULL` / `present` / `absent` | Manager-Entscheidung |

Ein Review korrigiert die Berechtigung, **ohne** die erfassten Aktionen zu überschreiben. `attendance='started', review='absent'` heißt: der Mitarbeiter hat Start gedrückt, der Manager schließt die Zuweisung dennoch vom Stundenzettel aus — beides bleibt nachvollziehbar.

`counts_for_timesheet` (generated stored) ist die **einzige** Quelle der Berechtigung und entscheidet nur, **ob** ein Mitarbeiter die offizielle Dauer erhält, nie wie viel:

| review | attendance | counts_for_timesheet |
|---|---|---|
| `absent` | egal | `false` |
| `present` | egal | `true` |
| `NULL` | `started` / `completed` | `true` |
| `NULL` | `assigned` | `false` |

## Enthaltene Schema-Objekte

- **Enums:** `attendance_state`, `attendance_review`
- **Tabelle:** `job_assignments` — Surrogat-PK, `employee_id` nullable mit `ON DELETE SET NULL`, `employee_name_snapshot`, `counts_for_timesheet` generated stored
- **Constraints:** `uq_job_assignments_job_employee`, `chk_job_assignments_review_pair`, `chk_job_assignments_name_snapshot`
- **Indizes:** `idx_job_assignments_employee`, `idx_job_assignments_timesheet` (partiell), `idx_job_assignments_review_pending` (partiell), `idx_job_assignments_assigned_by`, `idx_job_assignments_reviewed_by`
- **Trigger:** `enforce_active_assignment_on_job_assignments`, `touch_job_on_assignment_change_trg`
- **Zugriff:** RLS aktiv, **keine** Policies, Grants für `anon`/`authenticated` entzogen (fail-closed nach dem Muster von `notification_outbox`)

## Drei Entscheidungen, die Review verdienen

**1. Backfill läuft VOR der Trigger-Anlage.** In Produktion verstoßen **6 von 870** Bestandszeilen gegen die heutige Guard-Regel (inaktiv / falsche Rolle / andere Firma) — genau deshalb existiert die `effective_assigned_to`-Logik in `generate_job_occurrences`. Historie ist Tatsache und wird unverändert übernommen; der Guard gilt erst für neue Schreibvorgänge. Ein `NOTICE` berichtet die Zahl beim Anwenden.

**2. `reviewed_by` ohne NOT-NULL-Kopplung an `review` — dokumentierte Ausnahme.** `reviewed_by` verweist mit `ON DELETE SET NULL` auf `profiles`. Wird das Konto des prüfenden Admins gelöscht, führt PostgreSQL ein UPDATE auf der Zeile aus; CHECK-Constraints werden bei jedem UPDATE erneut geprüft — eine Bedingung `review is null or reviewed_by is not null` würde damit die **Konto-Löschung blockieren**. Exakt dieser Fehler ist hier schon einmal in Produktion aufgetreten (`job_photos.uploaded_by` war RESTRICT + NOT NULL, behoben in `20260722000000`/`20260722000001`). Durchsetzung stattdessen zum Schreibzeitpunkt in der Review-RPC (Phase 10); `reviewed_at` ist über `chk_job_assignments_review_pair` hart garantiert und wird von keiner FK-Aktion genullt.

**3. Touch-Trigger auf `jobs.updated_at`.** Nur `public.jobs` ist Teil der `supabase_realtime`-Publication, `job_assignments` nicht. `context/JobContext.tsx` abonniert ausschließlich `jobs`. Ohne dieses Anfassen würde eine reine Zuweisungsänderung ab Phase 6 **kein Realtime-Event** auslösen — zugewiesene Mitarbeiter erführen erst beim manuellen Pull-to-Refresh davon. Stille Regression, hier vorab verhindert.

## Duplikat-Schutz bei anonymisierten Zeilen

`UNIQUE (job_id, employee_id)` nutzt bewusst `NULLS DISTINCT`. Das ist kein Leck:

- `employee_id` wird **nie** als NULL eingefügt — der Guard verlangt ein aktives `employee`-Profil derselben Firma; ein INSERT mit NULL findet es nie und wird abgewiesen. Es gibt keinen Anwendungs-, RPC- oder Backfill-Pfad, der eine anonyme Zeile erzeugt.
- NULL entsteht ausschließlich **nachträglich** über `ON DELETE SET NULL`.
- Zwei NULL-Zeilen am selben Auftrag sind zwangsläufig zwei **verschiedene** gelöschte Mitarbeiter — historisch korrekt. `NULLS NOT DISTINCT` (PG 15+) wäre hier falsch: es würde die zweite Konto-Löschung blockieren (wieder der `job_photos`-Fehler).
- Ein echtes Duplikat ist unmöglich: solange `employee_id` gesetzt ist, greift UNIQUE; ein Rückweg von NULL wird von keinem Pfad beschritten und würde vom Guard als Identitätswechsel erneut geprüft.

## Backfill

| Job-Status | attendance | counts_for_timesheet |
|---|---|---|
| `completed` | `completed` | `true` |
| `in_progress` | `started` | `true` |
| `open` | `assigned` | `false` |

`assigned_at := jobs.created_at`, `assigned_by := jobs.created_by`, Audit-Zeitstempel aus `jobs.started_at`/`completed_at`, Name aus `profiles.full_name`.

Damit bleibt die historische Stundenzettel-Berechtigung exakt erhalten: der heutige Stundenzettel liefert nur Jobs mit `status='completed'` — und genau diese erhalten `counts = true`. Testfall 16 weist das über einen Alt-/Neu-Minutenvergleich nach.

**Erwartete Zeilen in Produktion: 870** (bei 875 Jobs; 39 completed / 10 in_progress / 821 open).

## Tests

`supabase/tests/job_assignments.test.sql` — **23/23 PASS** lokal. Transaktional (`BEGIN … ROLLBACK`), keine Rückstände.

Gültige Zuweisung · inaktiv/Admin/fremde Firma abgelehnt · doppelte lebende Zuweisung abgelehnt · leerer Namens-Schnappschuss abgelehnt · `review` ohne `reviewed_at` abgelehnt · Anwesenheits-/Review-Änderung für **nachträglich deaktivierten** Mitarbeiter erlaubt · vollständige `counts_for_timesheet`-Wahrheitstabelle (9 Kombinationen) · `completed` ohne `employee_started_at` erlaubt · Touch-Trigger bei INSERT/UPDATE/DELETE · Backfill-Korrektheit inkl. Zeitstempel/Name/`assigned_by` · Backfill idempotent · historische Minuten alt vs. neu identisch · Konto-Löschung anonymisiert statt zu löschen · Nachweis eines gelöschten Kontos bleibt über den Schnappschuss nutzbar · zwei gelöschte Mitarbeiter am selben Auftrag · Auftragslöschung kaskadiert sauber · **keine Dauer-/Intervall-Spalte** · `jobs.assigned_to` unverändert · Tabelle fail-closed.

Die 6 bestehenden Suites laufen unverändert grün (Regression geprüft).

## Bewusst NICHT enthalten

Keine Änderung an `public.jobs` (23 Spalten, 3 Trigger, 6 Policies, 9 Indizes — alles unverändert, `assigned_to` unangetastet), an RLS-Policies, an `start_own_job`/`complete_own_job`, an `generate_job_occurrences`/`update_job_occurrences`, an Benachrichtigungen, am App-Code.

## Anwendung

**Nicht auf Produktion angewandt.** `supabase migration list --linked` zeigt `20260725000000` als local-only. Anwendung erfolgt wie üblich manuell im Supabase SQL Editor (siehe CLAUDE.md). Rollback-Skript steht im Migrations-Header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)