### PR TITLE
feat(db): Kompatibilitäts-Dual-Write jobs.assigned_to ⟷ job_assignments (Phase 2/11)

### DIFF
--- a/supabase/migrations/20260726000000_job_assignments_dual_write.sql
+++ b/supabase/migrations/20260726000000_job_assignments_dual_write.sql
@@ -1,0 +1,603 @@
+-- =========================================================
+-- MIGRATION: Kompatibilitäts-Dual-Write jobs.assigned_to <-> job_assignments
+-- Datum: 2026-07-26   (Phase 2 von 11 — reine Datenschicht)
+-- =========================================================
+-- ZWECK
+--   Hält die alte Einzel-Spalte public.jobs.assigned_to und die neue
+--   Tabelle public.job_assignments automatisch synchron, damit
+--     * ALTE App-Versionen im Feld (die nur assigned_to kennen) weiter
+--       korrekt lesen und schreiben können, und
+--     * ab Phase 5/6 neuer Code ausschließlich mit job_assignments
+--       arbeiten kann — beide gleichzeitig, ohne Datenverlust.
+--
+--   Diese Migration ist ein TEMPORÄRES Kompatibilitätsgerüst. Sie wird in
+--   Phase 11 (Sunset) vollständig entfernt, sobald alte Clients
+--   ausgelaufen sind und assigned_to fällt.
+--
+-- REIN ADDITIV / KEINE DATENÄNDERUNG
+--   Die Migration legt NUR Funktionen und Trigger an und ersetzt EINE
+--   bestehende Funktion (touch_job_on_assignment_change, Begründung
+--   unten). Sie enthält KEINE einzige DML-Anweisung:
+--     * kein Backfill (Phase 1 hat bereits 870 Zeilen erzeugt)
+--     * keine Zeile wird umgeschrieben
+--     * die 6 historischen Guard-Ausnahmen werden NICHT angefasst,
+--       NICHT revalidiert und NICHT gelöscht
+--     * beim Deploy entsteht KEIN Realtime-Sturm, weil nichts geschrieben
+--       wird
+--   Sie ist damit gefahrlos VOR jeder App-Änderung anwendbar.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   Keine Änderung an RLS-Policies, an start_own_job/complete_own_job, an
+--   generate_job_occurrences/update_job_occurrences, an Benachrichtigungen
+--   oder am App-Code. Zuweisungs-MENGEN werden weiterhin NICHT auf
+--   Occurrences propagiert (das ist Phase 4) — gespiegelt wird nur der
+--   einzelne Legacy-Wert, exakt wie heute.
+--
+-- =========================================================
+-- ARCHITEKTUR-BEFUND (am deployten Stand erhoben, nicht aus Annahmen)
+-- =========================================================
+-- Schreibende Zugriffe auf jobs.assigned_to — vollständige Liste:
+--   1. services/jobs/jobs.service.ts createJob()  -> INSERT jobs
+--   2. services/jobs/jobs.service.ts updateJob()  -> UPDATE jobs
+--   3. public.generate_job_occurrences()          -> INSERT jobs (Occurrences)
+--   4. public.update_job_occurrences()            -> UPDATE jobs (SYNC-Block,
+--      MENGENBASIERT über alle zukünftigen offenen Occurrences einer Regel)
+--   5. direkte Admin-SQL / Supabase Studio
+--   start_own_job/complete_own_job LESEN assigned_to nur in der
+--   WHERE-Klausel und schreiben es nie.
+--
+-- Bestehende Trigger:
+--   jobs             BEFORE INS/UPD  enforce_active_assignee_on_jobs
+--   jobs             BEFORE UPD      trg_jobs_updated_at (setzt updated_at=now())
+--   jobs             BEFORE DEL      trg_jobs_protect_recurring_history
+--   job_assignments  BEFORE INS/UPD  enforce_active_assignment_on_job_assignments
+--   job_assignments  AFTER INS/UPD/DEL touch_job_on_assignment_change_trg
+--
+-- Realtime-Publication: nur public.jobs und public.profiles.
+--   job_assignments ist NICHT enthalten — deshalb existiert der
+--   Touch-Trigger aus Phase 1 überhaupt.
+--
+-- KRITISCHER BEFUND (Grund für die Flag-Architektur unten):
+--   update_job_occurrences() aktualisiert assigned_to MENGENBASIERT über
+--   alle zukünftigen offenen Occurrences einer Regel — laut Messung in
+--   20260723000004 bis zu 624 Zeilen pro Regel-Edit. Ohne Gegenmaßnahme
+--   würde jede dieser Zeilen
+--     (a) den Legacy->Assignments-Trigger auslösen,
+--     (b) dieser den Touch-Trigger,
+--     (c) dieser ein ZWEITES UPDATE auf derselben jobs-Zeile,
+--   also die doppelte Schreiblast UND die doppelte Zahl an
+--   Realtime-Events. Genau das verhindert das Sync-Flag: während einer
+--   Legacy->Assignments-Synchronisierung wird der Touch unterdrückt, weil
+--   die jobs-Zeile in diesem Moment ohnehin gerade geschrieben wird und
+--   trg_jobs_updated_at updated_at bereits anhebt. Ergebnis: exakt EINE
+--   Zeilenversion pro Occurrence — identisch zum heutigen Verhalten.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Schleifenschutz: transaktionslokales Sync-Flag
+-- ---------------------------------------------------------
+-- Beide Richtungen schreiben in die jeweils andere Tabelle. Ohne Guard
+-- ergäbe das eine Endlosschleife.
+--
+-- Gewählt: ein transaktionslokales GUC (set_config(..., is_local => true)).
+--   * Es ist EXPLIZIT und selbstdokumentierend — man sieht im Code, welche
+--     Richtung gerade aktiv ist.
+--   * Es wird beim COMMIT/ROLLBACK automatisch verworfen; es kann nicht in
+--     eine andere Transaktion oder Session auslaufen.
+--   * Es wirkt gezielt auf genau die drei Trigger, die es abfragen — im
+--     Gegensatz zu ALTER TABLE ... DISABLE TRIGGER, das global wirkt, eine
+--     ACCESS EXCLUSIVE Sperre auf der Produktionstabelle nimmt und den
+--     Schutz auch für Fremdsessions aushebelt. DISABLE TRIGGER ist hier
+--     ausdrücklich NICHT zulässig.
+--
+-- Verworfene Alternative pg_trigger_depth(): funktioniert zwar (Tiefe > 1
+-- bedeutet "verschachtelt"), unterscheidet aber nicht, WELCHE Richtung
+-- verschachtelt ist, und würde still kaputtgehen, sobald irgendwann ein
+-- weiterer, unbeteiligter Trigger auf jobs oder job_assignments dazukommt.
+-- Zusätzlich greift überall IS DISTINCT FROM als zweite, unabhängige
+-- Abbruchbedingung — selbst bei einem Flag-Fehler kann keine Endlosschleife
+-- entstehen, weil ein Sync, der nichts ändert, keinen weiteren Trigger
+-- auslöst.
+
+create or replace function public.compat_assignment_sync_active()
+returns boolean
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  select coalesce(current_setting('app.jobs_assignment_sync', true), '') = '1';
+$$;
+
+comment on function public.compat_assignment_sync_active() is
+'TEMPORÄR (Phase 2–11). Liest das transaktionslokale Sync-Flag. true = wir '
+'befinden uns bereits innerhalb einer Kompatibilitäts-Synchronisierung; '
+'weitere Sync-Trigger müssen dann aussetzen (Schleifen- und Sturmschutz).';
+
+revoke all on function public.compat_assignment_sync_active() from public;
+revoke all on function public.compat_assignment_sync_active() from anon, authenticated;
+
+
+-- ---------------------------------------------------------
+-- 2. Primär-Zuweisungs-Regel (Assignments -> Legacy)
+-- ---------------------------------------------------------
+-- jobs.assigned_to kann nur EINEN Mitarbeiter abbilden. Solange alte
+-- Clients existieren, muss dort ein sinnvoller "primärer" Mitarbeiter
+-- stehen. Diese Funktion ist die EINZIGE Stelle, die das entscheidet.
+--
+-- DEFINITIONEN
+--   LEBEND ist eine Zuweisung, wenn ALLE gelten:
+--     * employee_id IS NOT NULL          (nicht durch Konto-Löschung anonymisiert)
+--     * das Profil existiert, is_active = true, role = 'employee'
+--     * das Profil gehört zur company_id des Auftrags
+--   SAUBER ist eine Zuweisung, wenn sie LEBEND ist UND keinerlei Spuren
+--   trägt:
+--     * attendance = 'assigned'
+--     * review IS NULL
+--     * employee_started_at IS NULL
+--     * employee_completed_at IS NULL
+--   Eine Zuweisung MIT Spuren (gestartet/abgeschlossen/geprüft) ist ein
+--   Nachweis — nie "sauber".
+--
+-- REGEL (in dieser Reihenfolge, erste Übereinstimmung gewinnt)
+--   1. Zeigt jobs.assigned_to auf einen Mitarbeiter, für den an diesem
+--      Auftrag ÜBERHAUPT eine Zuweisungszeile existiert, bleibt der Zeiger
+--      unverändert.
+--   2. Sonst: die ÄLTESTE SAUBERE LEBENDE Zuweisung, sortiert nach
+--      (assigned_at, id).
+--   3. Sonst: NULL.
+--
+-- ZUM TIEBREAKER (im Test nachgewiesen, nicht angenommen)
+--   now() ist transaktionsfix: mehrere in DERSELBEN Transaktion erzeugte
+--   Zuweisungen tragen exakt denselben assigned_at. Die Reihenfolge
+--   entscheidet dann allein die id — eine zufällige UUID. Die Auswahl ist
+--   damit ARBITRÄR, aber DETERMINISTISCH: für einen gegebenen Datenbestand
+--   liefert die Funktion immer denselben Mitarbeiter, und die Reihenfolge
+--   ändert sich nachträglich nie. Ein besserer Tiebreaker existiert im
+--   aktuellen Schema nicht (eine Sequenz-Spalte wäre eine Schemaänderung
+--   und würde die Forderung verletzen, dass diese Phase allein durch
+--   Löschen von Triggern/Funktionen rückgängig zu machen ist). Fachlich
+--   ist die Wahl unter gleichzeitig angelegten, gleichrangigen
+--   Zuweisungen ohnehin beliebig.
+--
+-- WARUM SCHRITT 1 BEWUSST "IRGENDEINE" STATT "LEBENDE" ZUWEISUNG PRÜFT
+--   Die ursprüngliche Vorgabe lautete "solange assigned_to auf eine
+--   LEBENDE Zuweisung zeigt". Das wurde bewusst zu "irgendeine Zuweisung"
+--   erweitert, weil sonst genau die 6 historischen Guard-Ausnahmen in
+--   Produktion beschädigt würden: dort zeigt assigned_to auf einen
+--   inzwischen DEAKTIVIERTEN Mitarbeiter — nach der engeren Regel wäre
+--   dieser Zeiger "nicht lebend" und würde bei der nächsten beliebigen
+--   Zuweisungsänderung still auf einen anderen Mitarbeiter oder auf NULL
+--   umgebogen. Das wäre exakt die "Reparatur", die ausdrücklich untersagt
+--   ist. Die weitere Fassung lässt bestehende Zeiger unangetastet und
+--   wählt nur dann neu, wenn gar keine Deckung mehr existiert.
+--
+-- WARUM SCHRITT 2 NUR SAUBERE ZUWEISUNGEN WÄHLT
+--   Nachweis-Zeilen (bewahrte Historie) dürfen NICHT automatisch zum
+--   primären Mitarbeiter werden. Ein Mitarbeiter, der gerade arbeitet
+--   (attendance='started'), verliert dadurch nichts: für ihn greift
+--   bereits Schritt 1, weil assigned_to zu diesem Zeitpunkt noch auf ihn
+--   zeigt. Schritt 2 wird ausschließlich für die Wahl eines NEUEN Primärs
+--   herangezogen.
+--
+-- Anonymisierte Zeilen (employee_id IS NULL) werden durch die
+-- LEBEND-Bedingung strukturell nie ausgewählt.
+create or replace function public.compat_primary_assignee(p_job_id uuid)
+returns uuid
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_current uuid;
+  v_next    uuid;
+begin
+  select j.assigned_to into v_current
+  from public.jobs j
+  where j.id = p_job_id;
+
+  -- 1) Bestehenden Zeiger behalten, solange er gedeckt ist.
+  if v_current is not null and exists (
+    select 1
+    from public.job_assignments ja
+    where ja.job_id = p_job_id
+      and ja.employee_id = v_current
+  ) then
+    return v_current;
+  end if;
+
+  -- 2) Älteste saubere, lebende Zuweisung.
+  select ja.employee_id into v_next
+  from public.job_assignments ja
+  join public.jobs     j on j.id = ja.job_id
+  join public.profiles p on p.id = ja.employee_id
+  where ja.job_id                = p_job_id
+    and ja.employee_id          is not null
+    and ja.attendance            = 'assigned'
+    and ja.review               is null
+    and ja.employee_started_at  is null
+    and ja.employee_completed_at is null
+    and p.is_active              = true
+    and p.role                   = 'employee'
+    and p.company_id             = j.company_id
+  order by ja.assigned_at, ja.id
+  limit 1;
+
+  -- 3) NULL, wenn nichts Geeignetes existiert.
+  return v_next;
+end;
+$$;
+
+comment on function public.compat_primary_assignee(uuid) is
+'TEMPORÄR (Phase 2–11). Bestimmt den primären Mitarbeiter für die '
+'Legacy-Spalte jobs.assigned_to. 1) bestehenden Zeiger behalten, solange '
+'eine Zuweisungszeile ihn deckt (schützt u. a. historische Ausnahmen), '
+'2) sonst älteste SAUBERE LEBENDE Zuweisung nach (assigned_at, id), '
+'3) sonst NULL. Nachweis-Zeilen werden nie automatisch primär.';
+
+revoke all on function public.compat_primary_assignee(uuid) from public;
+revoke all on function public.compat_primary_assignee(uuid) from anon, authenticated;
+
+
+-- ---------------------------------------------------------
+-- 3. Richtung A: jobs.assigned_to  ->  job_assignments
+-- ---------------------------------------------------------
+-- SECURITY DEFINER — begründet: die Funktion schreibt in
+-- public.job_assignments, auf die normale Clients per RLS/Grants
+-- KEINEN Zugriff haben (Phase 1: fail-closed, Policies erst in Phase 3).
+-- Ein alter Client, der legitim jobs.assigned_to setzt, muss die
+-- Spiegelzeile trotzdem erzeugen können. Die Funktion nimmt keine
+-- Nutzereingabe außer NEW entgegen, ist als Trigger nicht über PostgREST
+-- aufrufbar, hat festen search_path und entzogene EXECUTE-Rechte.
+--
+-- ZUSAMMENSPIEL MIT enforce_active_assignment():
+--   Der Guard auf job_assignments bleibt WIRKSAM — er wird hier bewusst
+--   NICHT umgangen. Das ist unkritisch, weil jobs seinen eigenen,
+--   inhaltsgleichen Guard hat (enforce_active_assignee: aktiv,
+--   role='employee', gleiche Firma) und dieser BEFORE läuft. Jeder Wert,
+--   der diesen AFTER-Trigger erreicht, hat die identische Prüfung also
+--   bereits bestanden. Ein INSERT in job_assignments kann hier folglich
+--   nicht am Guard scheitern.
+create or replace function public.compat_sync_assignments_from_legacy()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid;
+begin
+  -- Wir stecken bereits in der Gegenrichtung -> nichts tun.
+  if public.compat_assignment_sync_active() then
+    return null;
+  end if;
+
+  perform set_config('app.jobs_assignment_sync', '1', true);
+
+  begin
+    -- ── Alten Zeiger abräumen — NUR wenn spurenfrei ────────────────
+    -- Trägt die Zuweisung irgendeinen Nachweis (gestartet, abgeschlossen,
+    -- Zeitstempel oder Manager-Review), bleibt sie als Historie stehen.
+    -- Sie ist danach eine "abgekoppelte" Nachweiszeile und wird von
+    -- compat_primary_assignee nie automatisch wieder primär.
+    if tg_op = 'UPDATE'
+       and old.assigned_to is not null
+       and old.assigned_to is distinct from new.assigned_to then
+
+      delete from public.job_assignments ja
+      where ja.job_id                 = new.id
+        and ja.employee_id            = old.assigned_to
+        and ja.attendance             = 'assigned'
+        and ja.review                is null
+        and ja.employee_started_at   is null
+        and ja.employee_completed_at is null;
+    end if;
+
+    -- ── Neuen Zeiger spiegeln ──────────────────────────────────────
+    if new.assigned_to is not null then
+
+      -- Handelnde Person, sofern verlässlich bestimmbar: der
+      -- authentifizierte Aufrufer, sonst der Ersteller des Auftrags.
+      -- Der Unterabfrage-Join stellt sicher, dass nur eine real
+      -- existierende Profil-ID gesetzt wird (assigned_by hat eine FK).
+      select p.id into v_actor
+      from public.profiles p
+      where p.id = coalesce(auth.uid(), new.created_by);
+
+      insert into public.job_assignments (
+        job_id, employee_id, employee_name_snapshot,
+        assigned_at, assigned_by,
+        attendance, employee_started_at, employee_completed_at
+      )
+      select
+        new.id,
+        new.assigned_to,
+        -- Schnappschuss immer aus dem LEBENDEN Profilnamen, nie leer.
+        coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+        now(),
+        v_actor,
+        -- Anwesenheit aus dem aktuellen Job-Status ableiten, damit ein
+        -- laufender oder bereits abgeschlossener Auftrag nicht
+        -- fälschlich als "nur zugewiesen" erscheint.
+        case new.status
+          when 'completed'   then 'completed'
+          when 'in_progress' then 'started'
+          else                    'assigned'
+        end::public.attendance_state,
+        -- Audit-Zeitstempel nur übernehmen, wenn sie fachlich passen.
+        case when new.status in ('in_progress', 'completed')
+             then new.started_at end,
+        case when new.status = 'completed'
+             then new.completed_at end
+      from public.profiles p
+      where p.id = new.assigned_to
+      -- Idempotenz: existiert die Zuweisung bereits (z. B. weil derselbe
+      -- Mitarbeiter erneut geschrieben wurde), bleibt sie unverändert.
+      -- Insbesondere werden vorhandene Anwesenheits- und Review-Daten
+      -- NICHT überschrieben.
+      on conflict (job_id, employee_id) do nothing;
+    end if;
+
+    perform set_config('app.jobs_assignment_sync', '', true);
+
+  exception when others then
+    -- Flag auch im Fehlerfall zurücksetzen, damit ein von außen
+    -- abgefangener Fehler den Rest der Transaktion nicht stumm schaltet.
+    perform set_config('app.jobs_assignment_sync', '', true);
+    raise;
+  end;
+
+  return null;
+end;
+$$;
+
+comment on function public.compat_sync_assignments_from_legacy() is
+'TEMPORÄR (Phase 2–11). Spiegelt Schreibvorgänge alter Clients auf '
+'jobs.assigned_to in public.job_assignments. Legt fehlende Zuweisungen an '
+'(Anwesenheit aus dem Job-Status abgeleitet) und entfernt den vorherigen '
+'Zeiger NUR, wenn dessen Zuweisung spurenfrei ist. Nachweise (Anwesenheit, '
+'Zeitstempel, Review) werden nie gelöscht oder überschrieben.';
+
+revoke all on function public.compat_sync_assignments_from_legacy() from public;
+revoke all on function public.compat_sync_assignments_from_legacy() from anon, authenticated;
+
+-- Zwei getrennte Trigger statt einem: nur so lässt sich je Ereignis eine
+-- passende WHEN-Bedingung setzen (OLD existiert bei INSERT nicht). Die
+-- WHEN-Klausel ist der erste und billigste Filter — bei Schreibvorgängen,
+-- die assigned_to nicht verändern, läuft die Funktion gar nicht erst an.
+drop trigger if exists compat_sync_assignments_from_legacy_ins on public.jobs;
+create trigger compat_sync_assignments_from_legacy_ins
+  after insert on public.jobs
+  for each row
+  when (new.assigned_to is not null)
+  execute function public.compat_sync_assignments_from_legacy();
+
+drop trigger if exists compat_sync_assignments_from_legacy_upd on public.jobs;
+create trigger compat_sync_assignments_from_legacy_upd
+  after update of assigned_to on public.jobs
+  for each row
+  when (new.assigned_to is distinct from old.assigned_to)
+  execute function public.compat_sync_assignments_from_legacy();
+
+
+-- ---------------------------------------------------------
+-- 4. Richtung B: job_assignments  ->  jobs.assigned_to
+-- ---------------------------------------------------------
+-- SECURITY DEFINER — begründet: schreibt public.jobs. Ein Mitarbeiter, der
+-- ab Phase 7 nur seine eigene Anwesenheit ändert, hat kein UPDATE-Recht auf
+-- der jobs-Zeile; die Legacy-Spalte muss trotzdem konsistent bleiben.
+-- Angefasst wird ausschließlich assigned_to des zugehörigen Auftrags.
+create or replace function public.compat_sync_legacy_from_assignments()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_job_id  uuid;
+  v_primary uuid;
+begin
+  -- Wir stecken bereits in der Gegenrichtung -> jobs.assigned_to ist dort
+  -- die Quelle und darf nicht zurückgeschrieben werden.
+  if public.compat_assignment_sync_active() then
+    return null;
+  end if;
+
+  v_job_id := case when tg_op = 'DELETE' then old.job_id else new.job_id end;
+
+  -- UPDATE ohne Wechsel der Mitarbeiter-Identität kann den Primär nicht
+  -- verändern (Regel 1 behält den bestehenden Zeiger). Reine Anwesenheits-
+  -- oder Review-Änderungen laufen damit ohne jeden Schreibvorgang durch.
+  if tg_op = 'UPDATE' and new.employee_id is not distinct from old.employee_id then
+    return null;
+  end if;
+
+  -- Wird der Auftrag selbst gerade gelöscht (ON DELETE CASCADE), gibt es
+  -- nichts mehr zu aktualisieren. Ohne diese Prüfung liefe pro
+  -- kaskadierter Zuweisung ein UPDATE über 0 Zeilen.
+  if not exists (select 1 from public.jobs j where j.id = v_job_id) then
+    return null;
+  end if;
+
+  v_primary := public.compat_primary_assignee(v_job_id);
+
+  perform set_config('app.jobs_assignment_sync', '1', true);
+
+  begin
+    -- IS DISTINCT FROM ist hier die zweite, vom Flag unabhängige
+    -- Abbruchbedingung: ändert sich nichts, wird auch nicht geschrieben —
+    -- kein Row-Churn, kein zusätzliches Realtime-Event, kein
+    -- angehobenes updated_at.
+    update public.jobs j
+       set assigned_to = v_primary
+     where j.id = v_job_id
+       and j.assigned_to is distinct from v_primary;
+
+    perform set_config('app.jobs_assignment_sync', '', true);
+
+  exception when others then
+    perform set_config('app.jobs_assignment_sync', '', true);
+    raise;
+  end;
+
+  return null;
+end;
+$$;
+
+comment on function public.compat_sync_legacy_from_assignments() is
+'TEMPORÄR (Phase 2–11). Hält jobs.assigned_to auf dem primären Mitarbeiter '
+'gemäß compat_primary_assignee(). Schreibt nur bei echter Änderung '
+'(IS DISTINCT FROM) und setzt bei reinen Anwesenheits-/Review-Änderungen '
+'gar nicht erst an.';
+
+revoke all on function public.compat_sync_legacy_from_assignments() from public;
+revoke all on function public.compat_sync_legacy_from_assignments() from anon, authenticated;
+
+-- UPDATE OF employee_id grenzt bereits auf Katalogebene ein: Änderungen an
+-- attendance/review/Zeitstempeln — der Regelfall ab Phase 7/10 — lösen den
+-- Trigger überhaupt nicht aus.
+drop trigger if exists compat_sync_legacy_from_assignments_trg on public.job_assignments;
+create trigger compat_sync_legacy_from_assignments_trg
+  after insert or delete or update of employee_id on public.job_assignments
+  for each row
+  execute function public.compat_sync_legacy_from_assignments();
+
+
+-- ---------------------------------------------------------
+-- 5. Touch-Trigger aus Phase 1 an den Dual-Write anpassen
+-- ---------------------------------------------------------
+-- ERSETZT public.touch_job_on_assignment_change() aus Migration
+-- 20260725000000. Einzige Änderung: ein vorangestellter Flag-Check.
+--
+-- Warum das nötig ist: läuft die Synchronisierung von jobs nach
+-- job_assignments, wird die jobs-Zeile in genau diesem Moment ohnehin
+-- geschrieben; trg_jobs_updated_at hebt updated_at bereits an und das
+-- Realtime-Event ist damit schon unterwegs. Ein zusätzliches UPDATE aus
+-- dem Touch-Trigger wäre reine Verdopplung — bei einem Regel-Edit über
+-- update_job_occurrences mit bis zu 624 betroffenen Occurrences also 624
+-- überflüssige Zeilenversionen und 624 überflüssige Realtime-Events.
+--
+-- In der Gegenrichtung (direkter Schreibzugriff auf job_assignments, ab
+-- Phase 6) bleibt der Touch unverändert aktiv und notwendig, weil
+-- job_assignments nicht Teil der supabase_realtime-Publication ist.
+--
+-- BEKANNTE, BEWUSST AKZEPTIERTE RESTKOSTEN: Ändert ein direkter
+-- Zuweisungs-Schreibvorgang zugleich den primären Mitarbeiter, schreiben
+-- Richtung B (assigned_to) und der Touch (updated_at) nacheinander je
+-- einmal auf dieselbe jobs-Zeile — zwei Zeilenversionen statt einer. Das
+-- betrifft nur einzelne, nutzerausgelöste Aktionen (nie Mengenoperationen)
+-- und wird in Phase 6 zusammengeführt, wenn der Schreibpfad ohnehin neu
+-- gebaut wird.
+create or replace function public.touch_job_on_assignment_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  -- Phase 2: während einer Legacy->Assignments-Synchronisierung wird die
+  -- jobs-Zeile bereits geschrieben -> kein zweites UPDATE.
+  if public.compat_assignment_sync_active() then
+    return null;
+  end if;
+
+  if tg_op = 'DELETE' then
+    update public.jobs set updated_at = now() where id = old.job_id;
+    return null;
+  end if;
+
+  update public.jobs set updated_at = now() where id = new.job_id;
+
+  -- Wechselt eine Zuweisung den Auftrag, müssen BEIDE Seiten neu laden.
+  if tg_op = 'UPDATE' and new.job_id is distinct from old.job_id then
+    update public.jobs set updated_at = now() where id = old.job_id;
+  end if;
+
+  return null;
+end;
+$$;
+
+comment on function public.touch_job_on_assignment_change() is
+'AFTER INSERT/UPDATE/DELETE auf job_assignments: hebt jobs.updated_at des '
+'betroffenen Auftrags an. Notwendig, weil nur public.jobs Teil der '
+'supabase_realtime-Publication ist. Setzt während einer '
+'Kompatibilitäts-Synchronisierung (Phase 2) aus, weil die jobs-Zeile dann '
+'ohnehin geschrieben wird.';
+
+revoke all on function public.touch_job_on_assignment_change() from public;
+revoke all on function public.touch_job_on_assignment_change() from anon, authenticated;
+
+
+-- =========================================================
+-- WIEDERKEHRENDE AUFTRÄGE — erwartetes Verhalten und Risiken
+-- =========================================================
+-- Die Kompatibilitäts-Trigger unterscheiden NICHT zwischen den drei
+-- Zeilenarten in public.jobs. Sie feuern damit auf:
+--
+--   1. PARENT-REGELN (job_type='recurring', parent_job_id IS NULL)
+--      Setzt ein Admin assigned_to auf einer Regel, entsteht eine
+--      Zuweisungszeile AN DER REGEL. Das ist beabsichtigt und entspricht
+--      dem Zielmodell: die Regel trägt die VORLAGE der Zuweisung, die
+--      Occurrence die tatsächliche. Regeln werden nie ausgeführt, ihre
+--      Anwesenheit bleibt daher dauerhaft 'assigned'. Da eine Regel-Zeile
+--      nie status='in_progress'/'completed' annimmt, kann die
+--      Statusableitung hier nichts Falsches erzeugen.
+--
+--   2. OCCURRENCES (job_type='single', parent_job_id IS NOT NULL)
+--      generate_job_occurrences() fügt Occurrences MIT assigned_to ein ->
+--      Richtung A legt je Occurrence eine Zuweisung an. Das spiegelt
+--      exakt den Legacy-Wert, den die Funktion ohnehin schon setzt.
+--      Es wird KEINE Zuweisungs-MENGE propagiert — Mehrfachzuweisung auf
+--      Occurrences ist Phase 4.
+--
+--   3. SYNC-BLOCK von update_job_occurrences()
+--      Mengenbasiertes UPDATE von assigned_to über alle zukünftigen
+--      offenen Occurrences. Richtung A feuert je betroffener Zeile:
+--        * wechselt der Mitarbeiter, wird die alte Zuweisung entfernt,
+--          sofern spurenfrei — was auf zukünftigen, offenen, noch nicht
+--          gestarteten Occurrences per Definition zutrifft;
+--        * wird effective_assigned_to zu NULL (Mitarbeiter inzwischen
+--          deaktiviert), wird die saubere Zuweisung entfernt, die Regel-
+--          Vorlage bleibt davon unberührt.
+--      Occurrences mit Historie fasst der SYNC-Block ohnehin nicht an
+--      (status='open' AND started_at IS NULL AND completed_at IS NULL),
+--      es kann dort also gar kein Nachweis verloren gehen.
+--
+--   4. PRUNE-BLOCK von update_job_occurrences() und Regel-Löschung
+--      Gelöschte Occurrence-Zeilen nehmen ihre Zuweisungen per
+--      ON DELETE CASCADE mit. Richtung B erkennt über die
+--      Existenzprüfung, dass der Auftrag verschwunden ist, und schreibt
+--      nichts.
+--
+-- RISIKEN (bewusst offen, gehören zu Phase 4)
+--   * Zuweisungs-MENGEN werden noch nicht auf Occurrences propagiert.
+--     Weist ab Phase 6 jemand einer Regel drei Mitarbeiter zu, erhalten
+--     neue Occurrences weiterhin nur den primären Mitarbeiter aus
+--     assigned_to. Das ist erwartet und nicht schädlich — es ist exakt
+--     das heutige Verhalten.
+--   * Ein Regel-Edit erzeugt weiterhin bis zu 624 Zeilen-Updates; durch
+--     die Touch-Unterdrückung entsteht daraus KEINE zusätzliche Last
+--     gegenüber heute.
+-- =========================================================
+
+
+-- =========================================================
+-- ROLLBACK (vollständig, nicht destruktiv)
+-- =========================================================
+--   drop trigger if exists compat_sync_assignments_from_legacy_ins on public.jobs;
+--   drop trigger if exists compat_sync_assignments_from_legacy_upd on public.jobs;
+--   drop trigger if exists compat_sync_legacy_from_assignments_trg on public.job_assignments;
+--   drop function if exists public.compat_sync_assignments_from_legacy();
+--   drop function if exists public.compat_sync_legacy_from_assignments();
+--   drop function if exists public.compat_primary_assignee(uuid);
+--   drop function if exists public.compat_assignment_sync_active();
+--   -- danach touch_job_on_assignment_change() auf den Phase-1-Stand
+--   -- zurücksetzen (Migration 20260725000000, Abschnitt 7) — identischer
+--   -- Rumpf ohne den vorangestellten Flag-Check.
+--
+-- Es gehen dabei KEINE Daten verloren: die Kompatibilitätsschicht besitzt
+-- keine eigenen Daten. jobs.assigned_to und job_assignments behalten
+-- exakt den zuletzt synchronisierten Stand, und jobs.assigned_to bleibt
+-- für alte Clients weiterhin die maßgebliche Quelle.
+-- =========================================================

