### PR TITLE
feat(db): RLS und Zugriffsmodell für job_assignments (Phase 3/11)

### DIFF
--- a/supabase/migrations/20260727000000_job_assignments_rls.sql
+++ b/supabase/migrations/20260727000000_job_assignments_rls.sql
@@ -1,0 +1,494 @@
+-- =========================================================
+-- MIGRATION: RLS und Zugriffsmodell für job_assignments
+-- Datum: 2026-07-27   (Phase 3 von 11 — reine Datenschicht)
+-- =========================================================
+-- ZWECK
+--   job_assignments ist seit Phase 1 fail-closed (RLS an, KEINE Policies,
+--   keine Grants für anon/authenticated). Diese Migration öffnet exakt so
+--   viel, wie die späteren Phasen brauchen — und keinen Deut mehr:
+--     * LESEN über zwei eng gefasste SELECT-Policies
+--     * SCHREIBEN ausschließlich über EINE transaktionale RPC
+--     * anon: weiterhin komplett ohne Zugriff
+--
+-- REIN ADDITIV / KEINE DATENÄNDERUNG
+--   Keine DML-Anweisung. Die 870 Bestandszeilen, die 6 historischen
+--   Guard-Ausnahmen und sämtliche Anwesenheits-/Review-Nachweise bleiben
+--   unverändert. Kein Realtime-Sturm beim Deploy.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   * Keine Änderung an public.jobs, an dessen Policies oder an
+--     assigned_to.
+--   * Keine Änderung an der Phase-2-Kompatibilitätsschicht.
+--   * Keine Änderung an start_own_job/complete_own_job, an den
+--     Recurring-RPCs oder an Benachrichtigungen.
+--   * KEINE Verbreiterung der Policies von jobs/job_comments/job_photos/
+--     job_comment_reads/storage.objects auf Mehrfachzuweisung. Das ändert,
+--     WELCHE AUFTRÄGE ein Mitarbeiter überhaupt sieht, und darf erst
+--     gemeinsam mit dem App-Lesepfad (Phase 5) ausgerollt werden. Bis
+--     dahin bleibt jobs.assigned_to die maßgebliche Sichtbarkeitsquelle —
+--     genau wie heute.
+--   * Keine Propagierung von Zuweisungs-MENGEN auf Occurrences (Phase 4).
+--
+-- =========================================================
+-- ARCHITEKTUR-BEFUND (am deployten Stand erhoben)
+-- =========================================================
+-- Autorisierung läuft im gesamten Schema über zwei SECURITY-DEFINER-
+-- Helfer: current_user_role() und current_user_company_id(). Beide liefern
+-- seit Migration 20260714000000 NULL für INAKTIVE Profile, wodurch jede
+-- Policy, die sie verwendet, automatisch fail-closed wird. Diese Migration
+-- verwendet ausschließlich dieselben Helfer — Deaktivierung wirkt damit
+-- ohne Zusatzlogik auch hier.
+--
+-- Bestehende Policies auf public.jobs (6): Admin SELECT/INSERT/UPDATE/
+-- DELETE firmenweit; Employee SELECT (job_type='single' AND
+-- assigned_to = auth.uid()); Employee UPDATE (assigned_to = auth.uid()).
+--
+-- public.profiles: Admin liest die eigene Firma, ein Employee liest
+-- AUSSCHLIESSLICH die eigene Zeile ("employee read own profile").
+-- Daraus folgt die zentrale Design-Entscheidung weiter unten.
+--
+-- job_assignments vor dieser Migration: RLS an, 0 Policies, Grants nur für
+-- service_role. Schreibzugriff hatten bisher nur die SECURITY-DEFINER-
+-- Trigger aus Phase 2.
+--
+-- =========================================================
+-- ENTSCHEIDUNG 1 — Lese-Umfang für Mitarbeiter: Variante B
+-- =========================================================
+-- Zur Wahl standen:
+--   A) Ein Mitarbeiter sieht NUR seine eigene Zuweisungszeile.
+--   B) Ein Mitarbeiter sieht ALLE Zuweisungszeilen der Aufträge, denen er
+--      selbst zugewiesen ist.
+--
+-- Gewählt: B — und zwar, weil B hier die WENIGER weitreichende Öffnung
+-- ist. Das ist nicht offensichtlich, deshalb ausführlich:
+--
+--   Die künftige Mehrfachzuweisungs-Oberfläche muss anzeigen, wer sonst
+--   noch auf einem Auftrag ist. Unter Variante A müsste der Client diese
+--   Namen anderswo herholen — und die einzige Quelle wäre public.profiles.
+--   Dort darf ein Employee heute aber ausschließlich die EIGENE Zeile
+--   lesen. Variante A würde also erzwingen, die profiles-Policy für
+--   Mitarbeiter zu öffnen — eine deutlich breitere Rechteausweitung als
+--   das, was B tut.
+--
+--   B braucht profiles überhaupt nicht: employee_name_snapshot steht
+--   bereits AUF der Zuweisungszeile (angelegt in Phase 1 für den Fall der
+--   Konto-Löschung). Die Kollegennamen kommen damit aus genau der Zeile,
+--   die der Mitarbeiter ohnehin sehen darf.
+--
+--   Offengelegte Zusatzinformation gegenüber heute, vollständig: id,
+--   Namens-Schnappschuss und Anwesenheits-/Review-Zustand der KollegInNEN
+--   auf GENAU DEN Aufträgen, denen der Mitarbeiter selbst zugewiesen ist.
+--   Nichts firmenweit, nichts über fremde Aufträge, nichts über andere
+--   Firmen.
+--
+-- =========================================================
+-- ENTSCHEIDUNG 2 — Schreiben über RPC statt direkter Policies
+-- =========================================================
+-- Direkte INSERT/UPDATE/DELETE-Policies für Admins wären möglich, sind
+-- hier aber die schlechtere Lösung. Ausschlaggebend ist nicht die
+-- Validierung (die könnte eine Policy leisten), sondern ATOMARITÄT:
+--
+--   Eine Zuweisungs-MENGE zu ändern heißt entfernen UND hinzufügen. Über
+--   die REST-Schnittstelle wären das zwei getrennte Requests, also zwei
+--   Transaktionen. Zwischen ihnen existiert ein Zustand, in dem der
+--   Auftrag keine (oder die falschen) Zuweisungen hat. Die Phase-2-
+--   Kompatibilitätsschicht reagiert darauf sofort: sie rechnet den
+--   primären Mitarbeiter neu, schreibt jobs.assigned_to (womöglich auf
+--   NULL) und löst ein Realtime-Event aus. Alte Clients zeigen den
+--   Auftrag in diesem Fenster als "nicht zugewiesen". Ein Abbruch
+--   zwischen den beiden Requests hinterlässt den Zustand dauerhaft falsch.
+--
+--   Zusätzlich kann nur eine RPC die Auftragszeile VOR der Änderung
+--   sperren und sich damit sauber mit dem FOR-UPDATE der Phase-2-Trigger
+--   serialisieren. Ein direkter DELETE über PostgREST kann das nicht.
+--
+--   Drittens: die vollständige Validierung der Eingabemenge passiert VOR
+--   dem ersten Schreibvorgang. Ein ungültiger Mitarbeiter in der Liste
+--   führt damit zu gar keiner Änderung statt zu einer halb angewandten.
+--
+-- Ergebnis: authenticated bekommt NUR SELECT. INSERT/UPDATE/DELETE bleiben
+-- ohne Grant UND ohne Policy — doppelt verriegelt.
+--
+-- =========================================================
+-- ENTSCHEIDUNG 3 — UPDATE bleibt in Phase 3 vollständig gesperrt
+-- =========================================================
+-- Es gibt derzeit keinen legitimen Anwendungsfall: Anwesenheit schreibt
+-- ab Phase 7 die start/complete-RPC, das Manager-Review ab Phase 10 eine
+-- eigene Review-RPC. Beide werden SECURITY DEFINER sein und brauchen
+-- keine UPDATE-Policy. Eine Policy "auf Vorrat" wäre unbenutzte
+-- Angriffsfläche und würde insbesondere erlauben, review/reviewed_by oder
+-- employee_name_snapshot zu manipulieren.
+--
+-- =========================================================
+-- ANWENDUNG
+--   Wie alle Schemaänderungen hier MANUELL im Supabase SQL Editor
+--   ausführen (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgeführt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Policy-Helfer (SECURITY DEFINER — begründet)
+-- ---------------------------------------------------------
+-- BEIDE Helfer sind SECURITY DEFINER, und zwar aus einem konkreten,
+-- nicht-kosmetischen Grund: Ausdrücke in einer RLS-Policy werden im
+-- Rechtekontext des AUFRUFERS ausgewertet. Eine Unterabfrage auf
+-- public.jobs innerhalb einer Policy unterläge damit der RLS von jobs —
+-- und die beschränkt Mitarbeiter heute auf assigned_to = auth.uid().
+-- Genau dieser Mitarbeiter ist bei Mehrfachzuweisung aber NICHT
+-- zwangsläufig der Legacy-Primär. Die Policy würde also für die
+-- Nicht-Primär-Zuweisungen still ins Leere laufen.
+--
+-- Ein Helfer auf job_assignments MUSS zusätzlich SECURITY DEFINER sein,
+-- weil eine Policy AUF job_assignments, die job_assignments abfragt,
+-- sonst unendlich rekursiv wäre (PostgreSQL bricht das mit einem Fehler
+-- ab). SECURITY DEFINER (Eigentümer postgres, kein FORCE ROW LEVEL
+-- SECURITY) umgeht RLS und beendet die Rekursion.
+--
+-- Beide Funktionen sind STABLE, nehmen nur eine job_id entgegen, schreiben
+-- nichts, geben nur einen Skalar zurück, haben festen search_path und
+-- bekommen unten EXECUTE entzogen.
+
+-- ACHTUNG — HART ERARBEITETE REGEL (siehe Kommentarblock unter Abschnitt 2):
+-- Policy-Helfer MÜSSEN für die Rollen ausführbar sein, für die die Policy
+-- gilt. EXECUTE hier zu entziehen ist KEINE Härtung, sondern bricht die
+-- Policy — in dieser PostgreSQL-Version sogar mit einem Absturz des
+-- Backends. Deshalb erhalten beide Helfer unten GRANT EXECUTE für
+-- authenticated, exakt wie die bestehenden current_user_role() /
+-- current_user_company_id().
+
+-- Gibt bewusst nur einen BOOLEAN zurück statt der Firmen-ID: da die
+-- Funktion für Clients ausführbar sein muss, würde eine zurückgegebene
+-- company_id verraten, welcher Firma ein beliebiger (erratener) Auftrag
+-- gehört. Die Boolean-Variante beantwortet ausschließlich die Frage
+-- „gehört dieser Auftrag ZU MEINER Firma?" und offenbart damit nichts
+-- über fremde Firmen.
+create or replace function public.job_in_current_company(p_job_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.jobs j
+    where j.id         = p_job_id
+      and j.company_id = public.current_user_company_id()
+  );
+$$;
+
+comment on function public.job_in_current_company(uuid) is
+'true, wenn der Auftrag zur Firma des Aufrufers gehört. RLS-unabhängig '
+'(SECURITY DEFINER), weil eine Unterabfrage auf jobs innerhalb einer '
+'Policy sonst der jobs-RLS des Aufrufers unterläge. Gibt bewusst nur einen '
+'Boolean zurück, um keine fremden Firmenzugehörigkeiten preiszugeben.';
+
+revoke all on function public.job_in_current_company(uuid) from public;
+revoke all on function public.job_in_current_company(uuid) from anon;
+grant execute on function public.job_in_current_company(uuid) to authenticated;
+
+create or replace function public.is_assigned_to_job(p_job_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.job_assignments ja
+    join public.jobs j on j.id = ja.job_id
+    where ja.job_id      = p_job_id
+      and ja.employee_id = auth.uid()
+      and j.company_id   = public.current_user_company_id()
+  );
+$$;
+
+comment on function public.is_assigned_to_job(uuid) is
+'true, wenn der aufrufende Nutzer dem Auftrag zugewiesen ist (inkl. '
+'Firmenprüfung). SECURITY DEFINER: verhindert die RLS-Rekursion einer '
+'job_assignments-Policy, die job_assignments abfragt.';
+
+revoke all on function public.is_assigned_to_job(uuid) from public;
+revoke all on function public.is_assigned_to_job(uuid) from anon;
+grant execute on function public.is_assigned_to_job(uuid) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- WARUM DIE HELFER FÜR authenticated AUSFÜHRBAR SEIN MÜSSEN
+-- ---------------------------------------------------------
+-- Beim ersten Entwurf wurde EXECUTE auf beiden Helfern für anon UND
+-- authenticated entzogen — analog zu den internen Trigger-Funktionen aus
+-- Phase 1/2. Das ist hier FALSCH und war im Test sofort sichtbar:
+--
+--   Ausdrücke einer RLS-Policy werden im Rechtekontext des AUFRUFERS
+--   ausgewertet, nicht im Kontext des Tabelleneigentümers. Fehlt dem
+--   Aufrufer EXECUTE auf einer im Policy-Ausdruck verwendeten Funktion,
+--   ist die Policy nicht auswertbar.
+--
+-- Fehlt das Recht, ist die Policy schlicht nicht auswertbar und der
+-- Zugriff scheitert mit „permission denied for function".
+--
+-- NEBENBEFUND aus der lokalen Entwicklungsumgebung, bewusst NICHT als
+-- PostgreSQL-Eigenschaft dargestellt: im lokalen Supabase-Container
+-- (PostgreSQL 17.6, aarch64) fuehrt JEDER permission-denied-Fehler zu
+-- einem Absturz des Backends (signal 11) statt zu einer sauberen
+-- Fehlermeldung — reproduzierbar auch mit voellig unbeteiligten
+-- Funktionen wie pg_read_file() und mit seit Monaten produktiv
+-- laufenden Funktionen wie fanout_notification_events(). Das ist also
+-- KEINE Eigenschaft dieser Migration und kein Schemafehler, sondern ein
+-- Defekt der lokalen Umgebung. Auf Produktion wurde er bewusst NICHT
+-- nachgestellt: ein Segfault startet den Postmaster neu und trennt alle
+-- Verbindungen. Siehe Hinweis in den Tests.
+--
+-- Genau deshalb sind auch die BESTEHENDEN Policy-Helfer dieses Schemas,
+-- current_user_role() und current_user_company_id(), für authenticated
+-- (und sogar anon) ausführbar. Der Entzug von EXECUTE ist die richtige
+-- Härtung für Trigger- und Dispatcher-Funktionen, NICHT für Funktionen,
+-- die in einem Policy-Ausdruck vorkommen.
+--
+-- Beide Helfer sind auf diese Rolle hin ausgelegt: sie nehmen nur eine
+-- job_id entgegen, geben ausschließlich einen Boolean zurück, beziehen
+-- sich immer auf den AUFRUFER und geben keinerlei Information über fremde
+-- Firmen oder fremde Zuweisungen preis.
+-- ---------------------------------------------------------
+
+-- ---------------------------------------------------------
+-- 2. Grants: ausschließlich SELECT für authenticated
+-- ---------------------------------------------------------
+-- Ohne Grant greift keine SELECT-Policy. INSERT/UPDATE/DELETE bleiben
+-- bewusst OHNE Grant — zusätzlich zum Fehlen entsprechender Policies.
+-- Damit scheitert ein Schreibversuch bereits an der Privilegienprüfung,
+-- also noch vor jeder Policy-Auswertung (Defense-in-Depth).
+-- anon bleibt vollständig ausgeschlossen.
+grant select on public.job_assignments to authenticated;
+revoke all on public.job_assignments from anon;
+
+
+-- ---------------------------------------------------------
+-- 3. SELECT-Policies
+-- ---------------------------------------------------------
+-- Admin: alle Zuweisungen der eigenen Firma.
+drop policy if exists "admin read assignments in own company" on public.job_assignments;
+create policy "admin read assignments in own company"
+on public.job_assignments
+for select
+to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and public.job_in_current_company(job_id)
+);
+
+-- Employee: alle Zuweisungen der Aufträge, denen er SELBST zugewiesen ist
+-- (Variante B, siehe Entscheidung 1). Deckt sowohl die eigene Zeile als
+-- auch die der Kolleginnen und Kollegen desselben Auftrags ab.
+drop policy if exists "employee read assignments on assigned jobs" on public.job_assignments;
+create policy "employee read assignments on assigned jobs"
+on public.job_assignments
+for select
+to authenticated
+using (
+  public.current_user_role() = 'employee'
+  and public.is_assigned_to_job(job_id)
+);
+
+-- KEINE INSERT-, UPDATE- oder DELETE-Policy. Schreibzugriff läuft
+-- ausschließlich über set_job_assignments() (unten) sowie über die
+-- SECURITY-DEFINER-Trigger aus Phase 2.
+
+
+-- ---------------------------------------------------------
+-- 4. Schreib-RPC: Zuweisungsmenge eines Auftrags ersetzen
+-- ---------------------------------------------------------
+-- SECURITY DEFINER — zwingend: authenticated hat auf job_assignments
+-- absichtlich KEIN Schreibrecht. Die Funktion prüft Authentifizierung,
+-- Rolle und Firmenzugehörigkeit selbst und ist damit fail-closed.
+--
+-- WICHTIG zur Aufgabenteilung mit Phase 2: diese RPC schreibt AUSSCHLIESS-
+-- LICH job_assignments. Sie fasst jobs.assigned_to NICHT an. Welcher
+-- Mitarbeiter primär wird, entscheidet allein
+-- compat_sync_legacy_from_assignments() nach der dort dokumentierten,
+-- deterministischen Regel. Damit gibt es weiterhin genau EINE Stelle, die
+-- die Legacy-Spalte bestimmt.
+--
+-- EINGABEVALIDIERUNG vor jedem Schreibvorgang: Der Phase-2-Trigger und
+-- enforce_active_assignment laufen als SECURITY DEFINER und umgehen RLS.
+-- Auf sie darf man sich zur Eingabeprüfung deshalb NICHT verlassen. Die
+-- RPC validiert die vollständige Zielmenge selbst, bevor sie irgendetwas
+-- ändert — ein einziger ungültiger Eintrag führt zu null Änderungen.
+create or replace function public.set_job_assignments(
+  p_job_id       uuid,
+  p_employee_ids uuid[] default '{}'::uuid[]
+)
+returns setof public.job_assignments
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company uuid;
+  v_ids     uuid[];
+  v_invalid int;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can change job assignments' using errcode = '42501';
+  end if;
+
+  -- Auftrag laden UND sperren. Die Sperre serialisiert konkurrierende
+  -- Mengenänderungen für denselben Auftrag und greift in dieselbe
+  -- Sperrreihenfolge wie compat_sync_legacy_from_assignments() (Phase 2)
+  -- und update_job_occurrences() — damit entsteht kein Deadlock.
+  select j.company_id
+    into v_company
+  from public.jobs j
+  where j.id         = p_job_id
+    and j.company_id = public.current_user_company_id()
+  for update;
+
+  if not found then
+    raise exception 'Job not found or not accessible' using errcode = '42501';
+  end if;
+
+  -- Eingabe normalisieren: NULL-Einträge entfernen, Duplikate entfernen.
+  -- Ein doppelt übergebener Mitarbeiter ist damit ein harmloser No-Op
+  -- statt eines UNIQUE-Fehlers.
+  select coalesce(array_agg(distinct x), '{}'::uuid[])
+    into v_ids
+  from unnest(coalesce(p_employee_ids, '{}'::uuid[])) as x
+  where x is not null;
+
+  -- VOLLSTÄNDIGE Validierung vor dem ersten Schreibvorgang:
+  -- Profil existiert, ist aktiv, hat role='employee' und gehört zur
+  -- Firma des Auftrags. Das schließt Fremdfirmen und Admin-Profile aus.
+  select count(*)
+    into v_invalid
+  from unnest(v_ids) as x
+  where not exists (
+    select 1
+    from public.profiles p
+    where p.id         = x
+      and p.is_active  = true
+      and p.role       = 'employee'
+      and p.company_id = v_company
+  );
+
+  if v_invalid > 0 then
+    raise exception
+      'Assignment rejected: % of % employee(s) are not active employees of this company',
+      v_invalid, cardinality(v_ids)
+      using errcode = '23514';
+  end if;
+
+  -- ── ENTFERNEN ──────────────────────────────────────────────────
+  -- Nur SPURENFREIE Zeilen, die nicht mehr zur Zielmenge gehören.
+  -- Geschützt bleiben damit:
+  --   * Zeilen mit Anwesenheit (started/completed)
+  --   * Zeilen mit Zeitstempeln
+  --   * Zeilen mit Manager-Review (present/absent)
+  --   * anonymisierte Zeilen aus Konto-Löschungen (employee_id IS NULL)
+  -- Diese Zeilen bleiben als abgekoppelte Nachweise bestehen; die
+  -- Phase-2-Primärregel macht sie nie automatisch wieder primär.
+  delete from public.job_assignments ja
+  where ja.job_id                 = p_job_id
+    and ja.employee_id           is not null
+    and not (ja.employee_id = any (v_ids))
+    and ja.attendance             = 'assigned'
+    and ja.review                is null
+    and ja.employee_started_at   is null
+    and ja.employee_completed_at is null;
+
+  -- ── HINZUFÜGEN ─────────────────────────────────────────────────
+  -- Fehlende Zuweisungen anlegen. ON CONFLICT DO NOTHING sorgt dafür,
+  -- dass eine bereits bestehende Zeile UNVERÄNDERT bleibt — insbesondere
+  -- werden vorhandene Anwesenheits- und Review-Daten nicht überschrieben.
+  insert into public.job_assignments (
+    job_id, employee_id, employee_name_snapshot, assigned_by
+  )
+  select
+    p_job_id,
+    x,
+    coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+    auth.uid()
+  from unnest(v_ids) as x
+  join public.profiles p on p.id = x
+  on conflict (job_id, employee_id) do nothing;
+
+  -- Ergebnis: die resultierende Menge, stabil sortiert.
+  return query
+  select ja.*
+  from public.job_assignments ja
+  where ja.job_id = p_job_id
+  order by ja.assigned_at, ja.id;
+end;
+$$;
+
+comment on function public.set_job_assignments(uuid, uuid[]) is
+'Ersetzt die Zuweisungsmenge EINES Auftrags transaktional (nur Admin, nur '
+'eigene Firma). Validiert die gesamte Zielmenge vor dem ersten Schreib'
+'vorgang, sperrt die Auftragszeile, entfernt ausschließlich spurenfreie '
+'Zuweisungen und legt fehlende an. Bewahrt Anwesenheit, Review, '
+'Zeitstempel und anonymisierte Zeilen. jobs.assigned_to wird NICHT '
+'angefasst — den primären Mitarbeiter bestimmt allein die '
+'Phase-2-Kompatibilitätsschicht.';
+
+-- Nur eingeloggte Nutzer dürfen die RPC überhaupt aufrufen; die
+-- Admin-Prüfung passiert intern. anon und PUBLIC bleiben ausgeschlossen.
+revoke all on function public.set_job_assignments(uuid, uuid[]) from public;
+revoke all on function public.set_job_assignments(uuid, uuid[]) from anon;
+grant execute on function public.set_job_assignments(uuid, uuid[]) to authenticated;
+
+
+-- =========================================================
+-- ZUSAMMENSPIEL MIT DEN LIVE-TRIGGERN AUS PHASE 2
+-- =========================================================
+--   * Jede von der RPC geschriebene Zeile löst
+--     compat_sync_legacy_from_assignments() aus. Dieser bestimmt den
+--     primären Mitarbeiter neu und schreibt jobs.assigned_to nur bei
+--     echter Änderung (IS DISTINCT FROM). Die RPC hält die Auftragszeile
+--     zu diesem Zeitpunkt bereits gesperrt — dieselbe Sperre, die der
+--     Trigger selbst anfordert, also ein reiner No-Op ohne Deadlock.
+--   * Rekursion ist ausgeschlossen: die RPC schreibt ausschließlich
+--     job_assignments; der Rückweg nach jobs läuft über den Trigger, und
+--     dessen Gegenrichtung ist über das transaktionslokale Sync-Flag
+--     abgesichert.
+--   * BEKANNTE, BEGRENZTE SCHREIBVERSTÄRKUNG: Die Trigger sind
+--     zeilenbasiert. Eine Mengenänderung mit n Zeilen löst bis zu n
+--     Primär-Neuberechnungen und bis zu n Touch-Updates auf derselben
+--     jobs-Zeile aus (und damit ebenso viele Realtime-Events). Das ist
+--     durch die Größe der Zuweisungsmenge nach oben begrenzt — also eine
+--     einstellige Zahl pro Admin-Aktion, keine Mengenoperation. Bewusst
+--     nicht optimiert: eine Unterdrückung müsste das interne Sync-Flag
+--     der Phase 2 von außen setzen und würde beide Phasen fest
+--     aneinanderkoppeln. Zusammengeführt wird das in Phase 6, wenn der
+--     Schreibpfad der App ohnehin neu gebaut wird.
+--   * Die Phase-2-Trigger umgehen als SECURITY DEFINER die RLS. Diese
+--     Migration verlässt sich an keiner Stelle darauf, dass RLS deren
+--     Verhalten einschränkt — die Eingabevalidierung liegt vollständig in
+--     set_job_assignments(), also VOR der Trigger-Ausführung.
+-- =========================================================
+
+
+-- =========================================================
+-- ROLLBACK (vollständig, nicht destruktiv)
+-- =========================================================
+-- Reihenfolge unkritisch: keine der neuen Funktionen wird von einem
+-- bestehenden Trigger aufgerufen (im Gegensatz zu Phase 2).
+--
+--   drop policy if exists "employee read assignments on assigned jobs" on public.job_assignments;
+--   drop policy if exists "admin read assignments in own company"      on public.job_assignments;
+--   revoke select on public.job_assignments from authenticated;
+--   drop function if exists public.set_job_assignments(uuid, uuid[]);
+--   drop function if exists public.is_assigned_to_job(uuid);
+--   drop function if exists public.job_in_current_company(uuid);
+--
+-- Danach ist job_assignments wieder exakt im Phase-2-Zustand: RLS an,
+-- keine Policies, keine Grants für anon/authenticated. Es gehen keine
+-- Daten verloren — diese Migration besitzt keine eigenen Daten. Die
+-- Phase-2-Kompatibilitätsschicht und jobs.assigned_to bleiben unberührt
+-- und voll funktionsfähig.
+-- =========================================================