--- a/supabase/migrations/20260726000000_job_assignments_dual_write.sql
+++ b/supabase/migrations/20260726000000_job_assignments_dual_write.sql
@@ -182,6 +182,19 @@ revoke all on function public.compat_assignment_sync_active() from anon, authent
 --
 -- Anonymisierte Zeilen (employee_id IS NULL) werden durch die
 -- LEBEND-Bedingung strukturell nie ausgewählt.
+--
+-- WARUM STABLE UND NICHT VOLATILE (im Review geprüft, nicht angenommen)
+--   Die Funktion wird ausschließlich aus
+--   compat_sync_legacy_from_assignments() aufgerufen, und zwar NACH dem
+--   dortigen "SELECT … FOR UPDATE". Der Aufruf ist eine eigene
+--   PL/pgSQL-Anweisung innerhalb einer VOLATILE-Triggerfunktion und
+--   erhält damit in READ COMMITTED einen frischen Snapshot — also den
+--   Stand NACH dem Commit der blockierenden Transaktion. Als STABLE
+--   übernimmt diese Funktion exakt diesen frischen Snapshot ihres
+--   Aufrufers. VOLATILE ist deshalb nicht nötig; die Zwei-Sitzungs-
+--   Reproduktion aus dem Review ist mit STABLE + FOR UPDATE nachweislich
+--   nicht mehr auslösbar (auch in der Variante, in der der korrekte
+--   Primär ein anderer Mitarbeiter statt NULL ist).
 create or replace function public.compat_primary_assignee(p_job_id uuid)
 returns uuid
 language plpgsql