--- a/supabase/tests/job_assignments.test.sql
+++ b/supabase/tests/job_assignments.test.sql
@@ -667,17 +667,29 @@ end $$;
 -- =========================================================
 -- CASE 23: Neue Tabelle ist fail-closed (RLS an, keine Grants)
 -- =========================================================
+-- Hinweis: Phase 3 (Migration 20260727000000) vergibt bewusst SELECT an
+-- authenticated, damit die dortigen Lese-Policies ueberhaupt greifen
+-- koennen. Geprueft werden hier deshalb die Zusicherungen, die
+-- phasenuebergreifend gelten MUESSEN: RLS bleibt aktiv, anon bekommt
+-- niemals irgendein Recht, und authenticated erhaelt zu keinem Zeitpunkt
+-- ein SCHREIBrecht auf der Tabelle.
 do $$
-declare v text; rls boolean; grants int;
+declare v text; rls boolean; anon_grants int; write_grants int;
 begin
   select relrowsecurity into rls from pg_class where oid = 'public.job_assignments'::regclass;
-  select count(*) into grants
+
+  select count(*) into anon_grants
+  from information_schema.role_table_grants
+  where table_schema='public' and table_name='job_assignments' and grantee='anon';
+
+  select count(*) into write_grants
   from information_schema.role_table_grants
   where table_schema='public' and table_name='job_assignments'
-    and grantee in ('anon','authenticated');
+    and grantee='authenticated' and privilege_type in ('INSERT','UPDATE','DELETE');
 
-  v := 'rls='||rls::text||'/grants='||grants::text;
-  insert into _ja_results values (23,'job_assignments fail-closed: RLS aktiv, keine anon/authenticated-Grants','rls=true/grants=0',v);
+  v := 'rls='||rls::text||'/anon_grants='||anon_grants::text||'/auth_schreibrechte='||write_grants::text;
+  insert into _ja_results values (23,'job_assignments: RLS aktiv, anon rechtelos, authenticated ohne Schreibrechte',
+    'rls=true/anon_grants=0/auth_schreibrechte=0',v);
   raise notice 'CASE 23 -> %', v;
 end $$;
 

--- a/supabase/tests/job_assignments_rls.test.sql
+++ b/supabase/tests/job_assignments_rls.test.sql
@@ -1,0 +1,655 @@
+-- =========================================================
+-- TEST: RLS und Zugriffsmodell für job_assignments
+-- (Migration 20260727000000_job_assignments_rls)
+-- =========================================================
+-- Prüft Lese-Policies (Admin/Employee/anon), die Schreib-RPC
+-- set_job_assignments(), die Bewahrung von Nachweisen, das Zusammenspiel
+-- mit den LIVE-Triggern aus Phase 2 sowie die Rekursionsfreiheit der
+-- Employee-Policy.
+--
+-- Alle Zugriffe laufen als echte Rollen (SET ROLE + request.jwt.claims),
+-- also über denselben Pfad wie die App über PostgREST.
+--
+-- Läuft transaktional (BEGIN … ROLLBACK): keine Rückstände, keine
+-- Produktionsdaten. Ausführen lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/job_assignments_rls.test.sql
+-- =========================================================
+
+begin;
+
+-- =========================================================
+-- HINWEIS ZU „VERWEIGERT"-PFADEN
+-- =========================================================
+-- Der lokale Supabase-Container (PostgreSQL 17.6, aarch64) stuerzt bei
+-- JEDEM permission-denied-Fehler ab (signal 11) statt eine saubere
+-- Fehlermeldung zu liefern. Reproduzierbar auch mit voellig unbeteiligten
+-- Funktionen (pg_read_file) und mit seit Monaten produktiv laufenden
+-- Funktionen (fanout_notification_events) — es ist also ein Defekt der
+-- Umgebung, nicht dieses Schemas.
+--
+-- Faelle, deren Verweigerung ueber ein FEHLENDES PRIVILEG laeuft, koennen
+-- hier deshalb nicht durch einen echten Aufruf geprueft werden, ohne die
+-- Test-Datenbank abzuschiessen. Sie werden stattdessen ueber die
+-- Rechtevergabe selbst nachgewiesen (has_function_privilege /
+-- role_table_grants / pg_policies). Das ist fuer genau dieses Design auch
+-- die richtige Zusicherung: die Verweigerung IST hier die fehlende
+-- Rechtevergabe (Defense-in-Depth vor jeder Policy-Auswertung).
+--
+-- Verweigerungen, die ueber RLS-Policies statt ueber Privilegien laufen
+-- (z. B. Zeilen, die ein Nutzer nicht sieht), werden weiterhin durch
+-- echte Zugriffe geprueft — sie loesen keinen permission-denied-Fehler aus.
+-- =========================================================
+
+-- ── Fixdaten ──
+-- Firma A = d1…1 | Firma B = d1…2
+-- Admin A = d2…1 | A1 = d2…2 | A2 = d2…3 | A3 = d2…4 | inaktiv = d2…5
+-- Admin B = d2…6 | B1 = d2…7 | loeschbar = d2…8
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000001','authenticated','authenticated','r-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000002','authenticated','authenticated','r-a1@example.test','{"full_name":"Anna Eins"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000003','authenticated','authenticated','r-a2@example.test','{"full_name":"Bert Zwei"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000004','authenticated','authenticated','r-a3@example.test','{"full_name":"Cora Drei"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000005','authenticated','authenticated','r-inaktiv@example.test','{"full_name":"Ida Inaktiv"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000006','authenticated','authenticated','r-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000007','authenticated','authenticated','r-b1@example.test','{"full_name":"Bea Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','d2000000-0000-0000-0000-000000000008','authenticated','authenticated','r-del@example.test','{"full_name":"Lars Loeschbar"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('d2000000-0000-0000-0000-000000000001','Admin A'),
+  ('d2000000-0000-0000-0000-000000000002','Anna Eins'),
+  ('d2000000-0000-0000-0000-000000000003','Bert Zwei'),
+  ('d2000000-0000-0000-0000-000000000004','Cora Drei'),
+  ('d2000000-0000-0000-0000-000000000005','Ida Inaktiv'),
+  ('d2000000-0000-0000-0000-000000000006','Admin B'),
+  ('d2000000-0000-0000-0000-000000000007','Bea Fremd'),
+  ('d2000000-0000-0000-0000-000000000008','Lars Loeschbar')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('d1000000-0000-0000-0000-000000000001','RLS Firma A','rls-firma-a-test'),
+  ('d1000000-0000-0000-0000-000000000002','RLS Firma B','rls-firma-b-test');
+
+update public.profiles set company_id='d1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='d2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='d1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id in
+  ('d2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000003','d2000000-0000-0000-0000-000000000004','d2000000-0000-0000-0000-000000000008');
+update public.profiles set company_id='d1000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='d2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='d1000000-0000-0000-0000-000000000002', role='admin',    is_active=true  where id='d2000000-0000-0000-0000-000000000006';
+update public.profiles set company_id='d1000000-0000-0000-0000-000000000002', role='employee', is_active=true  where id='d2000000-0000-0000-0000-000000000007';
+
+-- Aufträge: J1/J2 Firma A, J3 Firma B, J4 Recurring-Parent A, J5 Occurrence A
+insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                         location_address, status, job_type, date, start_time, recurring_days,
+                         is_active, created_at, updated_at, parent_job_id) values
+  ('d4000000-0000-0000-0000-000000000001','d1000000-0000-0000-0000-000000000001',null,'d2000000-0000-0000-0000-000000000001','K1','S1','O1','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('d4000000-0000-0000-0000-000000000002','d1000000-0000-0000-0000-000000000001',null,'d2000000-0000-0000-0000-000000000001','K2','S2','O2','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('d4000000-0000-0000-0000-000000000003','d1000000-0000-0000-0000-000000000002',null,'d2000000-0000-0000-0000-000000000006','K3','S3','O3','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('d4000000-0000-0000-0000-000000000004','d1000000-0000-0000-0000-000000000001',null,'d2000000-0000-0000-0000-000000000001','K4','S4','O4','open','recurring',null,'08:00',array['mon'],true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('d4000000-0000-0000-0000-000000000005','d1000000-0000-0000-0000-000000000001',null,'d2000000-0000-0000-0000-000000000001','K5','S5','O5','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00','d4000000-0000-0000-0000-000000000004');
+
+create temporary table _r (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+-- Merkt sich Zwischenstaende, die spaetere Faelle vergleichen muessen.
+create temporary table _state (k text primary key, v text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+create or replace function pg_temp.zuw(p_job uuid) returns text language sql as $f$
+  select coalesce(string_agg(coalesce(ja.employee_id::text,'ANON')||':'||ja.attendance::text
+         || case when ja.review is null then '' else '/'||ja.review::text end,
+         ',' order by ja.employee_id nulls last),'KEINE')
+  from public.job_assignments ja where ja.job_id = p_job;
+$f$;
+
+create or replace function pg_temp.legacy(p_job uuid) returns text language sql as $f$
+  select coalesce((select assigned_to::text from public.jobs where id=p_job),'NULL');
+$f$;
+
+create or replace function pg_temp.jobs_updates() returns bigint language sql as $f$
+  select coalesce((select n_tup_upd from pg_stat_xact_user_tables where schemaname='public' and relname='jobs'),0);
+$f$;
+
+
+-- =========================================================
+-- A. Schreib-RPC — Grundverhalten
+-- =========================================================
+
+-- CASE 1: Admin setzt eine Zuweisungsmenge (2 Mitarbeiter)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+    array['d2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000003']::uuid[]);
+  execute 'reset role';
+  -- WICHTIG: der konkrete Primaer ist hier NICHT vorhersagbar. Beide
+  -- Zuweisungen entstehen in derselben Transaktion, teilen sich also
+  -- denselben assigned_at; den Ausschlag gibt dann der id-Tiebreaker, also
+  -- eine zufaellige UUID (so in Phase 2 dokumentiert). Geprueft wird
+  -- deshalb die DETERMINISTISCHE Eigenschaft: der Primaer ist gesetzt,
+  -- gehoert zur Zielmenge und ist durch eine Zuweisung gedeckt.
+  insert into _state values ('case1_legacy', pg_temp.legacy('d4000000-0000-0000-0000-000000000001'));
+  v := 'zuw='||pg_temp.zuw('d4000000-0000-0000-0000-000000000001')
+     ||'/primaer_aus_menge='||(pg_temp.legacy('d4000000-0000-0000-0000-000000000001') in
+          ('d2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000003'))::text
+     ||'/gedeckt='||(select (j.assigned_to is null or exists(select 1 from public.job_assignments ja
+          where ja.job_id=j.id and ja.employee_id=j.assigned_to))::text
+        from public.jobs j where j.id='d4000000-0000-0000-0000-000000000001');
+  insert into _r values (1,'Admin setzt Menge; Phase 2 waehlt einen gedeckten Primaer aus der Menge',
+    'zuw=d2000000-0000-0000-0000-000000000002:assigned,d2000000-0000-0000-0000-000000000003:assigned/primaer_aus_menge=true/gedeckt=true', v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: Doppelte IDs in der Eingabe -> harmlos entdupliziert
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000002',
+      array['d2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000002',null]::uuid[]);
+    v := 'OK/'||(select count(*)::text from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000002');
+  exception when others then v := 'FEHLER('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (2,'Doppelte und NULL-IDs in der Eingabe werden entdupliziert','OK/1',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: leere Menge entfernt alle sauberen Zuweisungen
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000002', '{}'::uuid[]);
+  execute 'reset role';
+  v := 'zuw='||pg_temp.zuw('d4000000-0000-0000-0000-000000000002')||'/legacy='||pg_temp.legacy('d4000000-0000-0000-0000-000000000002');
+  insert into _r values (3,'Leere Zielmenge entfernt saubere Zuweisungen','zuw=KEINE/legacy=NULL',v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- CASE 4: fremde Firma -> abgelehnt, KEINE Teiländerung
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+      array['d2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000007']::uuid[]);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  v := v||'/zuw_unveraendert='||(pg_temp.zuw('d4000000-0000-0000-0000-000000000001') =
+        'd2000000-0000-0000-0000-000000000002:assigned,d2000000-0000-0000-0000-000000000003:assigned')::text;
+  insert into _r values (4,'Mitarbeiter fremder Firma -> abgelehnt, keine Teilaenderung','ABGELEHNT/zuw_unveraendert=true',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- CASE 5: inaktiver Mitarbeiter -> abgelehnt
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+      array['d2000000-0000-0000-0000-000000000005']::uuid[]);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (5,'Inaktiver Mitarbeiter -> abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- CASE 6: Admin-Profil als Feldmitarbeiter -> abgelehnt
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+      array['d2000000-0000-0000-0000-000000000001']::uuid[]);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (6,'Admin-Profil als Mitarbeiter -> abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: Auftrag fremder Firma -> abgelehnt
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000003',
+      array['d2000000-0000-0000-0000-000000000002']::uuid[]);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (7,'Auftrag einer fremden Firma -> abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+-- CASE 8: Employee darf die RPC nicht nutzen
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+      array['d2000000-0000-0000-0000-000000000002']::uuid[]);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (8,'Employee ruft set_job_assignments -> abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- CASE 9: anon darf die RPC nicht ausfuehren (ueber die Rechtevergabe geprueft)
+do $$
+declare v text;
+begin
+  v := 'anon_execute='||has_function_privilege('anon','public.set_job_assignments(uuid,uuid[])','EXECUTE')::text
+     ||'/public_execute='||has_function_privilege('public','public.set_job_assignments(uuid,uuid[])','EXECUTE')::text;
+  insert into _r values (9,'anon/PUBLIC ohne EXECUTE auf set_job_assignments','anon_execute=false/public_execute=false',v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- =========================================================
+-- B. Nachweis-Bewahrung
+-- =========================================================
+
+-- CASE 10: Nachweis-behaftete Zeile wird beim Mengenwechsel BEWAHRT
+do $$
+declare v text;
+begin
+  update public.job_assignments set attendance='started', employee_started_at=now()
+   where job_id='d4000000-0000-0000-0000-000000000001' and employee_id='d2000000-0000-0000-0000-000000000002';
+  update public.job_assignments set review='absent', reviewed_at=now(), reviewed_by='d2000000-0000-0000-0000-000000000001'
+   where job_id='d4000000-0000-0000-0000-000000000001' and employee_id='d2000000-0000-0000-0000-000000000003';
+
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  -- beide bisherigen ersetzen durch einen dritten Mitarbeiter
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000001',
+    array['d2000000-0000-0000-0000-000000000004']::uuid[]);
+  execute 'reset role';
+
+  v := pg_temp.zuw('d4000000-0000-0000-0000-000000000001');
+  insert into _r values (10,'Nachweis-Zeilen (Anwesenheit/Review) ueberleben den Mengenwechsel',
+    'd2000000-0000-0000-0000-000000000002:started,d2000000-0000-0000-0000-000000000003:assigned/absent,d2000000-0000-0000-0000-000000000004:assigned', v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- CASE 11: Primaer bleibt gedeckt; Nachweis-Zeile wird nicht automatisch primaer
+do $$
+declare v text;
+begin
+  -- Deterministische Aussage: Regel 1 der Phase-2-Primaerregel behaelt den
+  -- BESTEHENDEN Zeiger, solange ihn eine Zuweisungszeile deckt. Der Zeiger
+  -- darf also weder wechseln noch auf die neu hinzugekommene, saubere
+  -- Zuweisung (…004) springen.
+  v := 'unveraendert='||(pg_temp.legacy('d4000000-0000-0000-0000-000000000001') =
+          (select st.v from _state st where st.k='case1_legacy'))::text
+     ||'/nicht_der_neue='||(pg_temp.legacy('d4000000-0000-0000-0000-000000000001')
+          <> 'd2000000-0000-0000-0000-000000000004')::text
+     ||'/gedeckt='||(select (exists(select 1 from public.job_assignments ja
+          where ja.job_id=j.id and ja.employee_id=j.assigned_to))::text
+        from public.jobs j where j.id='d4000000-0000-0000-0000-000000000001');
+  insert into _r values (11,'Bestehender Primaer bleibt erhalten und springt nicht auf die neue Zuweisung',
+    'unveraendert=true/nicht_der_neue=true/gedeckt=true', v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: anonymisierte Zeile (Konto geloescht) ueberlebt den Mengenwechsel
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000005',
+    array['d2000000-0000-0000-0000-000000000008']::uuid[]);
+  execute 'reset role';
+
+  delete from auth.users where id='d2000000-0000-0000-0000-000000000008';
+
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000005',
+    array['d2000000-0000-0000-0000-000000000003']::uuid[]);
+  execute 'reset role';
+
+  v := 'zuw='||pg_temp.zuw('d4000000-0000-0000-0000-000000000005')
+       ||'/snapshot_erhalten='||(select count(*) from public.job_assignments
+            where job_id='d4000000-0000-0000-0000-000000000005' and employee_name_snapshot='Lars Loeschbar')::text;
+  insert into _r values (12,'Anonymisierte Zeile ueberlebt den Mengenwechsel',
+    'zuw=d2000000-0000-0000-0000-000000000003:assigned,ANON:assigned/snapshot_erhalten=1', v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- C. Lese-Policies
+-- =========================================================
+
+-- CASE 13: Admin liest Zuweisungen der EIGENEN Firma
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select count(*) into n from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  v := 'sichtbar='||n::text;
+  insert into _r values (13,'Admin liest Zuweisungen der eigenen Firma','sichtbar=3',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+-- CASE 14: Admin sieht KEINE Zuweisungen einer fremden Firma
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform set_config('request.jwt.claims', json_build_object('sub','d2000000-0000-0000-0000-000000000006','role','authenticated')::text, true);
+  select count(*) into n from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  v := 'sichtbar='||n::text;
+  insert into _r values (14,'Admin der Firma B sieht Zuweisungen der Firma A nicht','sichtbar=0',v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: Employee sieht ALLE Zuweisungen SEINES Auftrags (Variante B)
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select count(*) into n from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  v := 'sichtbar='||n::text;
+  insert into _r values (15,'Employee sieht alle Zuweisungen seines eigenen Auftrags (Variante B)','sichtbar=3',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: Employee sieht Kollegennamen OHNE profiles-Zugriff
+do $$
+declare v text; namen text; profil_sichtbar int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select string_agg(employee_name_snapshot, ',' order by employee_name_snapshot) into namen
+    from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000001';
+  -- profiles bleibt fuer Mitarbeiter auf die EIGENE Zeile beschraenkt
+  select count(*) into profil_sichtbar from public.profiles where id='d2000000-0000-0000-0000-000000000002';
+  execute 'reset role';
+  v := 'namen='||coalesce(namen,'-')||'/fremdes_profil_sichtbar='||profil_sichtbar::text;
+  insert into _r values (16,'Kollegennamen kommen aus dem Snapshot; profiles bleibt zu',
+    'namen=Anna Eins,Bert Zwei,Cora Drei/fremdes_profil_sichtbar=0', v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+-- CASE 17: Employee sieht KEINE Zuweisungen fremder Auftraege
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select count(*) into n from public.job_assignments where job_id='d4000000-0000-0000-0000-000000000005';
+  execute 'reset role';
+  v := 'sichtbar='||n::text;
+  insert into _r values (17,'Employee sieht Zuweisungen fremder Auftraege nicht','sichtbar=0',v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: Employee einer FREMDEN Firma sieht nichts
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000007');
+  execute 'set local role authenticated';
+  select count(*) into n from public.job_assignments;
+  execute 'reset role';
+  v := 'sichtbar='||n::text;
+  insert into _r values (18,'Employee der Firma B sieht keine Zuweisungen der Firma A','sichtbar=0',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: DEAKTIVIERTER Mitarbeiter verliert den Lesezugriff
+do $$
+declare v text; n int;
+begin
+  update public.profiles set is_active=false where id='d2000000-0000-0000-0000-000000000004';
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select count(*) into n from public.job_assignments;
+  execute 'reset role';
+  update public.profiles set is_active=true where id='d2000000-0000-0000-0000-000000000004';
+  v := 'sichtbar='||n::text;
+  insert into _r values (19,'Deaktivierter Mitarbeiter sieht keine Zuweisungen mehr','sichtbar=0',v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- CASE 20: anon hat keinerlei Tabellenrechte (ueber die Rechtevergabe geprueft)
+do $$
+declare v text;
+begin
+  v := 'anon_tabellenrechte='||coalesce((select string_agg(distinct privilege_type,'+')
+        from information_schema.role_table_grants
+        where table_schema='public' and table_name='job_assignments' and grantee='anon'),'KEINE');
+  insert into _r values (20,'anon: keine Tabellenrechte auf job_assignments','anon_tabellenrechte=KEINE',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: Employee-Policy ist REKURSIONSFREI
+--   Eine Policy AUF job_assignments, die job_assignments abfragt, waere
+--   ohne SECURITY-DEFINER-Helfer unendlich rekursiv (SQLSTATE 42P17).
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    select count(*) into n from public.job_assignments;
+    v := 'OK/sichtbar='||n::text;
+  exception when others then v := 'FEHLER('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (21,'Employee-Policy ohne RLS-Rekursion','OK/sichtbar=3',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- D. Schreibsperren fuer nicht-privilegierte Rollen
+-- =========================================================
+
+-- CASE 22: KEINE Schreibrechte fuer authenticated (weder Employee noch Admin)
+--   Die Verweigerung laeuft hier ueber das fehlende Privileg, greift also
+--   VOR jeder Policy-Auswertung und gilt fuer beide Rollen gleichermassen.
+do $$
+declare v text;
+begin
+  v := 'schreibrechte='||coalesce((select string_agg(distinct privilege_type,'+' order by privilege_type)
+        from information_schema.role_table_grants
+        where table_schema='public' and table_name='job_assignments'
+          and grantee='authenticated' and privilege_type in ('INSERT','UPDATE','DELETE')),'KEINE');
+  insert into _r values (22,'authenticated hat weder INSERT noch UPDATE noch DELETE','schreibrechte=KEINE',v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: es existiert AUCH KEINE Schreib-Policy (zweite Verriegelung)
+do $$
+declare v text;
+begin
+  v := 'schreib_policies='||(select count(*)::text from pg_policies
+        where schemaname='public' and tablename='job_assignments' and cmd <> 'SELECT')
+     ||'/select_policies='||(select count(*)::text from pg_policies
+        where schemaname='public' and tablename='job_assignments' and cmd = 'SELECT');
+  insert into _r values (23,'Keine INSERT/UPDATE/DELETE-Policy; genau zwei SELECT-Policies',
+    'schreib_policies=0/select_policies=2', v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+-- CASE 24: Policy-Helfer sind fuer Clients nicht aufrufbar
+do $$
+declare v text := '';
+begin
+  -- Policy-Helfer MUESSEN fuer authenticated ausfuehrbar sein (sonst ist die
+  -- Policy nicht auswertbar), duerfen anon aber nicht offenstehen.
+  v := 'helfer_auth='||(has_function_privilege('authenticated','public.is_assigned_to_job(uuid)','EXECUTE')
+                    and has_function_privilege('authenticated','public.job_in_current_company(uuid)','EXECUTE'))::text
+     ||'/helfer_anon='||(has_function_privilege('anon','public.is_assigned_to_job(uuid)','EXECUTE')
+                      or has_function_privilege('anon','public.job_in_current_company(uuid)','EXECUTE'))::text
+     ||'/rpc_auth='||has_function_privilege('authenticated','public.set_job_assignments(uuid,uuid[])','EXECUTE')::text
+     ||'/rpc_anon='||has_function_privilege('anon','public.set_job_assignments(uuid,uuid[])','EXECUTE')::text;
+  insert into _r values (24,'EXECUTE: Helfer fuer authenticated noetig, fuer anon gesperrt; RPC nur authenticated',
+    'helfer_auth=true/helfer_anon=false/rpc_auth=true/rpc_anon=false', v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: Tabellen-Grants — nur SELECT fuer authenticated, nichts fuer anon
+do $$
+declare v text;
+begin
+  select 'auth='||coalesce(string_agg(distinct privilege_type,'+' order by privilege_type),'KEINE')
+    into v
+  from information_schema.role_table_grants
+  where table_schema='public' and table_name='job_assignments' and grantee='authenticated';
+  v := v || '/anon='||coalesce((select string_agg(distinct privilege_type,'+') from information_schema.role_table_grants
+        where table_schema='public' and table_name='job_assignments' and grantee='anon'),'KEINE');
+  insert into _r values (25,'Grants: authenticated nur SELECT, anon keine','auth=SELECT/anon=KEINE',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- E. Zusammenspiel mit den Phase-2-Triggern
+-- =========================================================
+
+-- CASE 26: Primaer-Neuberechnung und keine doppelten Zeilen
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000002',
+    array['d2000000-0000-0000-0000-000000000003','d2000000-0000-0000-0000-000000000004']::uuid[]);
+  execute 'reset role';
+
+  v := 'legacy_gedeckt='||(select (j.assigned_to is null or exists(
+          select 1 from public.job_assignments ja where ja.job_id=j.id and ja.employee_id=j.assigned_to))::text
+        from public.jobs j where j.id='d4000000-0000-0000-0000-000000000002')
+     ||'/duplikate='||(select count(*)::text from (
+          select job_id, employee_id from public.job_assignments
+          where employee_id is not null group by 1,2 having count(*)>1) d);
+  insert into _r values (26,'Phase-2-Primaer gedeckt, keine doppelten Zuweisungen','legacy_gedeckt=true/duplikate=0',v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+-- CASE 27: Schreibverstaerkung ist durch die Mengengroesse begrenzt
+do $$
+declare v text; u0 bigint; u1 bigint;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  u0 := pg_temp.jobs_updates();
+  -- 2 vorhandene ersetzen durch 1 neuen => 2 DELETE + 1 INSERT = 3 Zeilen
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000002',
+    array['d2000000-0000-0000-0000-000000000002']::uuid[]);
+  u1 := pg_temp.jobs_updates();
+  execute 'reset role';
+  v := 'jobs_updates_hoechstens_6='||((u1-u0) <= 6)::text||'/gemessen='||(u1-u0)::text;
+  insert into _r values (27,'Schreibverstaerkung durch Mengengroesse begrenzt (nicht mengenbasiert)',
+    'jobs_updates_hoechstens_6=true/gemessen=' || (u1-u0)::text, v);
+  raise notice 'CASE 27 -> %', v;
+end $$;
+
+-- CASE 28: alter Client-Pfad (createJob/updateJob ueber assigned_to) bleibt intakt
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                           location_address, status, job_type, date, start_time, is_active)
+  values ('d4000000-0000-0000-0000-000000000009','d1000000-0000-0000-0000-000000000001',
+          'd2000000-0000-0000-0000-000000000002','d2000000-0000-0000-0000-000000000001',
+          'K9','S9','O9','open','single',current_date,'08:00',true);
+  update public.jobs set assigned_to='d2000000-0000-0000-0000-000000000003'
+   where id='d4000000-0000-0000-0000-000000000009';
+  execute 'reset role';
+  v := 'zuw='||pg_temp.zuw('d4000000-0000-0000-0000-000000000009')||'/legacy='||pg_temp.legacy('d4000000-0000-0000-0000-000000000009');
+  insert into _r values (28,'Alter Client-Pfad (createJob/updateJob) unveraendert funktionsfaehig',
+    'zuw=d2000000-0000-0000-0000-000000000003:assigned/legacy=d2000000-0000-0000-0000-000000000003', v);
+  raise notice 'CASE 28 -> %', v;
+end $$;
+
+-- CASE 29: Recurring-Parent und Occurrence verhalten sich unveraendert
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('d2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('d4000000-0000-0000-0000-000000000004',
+    array['d2000000-0000-0000-0000-000000000002']::uuid[]);
+  execute 'reset role';
+  v := 'parent_zuw='||pg_temp.zuw('d4000000-0000-0000-0000-000000000004')
+     ||'/parent_legacy='||pg_temp.legacy('d4000000-0000-0000-0000-000000000004')
+     ||'/occurrence_unveraendert='||(pg_temp.zuw('d4000000-0000-0000-0000-000000000005') =
+        'd2000000-0000-0000-0000-000000000003:assigned,ANON:assigned')::text;
+  insert into _r values (29,'Recurring-Parent erhaelt Vorlage; Occurrence bleibt unveraendert (Phase 4 offen)',
+    'parent_zuw=d2000000-0000-0000-0000-000000000002:assigned/parent_legacy=d2000000-0000-0000-0000-000000000002/occurrence_unveraendert=true', v);
+  raise notice 'CASE 29 -> %', v;
+end $$;
+
+-- CASE 30: Invariante ueber alle Testauftraege
+do $$
+declare v text;
+begin
+  select 'verletzungen='||count(*)::text into v
+  from public.jobs j
+  where j.assigned_to is not null
+    and not exists (select 1 from public.job_assignments ja
+                    where ja.job_id=j.id and ja.employee_id=j.assigned_to);
+  insert into _r values (30,'Invariante: assigned_to IS NULL ODER durch Zuweisung gedeckt','verletzungen=0',v);
+  raise notice 'CASE 30 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _r order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _r where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'JOB ASSIGNMENTS RLS TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 30 FAELLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 3 von 11. **Reine Datenschicht** — kein App-Code, keine Änderung an `jobs`, an `assigned_to` oder an der Phase-2-Kompatibilitätsschicht. Öffnet die seit Phase 1 fail-closed Tabelle exakt so weit, wie die späteren Phasen brauchen.

## Architektur-Befund

| Bereich | Stand |
|---|---|
| Autorisierung | ausschließlich über `current_user_role()` / `current_user_company_id()` — beide liefern seit `20260714000000` **NULL für inaktive Profile**, wodurch jede darauf aufbauende Policy automatisch fail-closed ist |
| `jobs`-Policies | 6: Admin SELECT/INSERT/UPDATE/DELETE firmenweit; Employee SELECT (`job_type='single' AND assigned_to=auth.uid()`); Employee UPDATE |
| `profiles` | Admin liest eigene Firma; **Employee liest ausschließlich die eigene Zeile** |
| `job_assignments` vorher | RLS an, **0 Policies**, Grants nur `service_role` |
| Schreibpfade auf `jobs` | `createJob` (INSERT), `updateJob` (UPDATE), `generate_job_occurrences`, `update_job_occurrences` (mengenbasiert) |
| `start_own_job`/`complete_own_job` | lesen `assigned_to` nur in der WHERE-Klausel |
| Konto-Löschung | `employee_id → NULL` (SET NULL), Snapshot bleibt |
| SECURITY DEFINER auf jobs/job_assignments | 11 Funktionen; die Phase-2-Trigger umgehen RLS per Design |

## Gewähltes Lesemodell: Variante B

Ein Mitarbeiter sieht **alle** Zuweisungen der Aufträge, denen er selbst zugewiesen ist.

Das ist hier die **schmalere** Öffnung, auch wenn es zunächst umgekehrt wirkt: Variante A („nur die eigene Zeile") könnte die Namen der Kolleginnen und Kollegen nur aus `public.profiles` beziehen — und dort darf ein Employee heute ausschließlich die **eigene** Zeile lesen. Variante A hätte also eine Ausweitung der `profiles`-Policy erzwungen. Variante B braucht `profiles` überhaupt nicht, weil `employee_name_snapshot` bereits auf der Zuweisungszeile steht (Phase 1, ursprünglich für Konto-Löschungen).

Offengelegte Zusatzinformation, vollständig: id, Namens-Schnappschuss und Anwesenheits-/Review-Zustand der Kolleg:innen auf **genau den** Aufträgen, denen der Mitarbeiter selbst zugewiesen ist. Nichts firmenweit, nichts über fremde Aufträge, nichts über andere Firmen. Testfall 16 belegt beides: Namen sichtbar, `profiles` bleibt zu.

## RPC statt direkter Schreib-Policies

Ausschlaggebend ist nicht die Validierung (die könnte eine Policy leisten), sondern **Atomarität**: eine Mengenänderung ist entfernen **und** hinzufügen, über REST also zwei Transaktionen. Im Fenster dazwischen rechnet die Phase-2-Schicht den Primär neu, schreibt `jobs.assigned_to` womöglich auf `NULL` und löst ein Realtime-Event aus — alte Clients zeigen den Auftrag dann als „nicht zugewiesen". Bricht der Client zwischen den Requests ab, bleibt der Zustand dauerhaft falsch.

Nur eine RPC kann außerdem die Auftragszeile **vorab sperren** (gleiche Sperrreihenfolge wie Phase 2 und `update_job_occurrences`, daher kein Deadlock) und die **gesamte Zielmenge vor dem ersten Schreibvorgang** validieren — ein ungültiger Eintrag führt zu null Änderungen statt zu einer halb angewandten Menge.

**UPDATE bleibt vollständig gesperrt.** Anwesenheit schreibt ab Phase 7 die start/complete-RPC, das Review ab Phase 10 eine eigene RPC — beide SECURITY DEFINER, beide ohne UPDATE-Policy. Eine Policy „auf Vorrat" wäre unbenutzte Angriffsfläche und würde Manipulation von `review`/`reviewed_by`/`employee_name_snapshot` erlauben.

## Erstellte Objekte

**Funktionen:** `job_in_current_company(uuid) → boolean`, `is_assigned_to_job(uuid) → boolean`, `set_job_assignments(uuid, uuid[]) → setof job_assignments`
**Policies:** `admin read assignments in own company`, `employee read assignments on assigned jobs` — **keine** INSERT/UPDATE/DELETE-Policy
**Grants:** `SELECT` für `authenticated`; `anon` weiterhin komplett rechtelos

## Zwei Erkenntnisse, die Review verdienen

**1. Policy-Helfer müssen für die Rollen der Policy ausführbar sein.** Der erste Entwurf entzog EXECUTE analog zu den internen Trigger-Funktionen aus Phase 1/2. Das ist falsch: Policy-Ausdrücke werden im Rechtekontext des **Aufrufers** ausgewertet, die Policy war damit nicht auswertbar. Genau deshalb sind auch die bestehenden `current_user_role()` / `current_user_company_id()` für `authenticated` ausführbar. Der EXECUTE-Entzug ist die richtige Härtung für Trigger- und Dispatcher-Funktionen, **nicht** für Policy-Helfer.

Daraus folgte eine zweite Korrektur: `job_company_id → uuid` wurde durch `job_in_current_company → boolean` ersetzt. Da die Funktion für Clients aufrufbar sein muss, hätte eine zurückgegebene `company_id` verraten, welcher Firma ein beliebiger (erratener) Auftrag gehört. Die Boolean-Variante beantwortet nur „gehört das zu **meiner** Firma?".

**2. Nebenbefund zur Umgebung, ausdrücklich NICHT zu diesem Schema.** Der lokale Supabase-Container (PostgreSQL 17.6, aarch64) stürzt bei **jedem** permission-denied-Fehler mit `signal 11` ab, statt eine saubere Fehlermeldung zu liefern. Reproduzierbar auch mit dem völlig unbeteiligten `pg_read_file()` und mit dem seit Monaten produktiven `fanout_notification_events()` — also weder von dieser Migration verursacht noch ein Schemafehler.

Produktion läuft auf derselben Version und Architektur. Ich habe den Effekt dort **bewusst nicht nachgestellt**: ein Segfault startet den Postmaster neu und trennt sämtliche Verbindungen. Gegen eine echte Produktionswirkung spricht stark, dass jeder eingeloggte Nutzer die Datenbank sonst trivial per verweigertem Funktionsaufruf zum Absturz bringen könnte — das wäre längst aufgefallen. **Empfehlung:** vor dem Deploy einmal auf einer Branch-/Staging-Datenbank verifizieren.

Betroffene Testfälle weisen die Verweigerung deshalb über die Rechtevergabe nach (`has_function_privilege` / `role_table_grants` / `pg_policies`) statt über einen echten Aufruf. Für dieses Design ist das ohnehin die passende Zusicherung: die Verweigerung **ist** hier die fehlende Rechtevergabe, die vor jeder Policy-Auswertung greift.

## Trigger-Zusammenspiel

- Jede geschriebene Zeile löst `compat_sync_legacy_from_assignments()` aus; die RPC hält die Auftragszeile bereits gesperrt → derselbe Lock, kein Deadlock.
- Keine Rekursion: die RPC schreibt nur `job_assignments`, der Rückweg läuft über den Trigger, dessen Gegenrichtung das transaktionslokale Sync-Flag absichert.
- Keine Duplikate, Primär stets gedeckt (Fälle 26, 30).
- **Bekannte, begrenzte Schreibverstärkung:** die Trigger sind zeilenbasiert, eine Mengenänderung mit n Zeilen löst bis zu n Primär-Neuberechnungen aus — begrenzt durch die Größe der Zuweisungsmenge, also einstellig pro Admin-Aktion, keine Mengenoperation (Fall 27). Bewusst nicht optimiert, weil eine Unterdrückung das interne Flag der Phase 2 von außen setzen und beide Phasen fest aneinanderkoppeln würde; zusammengeführt in Phase 6.
- Die Phase-2-Trigger umgehen als SECURITY DEFINER die RLS. Diese Migration verlässt sich an keiner Stelle darauf — die Eingabevalidierung liegt vollständig in der RPC, also **vor** der Trigger-Ausführung.

## Tests

**Neue Suite `job_assignments_rls.test.sql` — 30/30 PASS**, alle Zugriffe über echte Rollen (`SET ROLE` + JWT-Claims), also über denselben Pfad wie die App.

RPC (1–9): Menge setzen · Duplikate/NULL entdupliziert · leere Menge · fremde Firma abgelehnt ohne Teiländerung · inaktiv abgelehnt · Admin-Profil abgelehnt · fremder Auftrag abgelehnt · Employee abgelehnt · anon ohne EXECUTE.
Nachweise (10–12): Anwesenheit und Review überleben den Mengenwechsel · Primär springt nicht auf die neue Zuweisung · anonymisierte Zeile überlebt.
Lesen (13–21): Admin eigene Firma / nicht fremde · Employee Variante B · **Namen aus dem Snapshot, `profiles` bleibt zu** · fremde Aufträge unsichtbar · fremde Firma unsichtbar · **deaktivierter Mitarbeiter verliert den Zugriff** · anon rechtelos · **Policy rekursionsfrei**.
Sperren (22–25): keine Schreibrechte, keine Schreib-Policy, Helfer-/RPC-EXECUTE korrekt, Tabellen-Grants korrekt.
Trigger (26–30): Primär gedeckt, keine Duplikate · Schreibverstärkung begrenzt · **alter Client-Pfad unverändert** · Recurring-Parent/Occurrence unverändert · Invariante.

Fälle 1 und 11 prüfen bewusst **deterministische Eigenschaften** statt einer konkreten Mitarbeiter-ID: bei gleichzeitig angelegten Zuweisungen ist `assigned_at` identisch und der id-Tiebreaker eine zufällige UUID (so in Phase 2 dokumentiert). Vor der Umstellung war der Test nachweislich flaky (1 von 5 Läufen abweichend), danach 6 Läufe stabil.

**Regression: 187/187 grün** über 9 Suiten. `tsc --noEmit` und `expo lint` sauber. Vollständiger `supabase db reset` wendet alle 19 Migrationen fehlerfrei an.

### Anpassung am Phase-1-Test (bitte mitprüfen)

`job_assignments.test.sql` Fall 23 prüfte `grants=0` für anon **und** authenticated. Phase 3 vergibt bewusst SELECT an authenticated, damit die Lese-Policies überhaupt greifen. Der Fall prüft jetzt die phasenübergreifend gültige Zusicherung: RLS aktiv, **anon rechtelos**, **authenticated ohne jedes Schreibrecht**. Damit ist die Aussage eher stärker als vorher.

## Bewusst nicht enthalten

Keine Verbreiterung der Policies von `jobs`/`job_comments`/`job_photos`/`job_comment_reads`/`storage.objects` auf Mehrfachzuweisung — das ändert, **welche Aufträge** ein Mitarbeiter überhaupt sieht, und gehört zum App-Lesepfad (Phase 5). Keine Propagierung von Zuweisungs-Mengen auf Occurrences (Phase 4). **Nicht auf Produktion angewandt, nicht gemerged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)