@@ -420,6 +433,29 @@ begin
     return null;
   end if;
 
+  -- Auftragszeile SPERREN, bevor der Primär bestimmt wird.
+  --
+  -- Ohne diese Sperre ist die Berechnung ein Read-then-Write ohne
+  -- Serialisierung: Löschen zwei Transaktionen gleichzeitig VERSCHIEDENE
+  -- Zuweisungen desselben Auftrags, liest die zweite den noch alten
+  -- assigned_to-Wert, hält ihn nach Regel 1 für gedeckt und schreibt
+  -- nichts — obwohl die erste Transaktion den Zeiger inzwischen auf einen
+  -- Mitarbeiter gesetzt hat, dessen Zuweisung die zweite gerade entfernt.
+  -- Ergebnis: jobs.assigned_to zeigt auf eine nicht mehr existierende
+  -- Zuweisung. Das ist nicht nur kosmetisch — start_own_job/
+  -- complete_own_job prüfen ausschließlich assigned_to = auth.uid().
+  -- Der Fall wurde im Review mit zwei echten Sitzungen reproduziert.
+  --
+  -- Das UPDATE weiter unten serialisiert NICHT von allein: greift Regel 1,
+  -- ist die WHERE-Bedingung "IS DISTINCT FROM" leer, das UPDATE trifft
+  -- null Zeilen und fordert nie eine Sperre an.
+  --
+  -- Gleiche Sperrdisziplin wie in update_job_occurrences (20260723000004).
+  -- In READ COMMITTED wartet die zweite Transaktion hier, liest die
+  -- Auftragszeile nach dem Commit der ersten neu (EvalPlanQual) und
+  -- berechnet den Primär auf dem dann gültigen Stand.
+  perform 1 from public.jobs where id = v_job_id for update;
+
   v_primary := public.compat_primary_assignee(v_job_id);
 
   perform set_config('app.jobs_assignment_sync', '1', true);
@@ -585,6 +621,36 @@ revoke all on function public.touch_job_on_assignment_change() from anon, authen
 -- =========================================================
 -- ROLLBACK (vollständig, nicht destruktiv)
 -- =========================================================
+-- REIHENFOLGE IST ZWINGEND: touch_job_on_assignment_change() ruft
+-- compat_assignment_sync_active() auf. Wird die Hilfsfunktion zuerst
+-- entfernt, scheitert JEDER Schreibvorgang auf job_assignments mit
+-- SQLSTATE 42883, bis der Phase-1-Rumpf wiederhergestellt ist. In diesem
+-- Repository werden Schemaänderungen manuell und Anweisung für Anweisung
+-- im Supabase SQL Editor ausgeführt (siehe CLAUDE.md) — dieses Fenster
+-- wäre also real und für laufenden Traffic sichtbar. Deshalb ZUERST den
+-- Trigger-Rumpf zurücksetzen, DANN die Kompatibilitätsobjekte abbauen.
+--
+--   -- 1) touch_job_on_assignment_change() auf den Phase-1-Stand
+--   --    zurücksetzen (Migration 20260725000000, Abschnitt 7):
+--   --    identischer Rumpf OHNE den vorangestellten Flag-Check.
+--   create or replace function public.touch_job_on_assignment_change()
+--   returns trigger language plpgsql security definer
+--   set search_path = public, pg_temp
+--   as $body$
+--   begin
+--     if tg_op = 'DELETE' then
+--       update public.jobs set updated_at = now() where id = old.job_id;
+--       return null;
+--     end if;
+--     update public.jobs set updated_at = now() where id = new.job_id;
+--     if tg_op = 'UPDATE' and new.job_id is distinct from old.job_id then
+--       update public.jobs set updated_at = now() where id = old.job_id;
+--     end if;
+--     return null;
+--   end;
+--   $body$;
+--
+--   -- 2) erst danach die Kompatibilitätsschicht abbauen:
 --   drop trigger if exists compat_sync_assignments_from_legacy_ins on public.jobs;
 --   drop trigger if exists compat_sync_assignments_from_legacy_upd on public.jobs;
 --   drop trigger if exists compat_sync_legacy_from_assignments_trg on public.job_assignments;
@@ -592,9 +658,6 @@ revoke all on function public.touch_job_on_assignment_change() from anon, authen
 --   drop function if exists public.compat_sync_legacy_from_assignments();
 --   drop function if exists public.compat_primary_assignee(uuid);
 --   drop function if exists public.compat_assignment_sync_active();
---   -- danach touch_job_on_assignment_change() auf den Phase-1-Stand
---   -- zurücksetzen (Migration 20260725000000, Abschnitt 7) — identischer
---   -- Rumpf ohne den vorangestellten Flag-Check.
 --
 -- Es gehen dabei KEINE Daten verloren: die Kompatibilitätsschicht besitzt
 -- keine eigenen Daten. jobs.assigned_to und job_assignments behalten

--- a/supabase/tests/job_assignments.test.sql
+++ b/supabase/tests/job_assignments.test.sql
@@ -96,7 +96,15 @@ insert into public.jobs (
   -- J7: abgeschlossen, zugewiesen A4 (Konto wird später gelöscht)
   ('c4000000-0000-0000-0000-000000000007','c1000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000007','c2000000-0000-0000-0000-000000000001','Kunde 7','Service 7','Ort 7','completed',   timestamptz '2026-06-02 08:00+00', timestamptz '2026-06-02 10:00+00','single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
   -- J8: Auftrag zum Löschen (Cascade-Fall)
-  ('c4000000-0000-0000-0000-000000000008','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 8','Service 8','Ort 8','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00');
+  ('c4000000-0000-0000-0000-000000000008','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 8','Service 8','Ort 8','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00'),
+  -- J9: BEWUSST OHNE assigned_to — reserviert für die Touch-Trigger-Fälle 11–13.
+  -- Ab Phase 2 (Migration 20260726000000) legt der Kompatibilitäts-Trigger
+  -- compat_sync_assignments_from_legacy beim INSERT eines Auftrags MIT
+  -- assigned_to automatisch die passende Zuweisung an. Ein Auftrag mit
+  -- Zuweisung hätte hier also bereits eine Zeile, und der manuelle INSERT
+  -- der Touch-Fälle liefe in die UNIQUE-Bedingung. Ein unzugewiesener
+  -- Auftrag hält diese Fälle unabhängig von der Kompatibilitätsschicht.
+  ('c4000000-0000-0000-0000-000000000009','c1000000-0000-0000-0000-000000000001',null,                                  'c2000000-0000-0000-0000-000000000001','Kunde 9','Service 9','Ort 9','open',   null,                          null,                          'single', current_date, '08:00', true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00');
 
 create temporary table _ja_results (
   case_no      int,
@@ -343,10 +351,10 @@ end $$;
 do $$
 declare v text;
 begin
-  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000009');
   insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
-  values ('c4000000-0000-0000-0000-000000000002','c2000000-0000-0000-0000-000000000002','Anna Mueller');
-  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+  values ('c4000000-0000-0000-0000-000000000009','c2000000-0000-0000-0000-000000000002','Anna Mueller');
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000009') then 'TOUCHED' else 'NOT_TOUCHED' end;
   insert into _ja_results values (11,'jobs.updated_at angehoben bei Zuweisungs-INSERT','TOUCHED',v);
   raise notice 'CASE 11 -> %', v;
 end $$;
@@ -357,11 +365,11 @@ end $$;
 do $$
 declare v text;
 begin
-  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000009');
   update public.job_assignments
      set attendance = 'started', employee_started_at = now()
-   where job_id = 'c4000000-0000-0000-0000-000000000002';
-  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+   where job_id = 'c4000000-0000-0000-0000-000000000009';
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000009') then 'TOUCHED' else 'NOT_TOUCHED' end;
   insert into _ja_results values (12,'jobs.updated_at angehoben bei Zuweisungs-UPDATE','TOUCHED',v);
   raise notice 'CASE 12 -> %', v;
 end $$;
@@ -372,9 +380,9 @@ end $$;
 do $$
 declare v text;
 begin
-  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000002');
-  delete from public.job_assignments where job_id = 'c4000000-0000-0000-0000-000000000002';
-  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000002') then 'TOUCHED' else 'NOT_TOUCHED' end;
+  perform pg_temp.reset_touch('c4000000-0000-0000-0000-000000000009');
+  delete from public.job_assignments where job_id = 'c4000000-0000-0000-0000-000000000009';
+  v := case when pg_temp.touched('c4000000-0000-0000-0000-000000000009') then 'TOUCHED' else 'NOT_TOUCHED' end;
   insert into _ja_results values (13,'jobs.updated_at angehoben bei Zuweisungs-DELETE','TOUCHED',v);
   raise notice 'CASE 13 -> %', v;
 end $$;

--- a/supabase/tests/job_assignments_dual_write.test.sql
+++ b/supabase/tests/job_assignments_dual_write.test.sql
@@ -1,0 +1,583 @@
+-- =========================================================
+-- TEST: Kompatibilitäts-Dual-Write jobs.assigned_to <-> job_assignments
+-- (Migration 20260726000000_job_assignments_dual_write)
+-- =========================================================
+-- Prüft beide Synchronisierungsrichtungen, die Primär-Regel, den
+-- Schleifen- und Sturmschutz, die Bewahrung von Nachweisen sowie das
+-- Verhalten auf wiederkehrenden Aufträgen.
+--
+-- Läuft transaktional (BEGIN … ROLLBACK): keine Rückstände, keine
+-- Produktionsdaten. Ausführen lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/job_assignments_dual_write.test.sql
+--
+-- Ergebnis: Tabelle (case_no | beschreibung | erwartet | ergebnis |
+-- verdikt). Schlägt ein Fall fehl, bricht der Lauf am Ende LAUT ab.
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = e1…1 | Firma B = e1…2
+-- Admin A = e2…1 | A1 = e2…2 | A2 = e2…3 | A3 = e2…4 | inaktiv = e2…5
+-- B1 (Firma B) = e2…6 | löschbar = e2…7
+
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000001','authenticated','authenticated','dw-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000002','authenticated','authenticated','dw-a1@example.test','{"full_name":"Anna Eins"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000003','authenticated','authenticated','dw-a2@example.test','{"full_name":"Bert Zwei"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000004','authenticated','authenticated','dw-a3@example.test','{"full_name":"Cora Drei"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000005','authenticated','authenticated','dw-inaktiv@example.test','{"full_name":"Ida Inaktiv"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000006','authenticated','authenticated','dw-b1@example.test','{"full_name":"Bea Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000007','authenticated','authenticated','dw-del@example.test','{"full_name":"Lars Loeschbar"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('e2000000-0000-0000-0000-000000000001','Admin A'),
+  ('e2000000-0000-0000-0000-000000000002','Anna Eins'),
+  ('e2000000-0000-0000-0000-000000000003','Bert Zwei'),
+  ('e2000000-0000-0000-0000-000000000004','Cora Drei'),
+  ('e2000000-0000-0000-0000-000000000005','Ida Inaktiv'),
+  ('e2000000-0000-0000-0000-000000000006','Bea Fremd'),
+  ('e2000000-0000-0000-0000-000000000007','Lars Loeschbar')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('e1000000-0000-0000-0000-000000000001','DW Firma A','dw-firma-a-test'),
+  ('e1000000-0000-0000-0000-000000000002','DW Firma B','dw-firma-b-test');
+
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='e2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000002';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000003';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000004';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='e2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000006';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000007';
+
+create temporary table _dw (
+  case_no int, beschreibung text, erwartet text, ergebnis text
+) on commit drop;
+
+-- Legt einen frischen Auftrag mit altem updated_at an (INSERT feuert
+-- trg_jobs_updated_at nicht -> Touch/Änderungen bleiben beobachtbar).
+create or replace function pg_temp.mk_job(
+  p_id uuid, p_assigned uuid default null, p_status public.job_status default 'open',
+  p_started timestamptz default null, p_completed timestamptz default null,
+  p_company uuid default 'e1000000-0000-0000-0000-000000000001',
+  p_type public.job_type default 'single', p_parent uuid default null
+) returns void language plpgsql as $f$
+begin
+  insert into public.jobs (
+    id, company_id, assigned_to, created_by, customer_name, service_name,
+    location_address, status, started_at, completed_at, job_type, date,
+    start_time, recurring_days, is_active, created_at, updated_at, parent_job_id
+  ) values (
+    p_id, p_company, p_assigned, 'e2000000-0000-0000-0000-000000000001',
+    'Kunde','Service','Ort', p_status, p_started, p_completed, p_type,
+    case when p_type='single' then current_date else null end, '08:00',
+    case when p_type='recurring' then array['mon'] else null end,
+    true, timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00', p_parent
+  );
+end;
+$f$;
+
+create or replace function pg_temp.legacy(p_job uuid) returns text
+language sql as $f$ select coalesce((select assigned_to::text from public.jobs where id=p_job),'NULL'); $f$;
+
+-- Sortiert bewusst nach employee_id und NICHT nach (assigned_at, id):
+-- now() ist transaktionsfix, alle in einer Transaktion erzeugten Zeilen
+-- teilen sich daher denselben assigned_at, und der id-Tiebreaker waere
+-- eine zufaellige UUID -> nicht reproduzierbare Testausgabe.
+create or replace function pg_temp.zuw(p_job uuid) returns text
+language sql as $f$
+  select coalesce(string_agg(
+           coalesce(ja.employee_id::text,'ANON')||':'||ja.attendance::text||
+           case when ja.review is null then '' else '/'||ja.review::text end,
+           ',' order by ja.employee_id nulls last), 'KEINE')
+  from public.job_assignments ja where ja.job_id = p_job;
+$f$;
+
+-- Zaehlt Tupel-Updates auf public.jobs INNERHALB der laufenden
+-- Transaktion. Das ist die einzige verlaessliche Messung fuer
+-- "hat ein Trigger ein Folge-Update ausgeloest?" — xmin/xmax taugen dafuer
+-- nicht, weil alle Zeilenversionen derselben Transaktion dieselbe xmin
+-- tragen.
+create or replace function pg_temp.jobs_updates() returns bigint
+language sql as $f$
+  select coalesce((select n_tup_upd from pg_stat_xact_user_tables
+                   where schemaname='public' and relname='jobs'), 0);
+$f$;
+
+create or replace function pg_temp.updated(p_job uuid) returns timestamptz
+language sql as $f$ select updated_at from public.jobs where id=p_job; $f$;
+
+
+-- =========================================================
+-- A. Richtung Legacy -> job_assignments
+-- =========================================================
+
+-- CASE 1: NULL -> Mitarbeiter legt Zuweisung an
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000001');
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000001';
+  select 'zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000001')
+         ||'/snapshot='||coalesce((select employee_name_snapshot from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000001'),'-')
+         ||'/by='||coalesce((select assigned_by::text from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000001'),'-')
+    into v;
+  insert into _dw values (1,'NULL -> Mitarbeiter legt Zuweisung an',
+    'zuw=e2000000-0000-0000-0000-000000000002:assigned/snapshot=Anna Eins/by=e2000000-0000-0000-0000-000000000001', v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: derselbe Mitarbeiter zweimal geschrieben -> idempotent
+do $$
+declare v text; n int;
+begin
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000001';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000001';
+  select count(*) into n from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000001';
+  v := 'zeilen='||n::text;
+  insert into _dw values (2,'Derselbe Mitarbeiter mehrfach geschrieben bleibt idempotent','zeilen=1',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3+4: A -> B legt B an und entfernt das SAUBERE A
+do $$
+declare v text;
+begin
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000001';
+  v := pg_temp.zuw('e4000000-0000-0000-0000-000000000001');
+  insert into _dw values (3,'A -> B legt Zuweisung fuer B an','e2000000-0000-0000-0000-000000000003:assigned',v);
+  insert into _dw values (4,'Saubere Zuweisung von A wird nach Umzuweisung entfernt','e2000000-0000-0000-0000-000000000003:assigned',v);
+  raise notice 'CASE 3+4 -> %', v;
+end $$;
+
+-- CASE 5: A mit attendance='started' bleibt nach Umzuweisung erhalten
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000002');
+  update public.job_assignments set attendance='started', employee_started_at=now()
+   where job_id='e4000000-0000-0000-0000-000000000002';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000002';
+  v := pg_temp.zuw('e4000000-0000-0000-0000-000000000002');
+  insert into _dw values (5,'A mit attendance=started bleibt nach Umzuweisung erhalten',
+    'e2000000-0000-0000-0000-000000000002:started,e2000000-0000-0000-0000-000000000003:assigned', v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- CASE 6: A mit attendance='completed' bleibt erhalten
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000002');
+  update public.job_assignments set attendance='completed', employee_started_at=now(), employee_completed_at=now()
+   where job_id='e4000000-0000-0000-0000-000000000003';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000003';
+  v := pg_temp.zuw('e4000000-0000-0000-0000-000000000003');
+  insert into _dw values (6,'A mit attendance=completed bleibt erhalten',
+    'e2000000-0000-0000-0000-000000000002:completed,e2000000-0000-0000-0000-000000000003:assigned', v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: A mit review='present' bleibt erhalten (Anwesenheit unveraendert)
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000004','e2000000-0000-0000-0000-000000000002');
+  update public.job_assignments set review='present', reviewed_at=now(), reviewed_by='e2000000-0000-0000-0000-000000000001'
+   where job_id='e4000000-0000-0000-0000-000000000004';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000004';
+  v := pg_temp.zuw('e4000000-0000-0000-0000-000000000004');
+  insert into _dw values (7,'A mit review=present bleibt erhalten',
+    'e2000000-0000-0000-0000-000000000002:assigned/present,e2000000-0000-0000-0000-000000000003:assigned', v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+-- CASE 8: A mit review='absent' bleibt erhalten
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000005','e2000000-0000-0000-0000-000000000002');
+  update public.job_assignments set review='absent', reviewed_at=now(), reviewed_by='e2000000-0000-0000-0000-000000000001'
+   where job_id='e4000000-0000-0000-0000-000000000005';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000005';
+  v := pg_temp.zuw('e4000000-0000-0000-0000-000000000005');
+  insert into _dw values (8,'A mit review=absent bleibt erhalten',
+    'e2000000-0000-0000-0000-000000000002:assigned/absent,e2000000-0000-0000-0000-000000000003:assigned', v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- CASE 9: Mitarbeiter -> NULL entfernt NUR die saubere Zuweisung
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000006','e2000000-0000-0000-0000-000000000002');
+  update public.jobs set assigned_to=null where id='e4000000-0000-0000-0000-000000000006';
+  v := 'zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000006')||'/legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000006');
+  insert into _dw values (9,'Mitarbeiter -> NULL entfernt saubere Zuweisung','zuw=KEINE/legacy=NULL',v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- CASE 10: Mitarbeiter -> NULL bewahrt Nachweis-Zuweisung
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000007','e2000000-0000-0000-0000-000000000002');
+  update public.job_assignments set attendance='started', employee_started_at=now()
+   where job_id='e4000000-0000-0000-0000-000000000007';
+  update public.jobs set assigned_to=null where id='e4000000-0000-0000-0000-000000000007';
+  v := 'zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000007')||'/legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000007');
+  insert into _dw values (10,'Mitarbeiter -> NULL bewahrt Nachweis-Zuweisung',
+    'zuw=e2000000-0000-0000-0000-000000000002:started/legacy=NULL',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- B. Richtung job_assignments -> Legacy (Primaer-Regel)
+-- =========================================================
+
+-- CASE 11: Zuweisungs-INSERT fuellt leeres assigned_to
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000010');
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_at)
+  values ('e4000000-0000-0000-0000-000000000010','e2000000-0000-0000-0000-000000000002','Anna Eins', now() - interval '3 min');
+  v := pg_temp.legacy('e4000000-0000-0000-0000-000000000010');
+  insert into _dw values (11,'Zuweisungs-INSERT fuellt leeres jobs.assigned_to','e2000000-0000-0000-0000-000000000002',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: zweite Zuweisung ersetzt einen gueltigen Primaer NICHT
+do $$
+declare v text;
+begin
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_at)
+  values ('e4000000-0000-0000-0000-000000000010','e2000000-0000-0000-0000-000000000003','Bert Zwei', now() - interval '2 min');
+  v := pg_temp.legacy('e4000000-0000-0000-0000-000000000010');
+  insert into _dw values (12,'Zweite Zuweisung ersetzt gueltigen Primaer nicht','e2000000-0000-0000-0000-000000000002',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- CASE 13: Entfernen des Primaers waehlt die naechste geeignete Zuweisung
+do $$
+declare v text;
+begin
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_at)
+  values ('e4000000-0000-0000-0000-000000000010','e2000000-0000-0000-0000-000000000004','Cora Drei', now() - interval '1 min');
+  delete from public.job_assignments
+   where job_id='e4000000-0000-0000-0000-000000000010' and employee_id='e2000000-0000-0000-0000-000000000002';
+  v := pg_temp.legacy('e4000000-0000-0000-0000-000000000010');
+  insert into _dw values (13,'Entfernen des Primaers waehlt aeltesten verbleibenden (assigned_at, id)',
+    'e2000000-0000-0000-0000-000000000003',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+-- CASE 14: Entfernen der LETZTEN lebenden Zuweisung setzt assigned_to auf NULL
+do $$
+declare v text;
+begin
+  delete from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000010';
+  v := pg_temp.legacy('e4000000-0000-0000-0000-000000000010');
+  insert into _dw values (14,'Entfernen der letzten Zuweisung setzt assigned_to auf NULL','NULL',v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: anonyme (employee_id IS NULL) Zeilen werden nie primaer
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000011');
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('e4000000-0000-0000-0000-000000000011','e2000000-0000-0000-0000-000000000007','Lars Loeschbar');
+  -- anonymisieren ueber den echten FK-Pfad
+  delete from auth.users where id='e2000000-0000-0000-0000-000000000007';
+  v := 'legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000011')
+       ||'/zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000011')
+       ||'/snapshot='||coalesce((select employee_name_snapshot from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000011'),'-');
+  insert into _dw values (15,'Anonyme Zeile wird nie primaer; Snapshot bleibt erhalten',
+    'legacy=NULL/zuw=ANON:assigned/snapshot=Lars Loeschbar',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: Konto-Loeschung waehlt einen anderen Primaer, wenn vorhanden
+do $$
+declare v text;
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000008','authenticated','authenticated','dw-del2@example.test','{"full_name":"Mia Weg"}');
+  insert into public.profiles (id, full_name) values ('e2000000-0000-0000-0000-000000000008','Mia Weg') on conflict (id) do nothing;
+  update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true
+   where id='e2000000-0000-0000-0000-000000000008';
+
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000012');
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_at)
+  values ('e4000000-0000-0000-0000-000000000012','e2000000-0000-0000-0000-000000000008','Mia Weg', now() - interval '5 min');
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, assigned_at)
+  values ('e4000000-0000-0000-0000-000000000012','e2000000-0000-0000-0000-000000000003','Bert Zwei', now() - interval '1 min');
+
+  delete from auth.users where id='e2000000-0000-0000-0000-000000000008';
+
+  v := 'legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000012')
+       ||'/snapshot_bleibt='||(select count(*) from public.job_assignments
+            where job_id='e4000000-0000-0000-0000-000000000012' and employee_name_snapshot='Mia Weg')::text;
+  insert into _dw values (16,'Konto-Loeschung: Snapshot bleibt, anderer Primaer wird gewaehlt',
+    'legacy=e2000000-0000-0000-0000-000000000003/snapshot_bleibt=1',v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- C. Schleifen-, Sturm- und Konsistenzschutz
+-- =========================================================
+
+-- CASE 17: keine Trigger-Rekursion (Flag ist nach dem Schreiben sauber)
+do $$
+declare v text; flag text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000020');
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000020';
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000020';
+  update public.jobs set assigned_to=null where id='e4000000-0000-0000-0000-000000000020';
+  flag := coalesce(current_setting('app.jobs_assignment_sync', true),'');
+  -- Nach Abschluss aller Sync-Vorgaenge muss das Flag wieder leer sein,
+  -- sonst waeren nachfolgende Trigger in derselben Transaktion stumm.
+  v := 'zuw=' || pg_temp.zuw('e4000000-0000-0000-0000-000000000020')
+       || '/legacy=' || pg_temp.legacy('e4000000-0000-0000-0000-000000000020')
+       || '/flag=[' || flag || ']';
+  insert into _dw values (17,'Keine Rekursion; Sync-Flag nach Abschluss zurueckgesetzt',
+    'zuw=KEINE/legacy=NULL/flag=[]', v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: keine doppelten Zuweisungszeilen ueber alle Testauftraege
+do $$
+declare v text;
+begin
+  select 'duplikate='||count(*)::text into v from (
+    select job_id, employee_id from public.job_assignments
+    where employee_id is not null group by 1,2 having count(*)>1
+  ) d;
+  insert into _dw values (18,'Keine doppelten (job_id, employee_id)-Zuweisungen','duplikate=0',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: jobs.updated_at aendert sich NUR bei echter Kompatibilitaets-Aenderung
+do $$
+declare v text; t0 timestamptz; t1 timestamptz; t2 timestamptz;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000021');
+  t0 := pg_temp.updated('e4000000-0000-0000-0000-000000000021');
+
+  -- (a) echte Zuweisungsaenderung -> updated_at MUSS steigen
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('e4000000-0000-0000-0000-000000000021','e2000000-0000-0000-0000-000000000002','Anna Eins');
+  t1 := pg_temp.updated('e4000000-0000-0000-0000-000000000021');
+
+  -- (b) reine Anwesenheitsaenderung: Richtung B feuert nicht (UPDATE OF
+  --     employee_id), der Touch schon -> updated_at darf steigen, aber es
+  --     darf KEIN assigned_to-Schreibvorgang stattfinden.
+  update public.job_assignments set attendance='started', employee_started_at=now()
+   where job_id='e4000000-0000-0000-0000-000000000021';
+  t2 := pg_temp.updated('e4000000-0000-0000-0000-000000000021');
+
+  v := 'a_gestiegen='||(t1 > t0)::text||'/legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000021')
+       ||'/b_kein_rueckschritt='||(t2 >= t1)::text;
+  insert into _dw values (19,'updated_at steigt bei echter Aenderung; Primaer bleibt bei Anwesenheitsaenderung stabil',
+    'a_gestiegen=true/legacy=e2000000-0000-0000-0000-000000000002/b_kein_rueckschritt=true', v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- CASE 20: identische Wiederholung erzeugt KEINE weiteren Schreibvorgaenge
+--   xmin der jobs-Zeile aendert sich nur bei echtem Row-Update.
+do $$
+declare v text; id0 text; id1 text; n0 int; n1 int; u0 bigint; u1 bigint;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000022','e2000000-0000-0000-0000-000000000002');
+  select count(*), min(id::text) into n0, id0 from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000022';
+  u0 := pg_temp.jobs_updates();
+
+  -- Identischer Wert erneut geschrieben: die WHEN-Klausel unterdrueckt den
+  -- Trigger vollstaendig, die Funktion laeuft gar nicht erst an.
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000022';
+
+  u1 := pg_temp.jobs_updates();
+  select count(*), min(id::text) into n1, id1 from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000022';
+
+  -- Genau EIN Tupel-Update (das eigene) und dieselbe, unveraenderte
+  -- Zuweisungszeile -> kein Delete+Insert, kein Trigger-Folgeupdate.
+  v := 'zuweisungen='||n0::text||'->'||n1::text
+       ||'/zeile_identisch='||(id0 = id1)::text
+       ||'/jobs_updates='||(u1 - u0)::text;
+  insert into _dw values (20,'Identische Wiederholung: keine zusaetzliche Zuweisung, genau ein Tupel-Update',
+    'zuweisungen=1->1/zeile_identisch=true/jobs_updates=1', v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- D. Bestandsdaten und historische Ausnahmen
+-- =========================================================
+
+-- CASE 21: produktionsaehnlicher Bestand bleibt stabil
+--   30 Zeilen im Verhaeltnis der Produktion (completed/started/assigned),
+--   danach eine unbeteiligte Schreiboperation auf einem anderen Auftrag.
+do $$
+declare v text; i int; n_vor int; n_nach int; c_vor int; c_nach int;
+begin
+  for i in 1..30 loop
+    perform pg_temp.mk_job(
+      ('e5000000-0000-0000-0000-'||lpad(i::text,12,'0'))::uuid,
+      'e2000000-0000-0000-0000-000000000002',
+      case when i <= 3 then 'completed'::public.job_status
+           when i <= 6 then 'in_progress'::public.job_status
+           else 'open'::public.job_status end,
+      case when i <= 6 then timestamptz '2026-06-01 08:00+00' end,
+      case when i <= 3 then timestamptz '2026-06-01 10:00+00' end
+    );
+  end loop;
+
+  select count(*), count(*) filter (where counts_for_timesheet)
+    into n_vor, c_vor
+  from public.job_assignments where job_id::text like 'e5000000%';
+
+  -- unbeteiligte Operation
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000030','e2000000-0000-0000-0000-000000000003');
+  update public.jobs set assigned_to=null where id='e4000000-0000-0000-0000-000000000030';
+
+  select count(*), count(*) filter (where counts_for_timesheet)
+    into n_nach, c_nach
+  from public.job_assignments where job_id::text like 'e5000000%';
+
+  v := 'zeilen='||n_vor::text||'->'||n_nach::text||'/counts='||c_vor::text||'->'||c_nach::text;
+  insert into _dw values (21,'Produktionsaehnlicher Bestand (30 Zeilen) bleibt durch unbeteiligte Schreibvorgaenge stabil',
+    'zeilen=30->30/counts=6->6', v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- CASE 22: historische Guard-Ausnahme wird nicht geloescht/revalidiert
+--   Nachbildung der Produktion: Zuweisung an einen INAKTIVEN Mitarbeiter
+--   (angelegt wie im Phase-1-Backfill, also am Guard vorbei), danach eine
+--   unbeteiligte Aenderung am selben Auftrag.
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000040', null, 'in_progress', timestamptz '2026-06-01 08:00+00');
+
+  alter table public.job_assignments disable trigger enforce_active_assignment_on_job_assignments;
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot, attendance, employee_started_at)
+  values ('e4000000-0000-0000-0000-000000000040','e2000000-0000-0000-0000-000000000005','Ida Inaktiv','started', timestamptz '2026-06-01 08:00+00');
+  alter table public.job_assignments enable trigger enforce_active_assignment_on_job_assignments;
+
+  -- unbeteiligte Aenderung am selben Auftrag (kein assigned_to)
+  update public.jobs set notes='unbeteiligt' where id='e4000000-0000-0000-0000-000000000040';
+  -- und eine Zuweisung eines anderen Mitarbeiters
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003' where id='e4000000-0000-0000-0000-000000000040';
+
+  v := 'ausnahme_bleibt='||(select count(*) from public.job_assignments
+         where job_id='e4000000-0000-0000-0000-000000000040' and employee_id='e2000000-0000-0000-0000-000000000005')::text
+       ||'/attendance='||coalesce((select attendance::text from public.job_assignments
+         where job_id='e4000000-0000-0000-0000-000000000040' and employee_id='e2000000-0000-0000-0000-000000000005'),'-')
+       ||'/counts='||coalesce((select counts_for_timesheet::text from public.job_assignments
+         where job_id='e4000000-0000-0000-0000-000000000040' and employee_id='e2000000-0000-0000-0000-000000000005'),'-');
+  insert into _dw values (22,'Historische Guard-Ausnahme wird nicht geloescht oder revalidiert',
+    'ausnahme_bleibt=1/attendance=started/counts=true', v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- E. Wiederkehrende Auftraege
+-- =========================================================
+
+-- CASE 23: Parent-Regel erhaelt eine Vorlagen-Zuweisung
+do $$
+declare v text;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000050', null, 'open', null, null,
+                         'e1000000-0000-0000-0000-000000000001','recurring', null);
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000002' where id='e4000000-0000-0000-0000-000000000050';
+  v := 'zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000050')||'/legacy='||pg_temp.legacy('e4000000-0000-0000-0000-000000000050');
+  insert into _dw values (23,'Parent-Regel: Vorlagen-Zuweisung wird gespiegelt',
+    'zuw=e2000000-0000-0000-0000-000000000002:assigned/legacy=e2000000-0000-0000-0000-000000000002', v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+-- CASE 24: Occurrence spiegelt den Legacy-Wert; Loeschen kaskadiert sauber
+do $$
+declare v text; rest int;
+begin
+  perform pg_temp.mk_job('e4000000-0000-0000-0000-000000000051','e2000000-0000-0000-0000-000000000002','open',
+                         null, null, 'e1000000-0000-0000-0000-000000000001','single','e4000000-0000-0000-0000-000000000050');
+  v := 'zuw='||pg_temp.zuw('e4000000-0000-0000-0000-000000000051');
+
+  -- Occurrence loeschen -> Kaskade, Richtung B darf nicht stolpern
+  begin
+    delete from public.jobs where id='e4000000-0000-0000-0000-000000000051';
+    select count(*) into rest from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000051';
+    v := v || '/geloescht=ok/rest='||rest::text;
+  exception when others then v := v || '/geloescht=FEHLER('||sqlstate||')';
+  end;
+
+  insert into _dw values (24,'Occurrence spiegelt Legacy-Wert; Loeschung kaskadiert ohne Fehler',
+    'zuw=e2000000-0000-0000-0000-000000000002:assigned/geloescht=ok/rest=0', v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: Bulk-UPDATE wie im SYNC-Block von update_job_occurrences
+--   erzeugt genau EINE Zeilenversion je Auftrag (kein Realtime-Sturm).
+do $$
+declare v text; i int; u0 bigint; u1 bigint;
+begin
+  for i in 1..10 loop
+    perform pg_temp.mk_job(('e6000000-0000-0000-0000-'||lpad(i::text,12,'0'))::uuid,
+                           'e2000000-0000-0000-0000-000000000002');
+  end loop;
+
+  u0 := pg_temp.jobs_updates();
+
+  -- Mengenoperation wie im SYNC-Block von update_job_occurrences()
+  update public.jobs set assigned_to='e2000000-0000-0000-0000-000000000003'
+   where id::text like 'e6000000%';
+
+  u1 := pg_temp.jobs_updates();
+
+  -- ENTSCHEIDEND: genau 10 Tupel-Updates auf jobs — eines je Auftrag.
+  -- Ohne die Touch-Unterdrueckung waeren es 20 (und in Produktion bei
+  -- einem Regel-Edit bis zu 1248 statt 624), samt doppelter
+  -- Realtime-Events.
+  v := 'zuweisungen='||(select count(*) from public.job_assignments where job_id::text like 'e6000000%')::text
+       ||'/jobs_updates='||(u1 - u0)::text;
+  insert into _dw values (25,'Bulk-Umzuweisung (10 Auftraege): genau 10 Tupel-Updates, kein Touch-Folgeupdate',
+    'zuweisungen=10/jobs_updates=10', v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select
+  case_no, beschreibung, erwartet, ergebnis,
+  case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _dw
+order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _dw where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'DUAL WRITE TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 25 FAELLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 2 von 11. **Reine Datenschicht** — kein App-Code, keine RLS, keine RPCs, keine Benachrichtigungen. Hält die alte Einzel-Spalte und die neue Tabelle automatisch synchron, damit alte App-Versionen im Feld weiterlaufen, während neuer Code ab Phase 5/6 nur noch `job_assignments` nutzt.

## Architektur-Befund (am deployten Stand erhoben)

**Schreibende Zugriffe auf `jobs.assigned_to` — vollständig:**

| # | Quelle | Art |
|---|---|---|
| 1 | `jobs.service.ts createJob()` | INSERT |
| 2 | `jobs.service.ts updateJob()` | UPDATE |
| 3 | `generate_job_occurrences()` | INSERT (Occurrences) |
| 4 | `update_job_occurrences()` SYNC-Block | **UPDATE, mengenbasiert** |
| 5 | direkte Admin-SQL / Studio | — |

`start_own_job`/`complete_own_job` lesen `assigned_to` nur in der WHERE-Klausel und schreiben es nie.

**Bestehende Trigger:** `jobs` → `enforce_active_assignee_on_jobs` (BEFORE I/U), `trg_jobs_updated_at` (BEFORE U), `trg_jobs_protect_recurring_history` (BEFORE D). `job_assignments` → `enforce_active_assignment_on_job_assignments` (BEFORE I/U), `touch_job_on_assignment_change_trg` (AFTER I/U/D).

**Realtime-Publication:** nur `jobs` und `profiles`. `job_assignments` ist nicht enthalten — deshalb existiert der Touch-Trigger.

**Kritischer Befund:** Quelle 4 aktualisiert `assigned_to` mengenbasiert über alle zukünftigen offenen Occurrences — laut Messung in `20260723000004` **bis zu 624 Zeilen pro Regel-Edit**. Naiv verdrahtet hätte jede Zeile den Legacy→Assignments-Trigger, dieser den Touch-Trigger und dieser ein **zweites** UPDATE auf derselben `jobs`-Zeile ausgelöst: 1248 statt 624 Tupel-Updates und die doppelte Zahl an Realtime-Events. Das ist der Grund für die Flag-Architektur.

## Primär-Zuweisungs-Regel (exakt)

**LEBEND** = `employee_id IS NOT NULL` **und** Profil existiert, `is_active`, `role='employee'`, gleiche `company_id` wie der Auftrag.
**SAUBER** = LEBEND **und** `attendance='assigned'` **und** `review IS NULL` **und** beide Audit-Zeitstempel `NULL`.

1. Zeigt `jobs.assigned_to` auf einen Mitarbeiter, für den an diesem Auftrag **irgendeine** Zuweisungszeile existiert → Zeiger bleibt.
2. Sonst → **älteste SAUBERE LEBENDE** Zuweisung nach `(assigned_at, id)`.
3. Sonst → `NULL`.

**Bewusste Abweichung von der Vorgabe in Schritt 1:** gefordert war „solange `assigned_to` auf eine *lebende* Zuweisung zeigt". Das wurde auf „irgendeine Zuweisung" erweitert, weil sonst genau die **6 historischen Guard-Ausnahmen** beschädigt würden: dort zeigt `assigned_to` auf einen inzwischen deaktivierten Mitarbeiter, wäre also „nicht lebend" und würde bei der nächsten beliebigen Zuweisungsänderung still auf jemand anderen oder auf `NULL` umgebogen — exakt die untersagte Reparatur.

**Warum Schritt 2 nur saubere Zeilen wählt:** Nachweis-Zeilen dürfen nicht automatisch primär werden. Ein gerade arbeitender Mitarbeiter (`attendance='started'`) verliert dadurch nichts — für ihn greift bereits Schritt 1.

**Determinismus (im Test nachgewiesen):** `now()` ist transaktionsfix, in einer Transaktion erzeugte Zuweisungen teilen sich denselben `assigned_at`; der Tiebreaker ist dann die zufällige UUID. Die Auswahl ist damit *arbiträr, aber deterministisch* — gleicher Bestand, gleiches Ergebnis, nachträglich unveränderlich. Ein besserer Tiebreaker existiert ohne Schemaänderung nicht, und die wäre mit der Rückbau-Forderung unvereinbar.

## Trigger-Fluss

**Richtung A** — `compat_sync_assignments_from_legacy()`, zwei Trigger auf `jobs` mit WHEN-Klausel als erstem, billigstem Filter:
- `AFTER INSERT ... WHEN (new.assigned_to IS NOT NULL)`
- `AFTER UPDATE OF assigned_to ... WHEN (new.assigned_to IS DISTINCT FROM old.assigned_to)`

Legt fehlende Zuweisung an (`attendance` aus Job-Status, Zeitstempel nur wenn fachlich passend, Snapshot aus lebendem Profilnamen, `assigned_by = coalesce(auth.uid(), created_by)`, `ON CONFLICT DO NOTHING` für Idempotenz) und entfernt den alten Zeiger **nur wenn spurenfrei**.

**Richtung B** — `compat_sync_legacy_from_assignments()`, `AFTER INSERT OR DELETE OR UPDATE OF employee_id` auf `job_assignments`. Reine Anwesenheits-/Review-Änderungen (der Regelfall ab Phase 7/10) lösen den Trigger auf Katalogebene **gar nicht** aus. Schreibt nur bei echter Änderung und überspringt Aufträge, die gerade kaskadierend gelöscht werden.

## Schleifen- und Sturmschutz

Transaktionslokales GUC `app.jobs_assignment_sync` (`set_config(..., is_local => true)`): explizit, selbstdokumentierend, verfällt bei COMMIT/ROLLBACK automatisch, wirkt nur auf die drei abfragenden Trigger. `ALTER TABLE ... DISABLE TRIGGER` wird bewusst **nicht** verwendet (global, ACCESS EXCLUSIVE auf der Produktionstabelle, hebelt den Schutz auch für Fremdsessions aus). `pg_trigger_depth()` verworfen: unterscheidet die Richtung nicht und bräche still bei einem weiteren Trigger. Zusätzlich greift überall `IS DISTINCT FROM` als zweite, unabhängige Abbruchbedingung. Das Flag wird auch im Fehlerfall via EXCEPTION-Block zurückgesetzt.

`touch_job_on_assignment_change()` setzt während einer Legacy-Synchronisierung aus — die `jobs`-Zeile wird dort ohnehin geschrieben und `trg_jobs_updated_at` hebt `updated_at` bereits an. **Fall 25 misst das per `pg_stat_xact_user_tables`: Bulk-Umzuweisung über 10 Aufträge → genau 10 Tupel-Updates, nicht 20.**

Bekannte, dokumentierte Restkosten: ändert ein *direkter* Zuweisungs-Schreibvorgang zugleich den Primär, schreiben Richtung B und der Touch nacheinander je einmal — zwei Zeilenversionen statt einer. Betrifft nur einzelne nutzerausgelöste Aktionen, nie Mengenoperationen; wird in Phase 6 zusammengeführt.

## Wiederkehrende Aufträge

Analysiert und getestet, **ohne** die Recurring-RPCs anzufassen:

- **Parent-Regeln:** erhalten eine Vorlagen-Zuweisung. Beabsichtigt (Regel = Vorlage, Occurrence = Realität). Regeln nehmen nie `in_progress`/`completed` an, die Statusableitung kann dort nichts Falsches erzeugen. *(Fall 23)*
- **Occurrences:** `generate_job_occurrences` fügt mit `assigned_to` ein → je Occurrence eine Zuweisung, exakt der Legacy-Wert. *(Fall 24)*
- **SYNC-Block:** Zuweisungen wechseln mit; Occurrences mit Historie fasst der Block ohnehin nicht an, dort kann kein Nachweis verloren gehen.
- **PRUNE / Regel-Löschung:** Kaskade räumt Zuweisungen ab, Richtung B erkennt den fehlenden Auftrag und schreibt nichts. *(Fall 24)*

**Bewusst offen (Phase 4):** Zuweisungs-**Mengen** werden nicht auf Occurrences propagiert. Weist ab Phase 6 jemand einer Regel drei Mitarbeiter zu, erhalten neue Occurrences weiterhin nur den primären — das ist exakt das heutige Verhalten und nicht schädlich.

## Migrationssicherheit

Keine einzige DML-Anweisung: kein Backfill, keine der 870 Bestandszeilen wird umgeschrieben, die 6 historischen Ausnahmen werden weder revalidiert noch gelöscht, kein Realtime-Sturm beim Deploy, `jobs.assigned_to` bleibt unverändert. Sicher **vor** jeder App-Änderung anwendbar. Rückbau allein durch Löschen der Trigger/Funktionen — im Testlauf tatsächlich durchgespielt.

## Tests

**Neue Suite `job_assignments_dual_write.test.sql` — 25/25 PASS.**

Richtung A (1–10): NULL→Mitarbeiter · Idempotenz · A→B · sauberes A entfernt · A mit `started`/`completed`/`review=present`/`review=absent` bewahrt · →NULL entfernt nur Sauberes bzw. bewahrt Nachweis.
Richtung B (11–16): füllt leeres `assigned_to` · ersetzt gültigen Primär nicht · wählt nächsten · setzt NULL · anonyme Zeile nie primär · Konto-Löschung behält Snapshot und wählt anderen Primär.
Schutz (17–20): keine Rekursion, Flag sauber · keine Duplikate · `updated_at`-Verhalten · identische Wiederholung ohne Zusatzschreibvorgang.
Bestand (21–22): 30 produktionsähnliche Zeilen stabil · historische Guard-Ausnahme unangetastet.
Recurring (23–25): Parent · Occurrence + Kaskade · **Bulk ohne Touch-Folgeupdates**.

**Regression — alle Suiten grün (157 Fälle):**

| Suite | Fälle |
|---|---|
| `job_assignments_dual_write` | **25/25** |
| `job_assignments` | 25/25 |
| `admin_status_notifications` | 16/16 |
| `last_admin_deletion_reservation` | 14/14 |
| `non_destructive_update_job_occurrences` | 20/20 |
| `profile_field_guard` | 12/12 |
| `protect_recurring_job_history` | 7/7 |
| `recurring_jobs_display` | 38/38 |

Repository-CI (`tsc --noEmit`, `expo lint`): lokal grün. Vollständiger `supabase db reset` wendet alle 18 Migrationen fehlerfrei an.

### Anpassung am Phase-1-Test (bitte mitprüfen)

`job_assignments.test.sql` bekommt einen zusätzlichen **unzugewiesenen** Fixture-Auftrag (J9) für die Touch-Fälle 11–13. Grund: Phase 2 legt beim INSERT eines Auftrags *mit* `assigned_to` nun automatisch eine Zuweisung an — genau die geforderte Dual-Write-Semantik — wodurch der bisherige manuelle INSERT in die UNIQUE-Bedingung lief. Es wurde keine Zusicherung abgeschwächt; die Suite ist **mit und ohne** Phase 2 grün und bleibt damit gegen den Produktionsstand gültig (explizit verifiziert).

## Nicht enthalten

Kein React-Native-Code, keine RLS-Policy, keine Änderung an `start_own_job`/`complete_own_job`, an `generate_job_occurrences`/`update_job_occurrences` oder an Benachrichtigungen. **Nicht auf Produktion angewandt, nicht gemerged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)