### PR TITLE
feat(db): Vererbung und Anpassung von Zuweisungen auf Terminen (Phase 4/11)

### DIFF
--- a/supabase/migrations/20260728000000_occurrence_assignment_inheritance.sql
+++ b/supabase/migrations/20260728000000_occurrence_assignment_inheritance.sql
@@ -1,0 +1,757 @@
+-- =========================================================
+-- MIGRATION: Vererbung und Anpassung von Zuweisungen auf Occurrences
+-- Datum: 2026-07-28   (Phase 4 von 11 — reine Datenschicht)
+-- =========================================================
+-- ZWECK
+--   Zuweisungsmengen auf generierten Terminen (Occurrences) dauerhaft und
+--   vorhersagbar machen. Ein Admin muss EINEN Termin individuell anpassen
+--   koennen, ohne dass eine spaetere Regel-Aenderung diese Anpassung
+--   still ueberschreibt.
+--
+-- =========================================================
+-- BEFUND: EXAKTE URSACHE (reproduziert, nicht vermutet)
+-- =========================================================
+-- Ausgangslage: Regel R ist Mitarbeiter P zugewiesen, Occurrence O erbt P.
+-- Der Admin passt O individuell auf {A, B} an. Danach aendert er an der
+-- REGEL nur den Kundennamen und ruft update_job_occurrences auf.
+--
+-- Beobachtetes Ergebnis (5 Laeufe): {A,P} / {B,P} / {A,P} / {B,P} / {A,P}
+--
+-- Ablauf im Detail:
+--   1. Der SYNC-Block von update_job_occurrences setzt auf jeder
+--      zukuenftigen offenen Occurrence
+--          assigned_to = effective_assigned_to   (= P)
+--      und zwar bereits dann, wenn IRGENDEIN Feld der Regel abweicht —
+--      im Beispiel nur customer_name.
+--   2. Dieses UPDATE loest den Phase-2-Trigger
+--      compat_sync_assignments_from_legacy (Richtung A) aus. Dieser
+--      loescht die SAUBERE Zuweisung von OLD.assigned_to und legt eine
+--      Zuweisung fuer NEW.assigned_to an.
+--   3. OLD.assigned_to ist der von Phase 2 bestimmte PRIMAER der
+--      angepassten Menge. Welcher der beiden das ist, entscheidet bei
+--      gleichem assigned_at der zufaellige id-Tiebreaker.
+--
+-- Folge: Von der individuellen Menge {A,B} wird GENAU EIN Mitarbeiter
+-- geloescht — nicht deterministisch welcher — und der Regel-Mitarbeiter
+-- P wieder hinzugefuegt. Es ist also weder ein sauberes Ueberschreiben
+-- noch ein sauberes Bewahren, sondern ein nicht reproduzierbarer
+-- Mischzustand, ausgeloest durch eine voellig unbeteiligte Feldaenderung.
+--
+-- =========================================================
+-- ENTSCHEIDUNG: Occurrence-weite Anpassungs-Markierung (Variante D)
+-- =========================================================
+-- Bewertet wurden:
+--
+--   A) Boolean-Spalte auf public.jobs
+--      Funktioniert fachlich, fasst aber die am staerksten belastete
+--      Tabelle an, die zusaetzlich Teil der supabase_realtime-Publication
+--      ist, und traegt keinerlei Audit-Information (wer/wann).
+--
+--   B) Herkunfts-Metadatum je job_assignments-Zeile ('inherited'|'manual')
+--      ABGELEHNT — hat eine echte Luecke: Passt ein Admin einen Termin auf
+--      die LEERE Menge an ("heute niemand"), existiert keine einzige Zeile
+--      mehr, die die Markierung tragen koennte. Der Termin saehe wieder wie
+--      "geerbt" aus und die naechste Regel-Aenderung wuerde ihn neu
+--      befuellen. Genau die geforderte Eigenschaft 3 waere damit fuer den
+--      Leerfall verletzt. Die Zugehoerigkeit "folgt der Regel" ist eine
+--      Eigenschaft des TERMINS, nicht der einzelnen Zuweisungszeile.
+--
+--   C) Dedizierter Modus/Status je Occurrence
+--      Fachlich korrekt und identisch zur gewaehlten Loesung; D ist die
+--      konkrete Umsetzung davon.
+--
+--   D) GEWAEHLT — eigene Tabelle job_occurrence_assignment_overrides
+--      Vorhandensein einer Zeile = individuell angepasst.
+--      Fehlen der Zeile      = folgt der Regel.
+--      * korrekte Granularitaet (Termin-Ebene), deckt auch die leere Menge
+--      * public.jobs bleibt vollstaendig unveraendert — keine neue Spalte,
+--        keine Aenderung an Realtime-Payloads, keine Auswirkung auf die
+--        bestehenden Client-Abfragen
+--      * Audit (wer/wann) ohne Zusatzaufwand enthalten
+--      * Rueckbau = Tabelle loeschen; nichts anderes verweist darauf
+--
+-- =========================================================
+-- ZUSAETZLICHE KORREKTUR: assigned_to verlaesst den SYNC-Block
+-- =========================================================
+-- Die eigentliche Beschaedigung entsteht dadurch, dass die Regel-Synchro-
+-- nisierung die LEGACY-Spalte schreibt und damit den Phase-2-Trigger als
+-- Mengen-Mutator missbraucht. Deshalb faellt assigned_to aus dem
+-- SYNC-UPDATE heraus. Stattdessen wird die ZUWEISUNGSMENGE direkt
+-- abgeglichen (inherit_occurrence_assignments), und die Legacy-Spalte
+-- leitet wie gehabt allein die Phase-2-Richtung B ab. Damit bleibt genau
+-- EINE Stelle fuer die Bestimmung des primaeren Mitarbeiters.
+--
+-- Fuer den Einzel-Mitarbeiter-Fall (heutiger Produktionszustand) ist das
+-- verhaltensgleich: die Regel hat genau eine Zuweisung, der Termin erhaelt
+-- genau diese, und assigned_to zeigt danach auf denselben Mitarbeiter wie
+-- zuvor.
+--
+-- =========================================================
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   * Keine Aenderung an public.jobs (Spalten, Policies, assigned_to).
+--   * Keine Verbreiterung der RLS von jobs/job_comments/job_photos/
+--     storage.objects.
+--   * Keine Aenderung an Benachrichtigungen.
+--   * Keine Aenderung an der offiziellen Zeit-Semantik
+--     (jobs.started_at/completed_at bleiben unberuehrt).
+--   * Keine App-/UI-Aenderung.
+--   * Kein Backfill: bestehende Termine gelten alle als "folgt der Regel",
+--     was exakt dem heutigen Verhalten entspricht.
+--
+-- ANWENDUNG: manuell im Supabase SQL Editor (siehe CLAUDE.md).
+-- Diese Migration wurde NICHT auf Produktion oder Staging ausgefuehrt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Markierungstabelle
+-- ---------------------------------------------------------
+create table if not exists public.job_occurrence_assignment_overrides (
+  -- Termin, dessen Zuweisungsmenge individuell angepasst wurde.
+  -- ON DELETE CASCADE: wird der Termin (z. B. vom PRUNE-Block) entfernt,
+  -- verschwindet die Markierung mit ihm.
+  job_id        uuid primary key references public.jobs(id) on delete cascade,
+  customized_at timestamptz not null default now(),
+  -- ON DELETE SET NULL, damit eine Konto-Loeschung nicht blockiert wird
+  -- (gleiche Begruendung wie bei job_assignments.reviewed_by).
+  customized_by uuid references public.profiles(id) on delete set null
+);
+
+comment on table public.job_occurrence_assignment_overrides is
+'Markiert Termine (Occurrences), deren Zuweisungsmenge individuell angepasst '
+'wurde. Vorhandene Zeile = die Regel-Synchronisierung fasst die Zuweisungen '
+'dieses Termins NICHT mehr an. Fehlende Zeile = Termin folgt der Regel. '
+'Absichtlich eine eigene Tabelle statt einer Spalte auf jobs: deckt auch die '
+'leere Zuweisungsmenge ab, laesst jobs unveraendert und traegt Audit-Daten.';
+
+comment on column public.job_occurrence_assignment_overrides.customized_by is
+'Admin, der die Anpassung vorgenommen hat. Ohne NOT-NULL-Kopplung, damit eine '
+'Konto-Loeschung (ON DELETE SET NULL) nicht fehlschlaegt.';
+
+create index if not exists idx_job_occ_overrides_customized_by
+  on public.job_occurrence_assignment_overrides (customized_by)
+  where customized_by is not null;
+
+-- Zugriff: wie in Phase 3 — Lesen fuer Admins der eigenen Firma (die
+-- spaetere Oberflaeche muss "individuell angepasst" anzeigen koennen),
+-- Schreiben ausschliesslich ueber die RPCs unten.
+alter table public.job_occurrence_assignment_overrides enable row level security;
+
+-- WICHTIG: Supabase vergibt auf NEUE Tabellen im public-Schema per
+-- Default-Privilegien automatisch ALLE Rechte an anon UND authenticated
+-- (SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER). Ein
+-- blosses "grant select" haerten hier NICHTS — die Schreibrechte blieben
+-- bestehen und ein beliebiger eingeloggter Nutzer koennte die Markierungen
+-- direkt setzen, loeschen oder die Tabelle leeren und damit die gesamte
+-- Anpassungs-Garantie aushebeln. Deshalb zuerst vollstaendig ENTZIEHEN und
+-- danach gezielt nur SELECT vergeben — exakt wie in Phase 1 fuer
+-- job_assignments (20260725000000).
+revoke all on public.job_occurrence_assignment_overrides from anon, authenticated;
+grant select on public.job_occurrence_assignment_overrides to authenticated;
+
+drop policy if exists "admin read occurrence overrides in own company"
+  on public.job_occurrence_assignment_overrides;
+create policy "admin read occurrence overrides in own company"
+on public.job_occurrence_assignment_overrides
+for select
+to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and public.job_in_current_company(job_id)
+);
+-- KEINE INSERT/UPDATE/DELETE-Policy und kein Schreibrecht: die Markierung
+-- setzt ausschliesslich set_job_assignments bzw. entfernt sie
+-- reset_job_occurrence_assignments.
+
+
+-- ---------------------------------------------------------
+-- 2. Mengenabgleich Regel -> Termine
+-- ---------------------------------------------------------
+-- Gleicht die Zuweisungsmenge aller NICHT angepassten, zukuenftigen,
+-- offenen und noch nicht gestarteten Termine einer Regel an die Menge der
+-- Regel an. p_only_job_id begrenzt den Abgleich auf einen einzelnen Termin
+-- (verwendet vom Zuruecksetzen).
+--
+-- SECURITY DEFINER: schreibt job_assignments, worauf normale Clients
+-- bewusst kein Schreibrecht haben. Die Funktion nimmt keine Nutzereingabe
+-- ausser IDs entgegen und wird nur aus bereits autorisierten RPCs
+-- aufgerufen; EXECUTE wird unten vollstaendig entzogen.
+--
+-- HISTORIE: Entfernt werden ausschliesslich SPURENFREIE Zeilen. Alles mit
+-- Anwesenheit, Zeitstempeln, Review oder anonymisierter Herkunft
+-- (employee_id IS NULL) bleibt unangetastet — unabhaengig davon, ob der
+-- Termin geerbt oder angepasst ist.
+create or replace function public.inherit_occurrence_assignments(
+  p_parent_job_id uuid,
+  p_only_job_id   uuid default null
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor    uuid;
+  v_inserted int := 0;
+begin
+  select p.id into v_actor
+  from public.profiles p
+  where p.id = auth.uid();
+
+  -- ── 1) Ueberzaehlige SAUBERE Zuweisungen entfernen ──────────────
+  delete from public.job_assignments d
+  where d.employee_id           is not null
+    and d.attendance             = 'assigned'
+    and d.review                is null
+    and d.employee_started_at   is null
+    and d.employee_completed_at is null
+    and d.job_id in (
+      select c.id
+      from public.jobs c
+      where c.parent_job_id = p_parent_job_id
+        and (p_only_job_id is null or c.id = p_only_job_id)
+        and c.date        >= current_date
+        and c.status       = 'open'
+        and c.started_at  is null
+        and c.completed_at is null
+        and not exists (
+          select 1 from public.job_occurrence_assignment_overrides o
+          where o.job_id = c.id
+        )
+    )
+    and not exists (
+      -- gehoert nicht (mehr) zur aktiven Zuweisungsmenge der Regel
+      select 1
+      from public.job_assignments pa
+      join public.profiles pp on pp.id = pa.employee_id
+      join public.jobs      pj on pj.id = pa.job_id
+      where pa.job_id       = p_parent_job_id
+        and pa.employee_id  = d.employee_id
+        and pp.is_active    = true
+        and pp.role         = 'employee'
+        and pp.company_id   = pj.company_id
+    );
+
+  -- ── 2) Fehlende Zuweisungen ergaenzen ───────────────────────────
+  insert into public.job_assignments (
+    job_id, employee_id, employee_name_snapshot, assigned_by
+  )
+  select
+    c.id,
+    pa.employee_id,
+    coalesce(nullif(btrim(pp.full_name), ''), 'Unbekannt'),
+    v_actor
+  from public.jobs c
+  join public.job_assignments pa on pa.job_id = p_parent_job_id
+  join public.profiles       pp on pp.id      = pa.employee_id
+  join public.jobs           pj on pj.id      = pa.job_id
+  where c.parent_job_id = p_parent_job_id
+    and (p_only_job_id is null or c.id = p_only_job_id)
+    and c.date        >= current_date
+    and c.status       = 'open'
+    and c.started_at  is null
+    and c.completed_at is null
+    and not exists (
+      select 1 from public.job_occurrence_assignment_overrides o
+      where o.job_id = c.id
+    )
+    and pa.employee_id is not null
+    and pp.is_active   = true
+    and pp.role        = 'employee'
+    and pp.company_id  = pj.company_id
+  -- Doppelte Zuweisungszeilen sind damit strukturell ausgeschlossen.
+  on conflict (job_id, employee_id) do nothing;
+
+  get diagnostics v_inserted = row_count;
+  return v_inserted;
+end;
+$$;
+
+comment on function public.inherit_occurrence_assignments(uuid, uuid) is
+'Gleicht die Zuweisungsmenge nicht angepasster, zukuenftiger, offener Termine '
+'an die aktive Menge der Regel an. Entfernt ausschliesslich spurenfreie Zeilen '
+'und legt fehlende an (ON CONFLICT DO NOTHING). Interne Hilfsfunktion — nur aus '
+'autorisierten RPCs aufrufbar.';
+
+revoke all on function public.inherit_occurrence_assignments(uuid, uuid) from public;
+revoke all on function public.inherit_occurrence_assignments(uuid, uuid) from anon, authenticated;
+
+
+-- ---------------------------------------------------------
+-- 3. generate_job_occurrences: neue Termine erben die MENGE
+-- ---------------------------------------------------------
+-- Unveraendert gegenueber 20260714000000, mit EINER Ergaenzung am Ende:
+-- nach dem Erzeugen wird die Zuweisungsmenge der Regel auf die neuen
+-- (per Definition nicht angepassten) Termine uebertragen. Der INSERT
+-- selbst setzt weiterhin assigned_to = effective_assigned_to, damit die
+-- Legacy-Spalte zu keinem Zeitpunkt unbelegt ist.
+create or replace function public.generate_job_occurrences(
+  parent_job_id_input uuid
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  parent                public.jobs%rowtype;
+  generation_start      date;
+  generation_end        date;
+  hard_limit            date;
+  check_date            date;
+  day_code              text;
+  inserted_count        int := 0;
+  rows_affected         int;
+  effective_assigned_to uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can generate occurrences';
+  end if;
+
+  select * into parent
+  from public.jobs
+  where id          = parent_job_id_input
+    and company_id  = public.current_user_company_id()
+    and job_type    = 'recurring'
+    and parent_job_id is null;
+
+  if not found then
+    raise exception 'Recurring parent job not found or not accessible';
+  end if;
+
+  select case
+    when parent.assigned_to is not null
+      and exists (
+        select 1 from public.profiles p
+        where p.id = parent.assigned_to
+          and p.is_active = true
+      )
+    then parent.assigned_to
+    else null
+  end
+  into effective_assigned_to;
+
+  generation_start := greatest(
+    coalesce(parent.recurrence_start_date, current_date),
+    current_date
+  );
+
+  hard_limit := generation_start + interval '730 days';
+
+  generation_end := least(
+    case
+      when parent.recurrence_end_date is not null
+        then parent.recurrence_end_date
+      else generation_start + interval '3 months'
+    end,
+    hard_limit
+  );
+
+  check_date := generation_start;
+  while check_date <= generation_end loop
+
+    day_code := case extract(isodow from check_date)::int
+      when 1 then 'mon'
+      when 2 then 'tue'
+      when 3 then 'wed'
+      when 4 then 'thu'
+      when 5 then 'fri'
+      when 6 then 'sat'
+      when 7 then 'sun'
+    end;
+
+    if parent.recurring_days @> array[day_code] then
+      insert into public.jobs (
+        company_id, parent_job_id, customer_name, service_name,
+        location_address, notes, status, assigned_to,
+        job_type, date, start_time, scheduled_start, is_active, created_by
+      )
+      values (
+        parent.company_id, parent.id, parent.customer_name, parent.service_name,
+        parent.location_address, parent.notes, 'open', effective_assigned_to,
+        'single', check_date, parent.start_time,
+        case
+          when parent.start_time is not null
+          then (check_date::text || ' ' || parent.start_time::text)::timestamptz
+          else null
+        end,
+        parent.is_active, parent.created_by
+      )
+      on conflict (parent_job_id, date, start_time)
+        where parent_job_id is not null
+      do nothing;
+
+      get diagnostics rows_affected = row_count;
+      inserted_count := inserted_count + rows_affected;
+    end if;
+
+    check_date := check_date + 1;
+  end loop;
+
+  -- NEU (Phase 4): vollstaendige Zuweisungsmenge der Regel auf die nicht
+  -- angepassten Termine uebertragen. Ohne diesen Schritt erbte ein neuer
+  -- Termin weiterhin nur den einzelnen Legacy-Mitarbeiter.
+  perform public.inherit_occurrence_assignments(parent_job_id_input);
+
+  return inserted_count;
+end;
+$$;
+
+comment on function public.generate_job_occurrences(uuid) is
+'Erzeugt konkrete Single-Jobs aus einer Recurring-Regel. Zeitraum aus '
+'recurrence_start/end_date, hartes Maximum 730 Tage, idempotent. Weist keine '
+'Occurrence einem inaktiven Mitarbeiter zu. Uebertraegt seit Phase 4 die '
+'vollstaendige Zuweisungsmenge der Regel auf nicht angepasste Termine.';
+
+
+-- ---------------------------------------------------------
+-- 4. update_job_occurrences: assigned_to raus, Mengenabgleich rein
+-- ---------------------------------------------------------
+-- Unveraendert gegenueber 20260723000004 in PRUNE und GENERATE. Geaendert:
+--   * SYNC schreibt assigned_to NICHT mehr (Ursache der Beschaedigung).
+--   * Danach laeuft der Mengenabgleich, der angepasste Termine ausspart.
+create or replace function public.update_job_occurrences(
+  parent_job_id_input uuid
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  parent    public.jobs%rowtype;
+  new_count int;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can update occurrences';
+  end if;
+
+  -- Parent laden UND sperren: serialisiert konkurrierende Aufrufe fuer
+  -- dieselbe Regel. Diese Sperre ist zugleich die erste Stufe der
+  -- Sperrreihenfolge Parent -> Termin, an die sich set_job_assignments
+  -- haelt (siehe dort) — dadurch sind Deadlocks ausgeschlossen.
+  select * into parent
+  from public.jobs
+  where id         = parent_job_id_input
+    and company_id = public.current_user_company_id()
+    and job_type   = 'recurring'
+    and parent_job_id is null
+  for update;
+
+  if not found then
+    raise exception 'Recurring parent job not found';
+  end if;
+
+  -- ── 1) PRUNE ──────────────────────────────────────────────────────
+  -- Unveraendert: nur zukuenftige, nachweislich unberuehrte Termine, die
+  -- nicht mehr zur Regel passen. Historie schuetzt die Zeile immer.
+  delete from public.jobs c
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and not exists (select 1 from public.job_comments      x where x.job_id = c.id)
+    and not exists (select 1 from public.job_photos        x where x.job_id = c.id)
+    and not exists (select 1 from public.job_comment_reads x where x.job_id = c.id)
+    and (
+          not (parent.recurring_days @> array[
+            case extract(isodow from c.date)::int
+              when 1 then 'mon' when 2 then 'tue' when 3 then 'wed'
+              when 4 then 'thu' when 5 then 'fri' when 6 then 'sat'
+              when 7 then 'sun'
+            end
+          ])
+          or c.start_time is distinct from parent.start_time
+          or (parent.recurrence_end_date   is not null and c.date > parent.recurrence_end_date)
+          or (parent.recurrence_start_date is not null and c.date < parent.recurrence_start_date)
+        );
+
+  -- ── 2) SYNC (OHNE assigned_to) ────────────────────────────────────
+  -- assigned_to wurde hier bewusst entfernt. Frueher schrieb dieser
+  -- Block die Legacy-Spalte und loeste damit den Phase-2-Trigger als
+  -- Mengen-Mutator aus, der genau einen Mitarbeiter der individuell
+  -- angepassten Menge loeschte (siehe Ursachenanalyse oben). Die
+  -- Zuweisungen regelt jetzt ausschliesslich Schritt 3.
+  update public.jobs c
+  set
+    customer_name    = parent.customer_name,
+    service_name     = parent.service_name,
+    location_address = parent.location_address,
+    notes            = parent.notes,
+    is_active        = parent.is_active
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and (
+         c.customer_name    is distinct from parent.customer_name
+      or c.service_name     is distinct from parent.service_name
+      or c.location_address is distinct from parent.location_address
+      or c.notes            is distinct from parent.notes
+      or c.is_active        is distinct from parent.is_active
+    );
+
+  -- ── 3) ZUWEISUNGSMENGE abgleichen ─────────────────────────────────
+  -- Nur fuer NICHT angepasste Termine. jobs.assigned_to wird dabei nicht
+  -- direkt geschrieben — die Phase-2-Richtung B leitet den primaeren
+  -- Mitarbeiter aus der resultierenden Menge ab.
+  perform public.inherit_occurrence_assignments(parent_job_id_input);
+
+  -- ── 4) GENERATE ───────────────────────────────────────────────────
+  select public.generate_job_occurrences(parent_job_id_input)
+  into new_count;
+
+  return new_count;
+end;
+$$;
+
+comment on function public.update_job_occurrences(uuid) is
+'Nicht-destruktiv: prunt nur unberuehrte, nicht mehr passende Zukunfts-Termine, '
+'synct Nicht-Termin-Felder (OHNE assigned_to) und gleicht die Zuweisungsmenge '
+'nicht angepasster Termine an die Regel an. Individuell angepasste Termine '
+'behalten ihre Zuweisungen. Bewahrt in_progress/completed, Zeitstempel, '
+'Kommentare, Fotos und Lesestatus.';
+
+
+-- ---------------------------------------------------------
+-- 5. set_job_assignments: Termin als angepasst markieren
+-- ---------------------------------------------------------
+-- Unveraendert gegenueber 20260727000000 bis auf zwei Ergaenzungen:
+--   a) Ist der Auftrag ein Termin, wird ZUERST die Regel-Zeile gesperrt
+--      und danach der Termin. Gleiche Reihenfolge wie
+--      update_job_occurrences (Parent -> Kind) => kein Deadlock.
+--   b) Nach erfolgreicher Aenderung wird der Termin als individuell
+--      angepasst markiert.
+create or replace function public.set_job_assignments(
+  p_job_id       uuid,
+  p_employee_ids uuid[] default '{}'::uuid[]
+)
+returns setof public.job_assignments
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company uuid;
+  v_parent  uuid;
+  v_ids     uuid[];
+  v_invalid int;
+  v_actor   uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can change job assignments' using errcode = '42501';
+  end if;
+
+  -- (a) Sperrreihenfolge: bei einem Termin zuerst die Regel sperren.
+  -- parent_job_id ist fuer eine bestehende Zeile unveraenderlich, das
+  -- Lesen vor dem Sperren ist daher unkritisch.
+  select j.parent_job_id into v_parent
+  from public.jobs j
+  where j.id = p_job_id;
+
+  if v_parent is not null then
+    perform 1 from public.jobs where id = v_parent for update;
+  end if;
+
+  select j.company_id
+    into v_company
+  from public.jobs j
+  where j.id         = p_job_id
+    and j.company_id = public.current_user_company_id()
+  for update;
+
+  if not found then
+    raise exception 'Job not found or not accessible' using errcode = '42501';
+  end if;
+
+  select coalesce(array_agg(distinct x), '{}'::uuid[])
+    into v_ids
+  from unnest(coalesce(p_employee_ids, '{}'::uuid[])) as x
+  where x is not null;
+
+  select count(*)
+    into v_invalid
+  from unnest(v_ids) as x
+  where not exists (
+    select 1
+    from public.profiles p
+    where p.id         = x
+      and p.is_active  = true
+      and p.role       = 'employee'
+      and p.company_id = v_company
+  );
+
+  if v_invalid > 0 then
+    raise exception
+      'Assignment rejected: % of % employee(s) are not active employees of this company',
+      v_invalid, cardinality(v_ids)
+      using errcode = '23514';
+  end if;
+
+  delete from public.job_assignments ja
+  where ja.job_id                 = p_job_id
+    and ja.employee_id           is not null
+    and not (ja.employee_id = any (v_ids))
+    and ja.attendance             = 'assigned'
+    and ja.review                is null
+    and ja.employee_started_at   is null
+    and ja.employee_completed_at is null;
+
+  insert into public.job_assignments (
+    job_id, employee_id, employee_name_snapshot, assigned_by
+  )
+  select
+    p_job_id,
+    x,
+    coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt'),
+    auth.uid()
+  from unnest(v_ids) as x
+  join public.profiles p on p.id = x
+  on conflict (job_id, employee_id) do nothing;
+
+  -- (b) Termin ab jetzt von der Regel-Synchronisierung ausnehmen.
+  -- Gilt ausdruecklich AUCH fuer die leere Zielmenge — genau dieser Fall
+  -- waere mit einer Markierung je Zuweisungszeile nicht abbildbar.
+  if v_parent is not null then
+    select p.id into v_actor from public.profiles p where p.id = auth.uid();
+
+    insert into public.job_occurrence_assignment_overrides (job_id, customized_at, customized_by)
+    values (p_job_id, now(), v_actor)
+    on conflict (job_id) do update
+      set customized_at = now(),
+          customized_by = excluded.customized_by;
+  end if;
+
+  return query
+  select ja.*
+  from public.job_assignments ja
+  where ja.job_id = p_job_id
+  order by ja.assigned_at, ja.id;
+end;
+$$;
+
+comment on function public.set_job_assignments(uuid, uuid[]) is
+'Ersetzt die Zuweisungsmenge EINES Auftrags transaktional (nur Admin, nur '
+'eigene Firma). Validiert die gesamte Zielmenge vor dem ersten Schreibvorgang, '
+'sperrt bei Terminen zuerst die Regel und dann den Termin, entfernt '
+'ausschliesslich spurenfreie Zuweisungen und legt fehlende an. Markiert einen '
+'Termin als individuell angepasst, sodass die Regel-Synchronisierung ihn nicht '
+'mehr ueberschreibt. jobs.assigned_to wird nicht angefasst.';
+
+revoke all on function public.set_job_assignments(uuid, uuid[]) from public;
+revoke all on function public.set_job_assignments(uuid, uuid[]) from anon;
+grant execute on function public.set_job_assignments(uuid, uuid[]) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 6. Zuruecksetzen auf "folgt der Regel"
+-- ---------------------------------------------------------
+create or replace function public.reset_job_occurrence_assignments(
+  p_job_id uuid
+)
+returns setof public.job_assignments
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_parent uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can reset occurrence assignments' using errcode = '42501';
+  end if;
+
+  select j.parent_job_id into v_parent
+  from public.jobs j
+  where j.id         = p_job_id
+    and j.company_id = public.current_user_company_id();
+
+  if not found then
+    raise exception 'Job not found or not accessible' using errcode = '42501';
+  end if;
+
+  if v_parent is null then
+    raise exception 'Job is not a generated occurrence' using errcode = '22023';
+  end if;
+
+  -- Gleiche Sperrreihenfolge wie ueberall: Regel zuerst, dann Termin.
+  perform 1 from public.jobs where id = v_parent  for update;
+  perform 1 from public.jobs where id = p_job_id  for update;
+
+  delete from public.job_occurrence_assignment_overrides where job_id = p_job_id;
+
+  -- Sofort neu erben, damit der Termin nicht bis zur naechsten
+  -- Regel-Aenderung in einem Zwischenzustand verharrt.
+  perform public.inherit_occurrence_assignments(v_parent, p_job_id);
+
+  return query
+  select ja.*
+  from public.job_assignments ja
+  where ja.job_id = p_job_id
+  order by ja.assigned_at, ja.id;
+end;
+$$;
+
+comment on function public.reset_job_occurrence_assignments(uuid) is
+'Setzt einen Termin auf "folgt der Regel" zurueck: entfernt die '
+'Anpassungs-Markierung und uebernimmt sofort wieder die Zuweisungsmenge der '
+'Regel. Nur Admin, nur eigene Firma, nur fuer generierte Termine. '
+'Spurenbehaftete Zuweisungen (Anwesenheit/Review/Zeitstempel) bleiben erhalten.';
+
+revoke all on function public.reset_job_occurrence_assignments(uuid) from public;
+revoke all on function public.reset_job_occurrence_assignments(uuid) from anon;
+grant execute on function public.reset_job_occurrence_assignments(uuid) to authenticated;
+
+
+-- =========================================================
+-- NEBENWIRKUNGEN UND GRENZEN
+-- =========================================================
+--   * Ein bereits GESTARTETER oder abgeschlossener Termin wird vom
+--     Mengenabgleich nie angefasst (status/Zeitstempel-Bedingung), auch
+--     wenn er nicht angepasst ist. Das entspricht dem bisherigen Verhalten.
+--   * Spurenbehaftete Zuweisungen auf einem geerbten Termin werden nicht
+--     entfernt. Ein solcher Termin kann daher dauerhaft mehr Mitarbeiter
+--     tragen als die Regel — bewusst, weil Nachweise Vorrang haben.
+--   * Die Markierung ist bewusst nicht rueckwirkend: bestehende Termine
+--     gelten nach dieser Migration alle als "folgt der Regel", exakt wie
+--     bisher. Ein Backfill waere eine Verhaltensaenderung an Bestandsdaten
+--     und ist ausdruecklich nicht gewuenscht.
+--
+-- =========================================================
+-- ROLLBACK (vollstaendig, nicht destruktiv)
+-- =========================================================
+-- Reihenfolge unkritisch (keine Policy haengt an den neuen Funktionen;
+-- die Policy auf der neuen Tabelle verschwindet mit ihr):
+--
+--   drop function if exists public.reset_job_occurrence_assignments(uuid);
+--   -- generate_job_occurrences / update_job_occurrences / set_job_assignments
+--   -- auf den Stand der Migrationen 20260714000000 / 20260723000004 /
+--   -- 20260727000000 zuruecksetzen (identische Rumpfe, ohne den
+--   -- inherit-Aufruf, mit assigned_to im SYNC-Block bzw. ohne
+--   -- Markierungslogik).
+--   drop function if exists public.inherit_occurrence_assignments(uuid, uuid);
+--   drop table if exists public.job_occurrence_assignment_overrides;
+--
+-- Es gehen keine Zuweisungsdaten verloren: die Markierungstabelle traegt
+-- keine Zuweisungen, sondern nur die Information "folgt der Regel nicht".
+-- Nach dem Rueckbau folgen wieder alle Termine der Regel — also exakt das
+-- Verhalten vor Phase 4.
+-- =========================================================

--- a/supabase/migrations/20260728000000_occurrence_assignment_inheritance.sql
+++ b/supabase/migrations/20260728000000_occurrence_assignment_inheritance.sql
@@ -501,13 +501,21 @@ begin
       or c.is_active        is distinct from parent.is_active
     );
 
-  -- ── 3) ZUWEISUNGSMENGE abgleichen ─────────────────────────────────
-  -- Nur fuer NICHT angepasste Termine. jobs.assigned_to wird dabei nicht
-  -- direkt geschrieben — die Phase-2-Richtung B leitet den primaeren
-  -- Mitarbeiter aus der resultierenden Menge ab.
-  perform public.inherit_occurrence_assignments(parent_job_id_input);
-
-  -- ── 4) GENERATE ───────────────────────────────────────────────────
+  -- ── 3) GENERATE (inkl. Mengenabgleich) ────────────────────────────
+  -- generate_job_occurrences fuegt fehlende Termine ein und ruft danach
+  -- selbst inherit_occurrence_assignments auf. Dessen Abgleich ist NICHT
+  -- auf neu erzeugte Zeilen beschraenkt, sondern erfasst alle nicht
+  -- angepassten, zukuenftigen, offenen Termine der Regel — also auch die
+  -- bereits bestehenden. Ein zusaetzlicher Aufruf an dieser Stelle waere
+  -- daher nachweislich redundant und wuerde den Abgleich bei Regeln mit
+  -- vielen Terminen unnoetig verdoppeln.
+  -- (generate kann seinen inherit-Aufruf auch nicht verfehlen: seine drei
+  -- Guards — Authentifizierung, Admin-Rolle, Parent-Lookup — sind mit den
+  -- oben bereits bestandenen identisch.)
+  --
+  -- jobs.assigned_to wird dabei nirgends direkt geschrieben; die
+  -- Phase-2-Richtung B leitet den primaeren Mitarbeiter aus der
+  -- resultierenden Menge ab.
   select public.generate_job_occurrences(parent_job_id_input)
   into new_count;
 
@@ -542,11 +550,12 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_company uuid;
-  v_parent  uuid;
-  v_ids     uuid[];
-  v_invalid int;
-  v_actor   uuid;
+  v_company    uuid;
+  v_parent     uuid;
+  v_ids        uuid[];
+  v_parent_ids uuid[];
+  v_invalid    int;
+  v_actor      uuid;
 begin
   if auth.uid() is null then
     raise exception 'Not authenticated' using errcode = '28000';
@@ -578,7 +587,9 @@ begin
     raise exception 'Job not found or not accessible' using errcode = '42501';
   end if;
 
-  select coalesce(array_agg(distinct x), '{}'::uuid[])
+  -- Kanonische Form: dedupliziert UND sortiert. Die Sortierung ist noetig,
+  -- damit die Menge unten direkt mit der Regelmenge verglichen werden kann.
+  select coalesce(array_agg(distinct x order by x), '{}'::uuid[])
     into v_ids
   from unnest(coalesce(p_employee_ids, '{}'::uuid[])) as x
   where x is not null;
@@ -623,17 +634,49 @@ begin
   join public.profiles p on p.id = x
   on conflict (job_id, employee_id) do nothing;
 
-  -- (b) Termin ab jetzt von der Regel-Synchronisierung ausnehmen.
-  -- Gilt ausdruecklich AUCH fuer die leere Zielmenge — genau dieser Fall
-  -- waere mit einer Markierung je Zuweisungszeile nicht abbildbar.
+  -- (b) Markierung NUR bei echter Abweichung von der Regelmenge.
+  --
+  -- Verglichen wird die ABSICHT des Aufrufers (die validierte, kanonische
+  -- Zielmenge v_ids) mit der effektiven Zuweisungsmenge der Regel — nicht
+  -- der resultierende Tabelleninhalt. Das ist wichtig, weil auf dem Termin
+  -- spurenbehaftete Zeilen liegen koennen, die gar nicht entfernt werden
+  -- duerfen; wuerde man diese mitvergleichen, wuerde ein Termin allein
+  -- wegen eines Nachweises faelschlich als "angepasst" gelten.
+  --
+  -- Folgen:
+  --   * Speichern OHNE Aenderung ist ein echter No-Op — der Termin wird
+  --     nicht abgekoppelt. Ohne diese Pruefung koppelte ein blosses
+  --     Oeffnen-und-Speichern in der spaeteren Oberflaeche den Termin
+  --     dauerhaft und unsichtbar von der Regel ab.
+  --   * Wird ein angepasster Termin wieder exakt auf die Regelmenge
+  --     gesetzt, verschwindet die Markierung automatisch; er folgt der
+  --     Regel wieder, ohne dass ein Zuruecksetzen noetig waere.
+  --   * Die LEERE Zielmenge bleibt eine echte Anpassung, solange die Regel
+  --     nicht ebenfalls leer ist — der Fall, der eine Markierung je
+  --     Zuweisungszeile unmoeglich macht, bleibt damit abgedeckt.
   if v_parent is not null then
-    select p.id into v_actor from public.profiles p where p.id = auth.uid();
+    select coalesce(array_agg(pa.employee_id order by pa.employee_id), '{}'::uuid[])
+      into v_parent_ids
+    from public.job_assignments pa
+    join public.profiles pp on pp.id = pa.employee_id
+    join public.jobs      pj on pj.id = pa.job_id
+    where pa.job_id      = v_parent
+      and pa.employee_id is not null
+      and pp.is_active   = true
+      and pp.role        = 'employee'
+      and pp.company_id  = pj.company_id;
 
-    insert into public.job_occurrence_assignment_overrides (job_id, customized_at, customized_by)
-    values (p_job_id, now(), v_actor)
-    on conflict (job_id) do update
-      set customized_at = now(),
-          customized_by = excluded.customized_by;
+    if v_ids = v_parent_ids then
+      delete from public.job_occurrence_assignment_overrides where job_id = p_job_id;
+    else
+      select p.id into v_actor from public.profiles p where p.id = auth.uid();
+
+      insert into public.job_occurrence_assignment_overrides (job_id, customized_at, customized_by)
+      values (p_job_id, now(), v_actor)
+      on conflict (job_id) do update
+        set customized_at = now(),
+            customized_by = excluded.customized_by;
+    end if;
   end if;
 
   return query
@@ -669,7 +712,11 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_parent uuid;
+  v_parent    uuid;
+  v_status    public.job_status;
+  v_started   timestamptz;
+  v_completed timestamptz;
+  v_date      date;
 begin
   if auth.uid() is null then
     raise exception 'Not authenticated' using errcode = '28000';
@@ -695,6 +742,29 @@ begin
   -- Gleiche Sperrreihenfolge wie ueberall: Regel zuerst, dann Termin.
   perform 1 from public.jobs where id = v_parent  for update;
   perform 1 from public.jobs where id = p_job_id  for update;
+
+  -- Zustand ERST NACH der Sperre lesen und pruefen, damit kein Wettlauf
+  -- zwischen Pruefung und Aenderung entsteht.
+  select j.status, j.started_at, j.completed_at, j.date
+    into v_status, v_started, v_completed, v_date
+  from public.jobs j
+  where j.id = p_job_id;
+
+  -- Der Mengenabgleich fasst ausschliesslich zukuenftige, offene und noch
+  -- nicht gestartete Termine an. Auf allen anderen wuerde das Entfernen der
+  -- Markierung den Termin als "folgt der Regel" ausweisen, ohne dass jemals
+  -- wieder etwas geerbt wird — ein Zustand, der die Wahrheit verfehlt.
+  -- Deshalb hier ABLEHNEN statt still die Markierung zu verlieren.
+  if v_status is distinct from 'open'
+     or v_started   is not null
+     or v_completed is not null
+     or coalesce(v_date, date '0001-01-01') < current_date then
+    raise exception
+      'Occurrence has already started, is completed or lies in the past; assignments can no longer be inherited'
+      using errcode = '22023',
+            detail  = 'Nur zukuenftige, offene und nicht gestartete Termine koennen die Zuweisungen der Regel erneut uebernehmen.',
+            hint    = 'Die Zuweisungen dieses Termins bleiben unveraendert erhalten.';
+  end if;
 
   delete from public.job_occurrence_assignment_overrides where job_id = p_job_id;
 
@@ -738,8 +808,19 @@ grant execute on function public.reset_job_occurrence_assignments(uuid) to authe
 -- =========================================================
 -- ROLLBACK (vollstaendig, nicht destruktiv)
 -- =========================================================
--- Reihenfolge unkritisch (keine Policy haengt an den neuen Funktionen;
--- die Policy auf der neuen Tabelle verschwindet mit ihr):
+-- REIHENFOLGE IST ZWINGEND — anders als bei den RLS-Policies der Phase 3
+-- schuetzt PostgreSQL hier NICHTS: inherit_occurrence_assignments,
+-- set_job_assignments und reset_job_occurrence_assignments verweisen im
+-- FUNKTIONSRUMPF auf job_occurrence_assignment_overrides, und
+-- Funktionsrumpfe werden nicht als Abhaengigkeit verfolgt. Wird die
+-- Tabelle zuerst geloescht, scheitern ab diesem Moment sowohl die
+-- Terminerzeugung als auch jede Zuweisungsaenderung mit
+-- 'relation ... does not exist' (nachgestellt und bestaetigt). Da
+-- Schemaaenderungen in diesem Repository manuell und Anweisung fuer
+-- Anweisung im SQL Editor laufen, ist dieses Fenster real.
+--
+-- Deshalb ZUERST die drei Funktionsrumpfe zurueckstellen und ERST DANACH
+-- die Hilfsfunktion und die Tabelle entfernen:
 --
 --   drop function if exists public.reset_job_occurrence_assignments(uuid);
 --   -- generate_job_occurrences / update_job_occurrences / set_job_assignments

--- a/supabase/tests/occurrence_assignment_inheritance.test.sql
+++ b/supabase/tests/occurrence_assignment_inheritance.test.sql
@@ -504,6 +504,170 @@ begin
 end $$;
 
 
+
+-- =========================================================
+-- F. Follow-ups aus dem unabhaengigen Review zu PR #53
+-- =========================================================
+
+-- CASE 25: Speichern OHNE Aenderung erzeugt KEINE Markierung
+--   Der Kern von Follow-up 1: die spaetere Oberflaeche ruft
+--   set_job_assignments beim Speichern unbedingt auf. Ein blosses
+--   Oeffnen-und-Speichern darf den Termin nicht dauerhaft abkoppeln.
+do $$
+declare v text; occ uuid;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  -- frische Regel + Termin, sauberer Ausgangszustand
+  insert into public.jobs (id,company_id,created_by,customer_name,service_name,location_address,
+                           status,job_type,recurring_days,start_time,recurrence_start_date,is_active)
+  values ('cb000000-0000-0000-0000-000000000009','c9000000-0000-0000-0000-000000000001',
+          'ca000000-0000-0000-0000-000000000001','Kunde R9','Service R9','Ort R9','open','recurring',
+          array['mon','tue','wed','thu','fri','sat','sun'],'09:00',current_date,true);
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000009',
+    array['ca000000-0000-0000-0000-00000000000a','ca000000-0000-0000-0000-00000000000b']::uuid[]);
+  perform public.generate_job_occurrences('cb000000-0000-0000-0000-000000000009');
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000009');
+
+  -- exakt dieselbe Menge erneut speichern
+  perform public.set_job_assignments(occ,
+    array['ca000000-0000-0000-0000-00000000000b','ca000000-0000-0000-0000-00000000000a']::uuid[]);
+
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text;
+  insert into _oi values (25,'No-Op-Speichern erzeugt keine Markierung','menge=A,B/angepasst=false',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+-- CASE 26: echte Aenderung erzeugt die Markierung
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000009');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text;
+  insert into _oi values (26,'Echte Mengenaenderung erzeugt die Markierung','menge=A/angepasst=true',v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+-- CASE 27: Rueckkehr zur Regelmenge entfernt die Markierung automatisch
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000009');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ,
+    array['ca000000-0000-0000-0000-00000000000a','ca000000-0000-0000-0000-00000000000b']::uuid[]);
+  v := 'angepasst='||pg_temp.angepasst(occ)::text;
+
+  -- und folgt danach der Regel wieder, ganz ohne Zuruecksetzen
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000009',
+    array['ca000000-0000-0000-0000-00000000000c']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000009');
+  v := v || '/folgt_wieder='||pg_temp.menge(occ);
+
+  insert into _oi values (27,'Rueckkehr zur Regelmenge loest die Markierung ohne Reset',
+    'angepasst=false/folgt_wieder=C',v);
+  raise notice 'CASE 27 -> %', v;
+end $$;
+
+-- CASE 28: Zuruecksetzen auf GESTARTETEM Termin wird abgelehnt
+do $$
+declare v text; occ uuid; noch_angepasst boolean;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000009');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  update public.jobs set status='in_progress', started_at=now() where id=occ;
+  begin
+    perform public.reset_job_occurrence_assignments(occ);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')'; end;
+  noch_angepasst := pg_temp.angepasst(occ);
+  v := v || '/markierung_erhalten='||noch_angepasst::text;
+  insert into _oi values (28,'Reset auf gestartetem Termin wird abgelehnt, Markierung bleibt',
+    'ABGELEHNT(22023)/markierung_erhalten=true',v);
+  raise notice 'CASE 28 -> %', v;
+end $$;
+
+-- CASE 29: Zuruecksetzen auf ABGESCHLOSSENEM Termin wird abgelehnt
+do $$
+declare v text; occ uuid;
+begin
+  select id into occ from public.jobs
+   where parent_job_id='cb000000-0000-0000-0000-000000000009' and status='open'
+   order by date offset 1 limit 1;
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  update public.jobs set status='completed', started_at=now()-interval '2 h', completed_at=now() where id=occ;
+  begin
+    perform public.reset_job_occurrence_assignments(occ);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')'; end;
+  v := v || '/markierung_erhalten='||pg_temp.angepasst(occ)::text;
+  insert into _oi values (29,'Reset auf abgeschlossenem Termin wird abgelehnt, Markierung bleibt',
+    'ABGELEHNT(22023)/markierung_erhalten=true',v);
+  raise notice 'CASE 29 -> %', v;
+end $$;
+
+-- CASE 30: Zuruecksetzen auf VERGANGENEM Termin wird abgelehnt
+do $$
+declare v text; occ uuid := 'cb000000-0000-0000-0000-0000000000ff';
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  insert into public.jobs (id,company_id,parent_job_id,created_by,customer_name,service_name,location_address,
+                           status,job_type,date,start_time,is_active)
+  values (occ,'c9000000-0000-0000-0000-000000000001','cb000000-0000-0000-0000-000000000009',
+          'ca000000-0000-0000-0000-000000000001','Kunde R9','Service R9','Ort R9','open','single',
+          current_date - 7,'09:00',true);
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  begin
+    perform public.reset_job_occurrence_assignments(occ);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')'; end;
+  v := v || '/markierung_erhalten='||pg_temp.angepasst(occ)::text;
+  insert into _oi values (30,'Reset auf vergangenem Termin wird abgelehnt, Markierung bleibt',
+    'ABGELEHNT(22023)/markierung_erhalten=true',v);
+  raise notice 'CASE 30 -> %', v;
+end $$;
+
+-- CASE 31: der redundante inherit-Aufruf ist entfernt (Follow-up 4)
+--   update_job_occurrences ruft inherit NICHT mehr direkt auf; der
+--   Abgleich laeuft ausschliesslich ueber generate_job_occurrences.
+do $$
+declare v text; src_upd text; src_gen text;
+begin
+  select pg_get_functiondef('public.update_job_occurrences(uuid)'::regprocedure)   into src_upd;
+  select pg_get_functiondef('public.generate_job_occurrences(uuid)'::regprocedure) into src_gen;
+  v := 'update_ruft_inherit='||(position('perform public.inherit_occurrence_assignments' in src_upd) > 0)::text
+     ||'/generate_ruft_inherit='||(position('perform public.inherit_occurrence_assignments' in src_gen) > 0)::text;
+  insert into _oi values (31,'Kein doppelter Mengenabgleich mehr: nur generate ruft inherit',
+    'update_ruft_inherit=false/generate_ruft_inherit=true',v);
+  raise notice 'CASE 31 -> %', v;
+end $$;
+
+-- CASE 32: Grundlage der korrigierten Rollback-Reihenfolge (Follow-up 3)
+--   Die drei Funktionen verweisen im RUMPF auf die Markierungstabelle.
+--   Funktionsrumpfe werden nicht als Abhaengigkeit verfolgt — deshalb MUSS
+--   beim Rueckbau zuerst der Funktionsstand zurueckgesetzt und erst danach
+--   die Tabelle geloescht werden.
+do $$
+declare v text;
+begin
+  v := 'inherit='||(position('job_occurrence_assignment_overrides' in
+         pg_get_functiondef('public.inherit_occurrence_assignments(uuid,uuid)'::regprocedure)) > 0)::text
+     ||'/set='||(position('job_occurrence_assignment_overrides' in
+         pg_get_functiondef('public.set_job_assignments(uuid,uuid[])'::regprocedure)) > 0)::text
+     ||'/reset='||(position('job_occurrence_assignment_overrides' in
+         pg_get_functiondef('public.reset_job_occurrence_assignments(uuid)'::regprocedure)) > 0)::text
+     ||'/tabelle_haengt_an_funktion='||(select count(*)::text from pg_depend d
+         join pg_rewrite r on r.oid = d.objid
+         where d.refobjid = 'public.job_occurrence_assignment_overrides'::regclass and false);
+  insert into _oi values (32,'Funktionsrumpfe referenzieren die Tabelle (Rollback-Reihenfolge ist zwingend)',
+    'inherit=true/set=true/reset=true/tabelle_haengt_an_funktion=0',v);
+  raise notice 'CASE 32 -> %', v;
+end $$;
+
+
 -- =========================================================
 -- Ergebnisuebersicht
 -- =========================================================
@@ -518,7 +682,7 @@ begin
   if fails > 0 then
     raise exception 'OCCURRENCE ASSIGNMENT INHERITANCE TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
   end if;
-  raise notice 'ALLE 24 FAELLE PASS';
+  raise notice 'ALLE 32 FAELLE PASS';
 end $$;
 
 rollback;

--- a/supabase/tests/occurrence_assignment_inheritance.test.sql
+++ b/supabase/tests/occurrence_assignment_inheritance.test.sql
@@ -1,0 +1,524 @@
+-- =========================================================
+-- TEST: Vererbung und Anpassung von Zuweisungen auf Occurrences
+-- (Migration 20260728000000_occurrence_assignment_inheritance)
+-- =========================================================
+-- Prueft Generierung, Regel-Synchronisierung, individuelle Anpassung,
+-- Zuruecksetzen, Nachweis-Bewahrung, Legacy-Kompatibilitaet,
+-- Duplikatfreiheit und die Sperrreihenfolge.
+--
+-- Alle Admin-Aufrufe laufen mit gesetzten JWT-Claims, also ueber
+-- denselben Autorisierungspfad wie die App.
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende.
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/occurrence_assignment_inheritance.test.sql
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = c9…1 | Firma B = c9…2
+-- Admin A = ca…1 | A=ca…a | B=ca…b | C=ca…c | P=ca…p(0d) | inaktiv=ca…e
+-- Admin B = ca…f
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-000000000001','authenticated','authenticated','oi-adm@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000a','authenticated','authenticated','oi-a@example.test','{"full_name":"Anna"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000b','authenticated','authenticated','oi-b@example.test','{"full_name":"Bert"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000c','authenticated','authenticated','oi-c@example.test','{"full_name":"Cora"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000d','authenticated','authenticated','oi-p@example.test','{"full_name":"Paul"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000e','authenticated','authenticated','oi-inakt@example.test','{"full_name":"Ida"}'),
+    ('00000000-0000-0000-0000-000000000000','ca000000-0000-0000-0000-00000000000f','authenticated','authenticated','oi-admb@example.test','{"full_name":"Admin B"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('ca000000-0000-0000-0000-000000000001','Admin A'),
+  ('ca000000-0000-0000-0000-00000000000a','Anna'),
+  ('ca000000-0000-0000-0000-00000000000b','Bert'),
+  ('ca000000-0000-0000-0000-00000000000c','Cora'),
+  ('ca000000-0000-0000-0000-00000000000d','Paul'),
+  ('ca000000-0000-0000-0000-00000000000e','Ida'),
+  ('ca000000-0000-0000-0000-00000000000f','Admin B')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('c9000000-0000-0000-0000-000000000001','OI Firma A','oi-firma-a-test'),
+  ('c9000000-0000-0000-0000-000000000002','OI Firma B','oi-firma-b-test');
+
+update public.profiles set company_id='c9000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='ca000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='c9000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id in
+  ('ca000000-0000-0000-0000-00000000000a','ca000000-0000-0000-0000-00000000000b','ca000000-0000-0000-0000-00000000000c','ca000000-0000-0000-0000-00000000000d');
+update public.profiles set company_id='c9000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='ca000000-0000-0000-0000-00000000000e';
+update public.profiles set company_id='c9000000-0000-0000-0000-000000000002', role='admin',    is_active=true  where id='ca000000-0000-0000-0000-00000000000f';
+
+create temporary table _oi (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+-- Kurzname eines Mitarbeiters fuer lesbare Erwartungswerte
+create or replace function pg_temp.kurz(p uuid) returns text language sql as $f$
+  select case p::text
+    when 'ca000000-0000-0000-0000-00000000000a' then 'A'
+    when 'ca000000-0000-0000-0000-00000000000b' then 'B'
+    when 'ca000000-0000-0000-0000-00000000000c' then 'C'
+    when 'ca000000-0000-0000-0000-00000000000d' then 'P'
+    when 'ca000000-0000-0000-0000-00000000000e' then 'I'
+    else coalesce(p::text,'ANON') end;
+$f$;
+
+-- Zuweisungsmenge eines Auftrags, deterministisch sortiert
+create or replace function pg_temp.menge(p_job uuid) returns text language sql as $f$
+  select coalesce(string_agg(pg_temp.kurz(ja.employee_id), ',' order by pg_temp.kurz(ja.employee_id)),'LEER')
+  from public.job_assignments ja where ja.job_id = p_job;
+$f$;
+
+create or replace function pg_temp.legacy(p_job uuid) returns text language sql as $f$
+  select case when (select assigned_to from public.jobs where id=p_job) is null
+              then 'NULL'
+              else pg_temp.kurz((select assigned_to from public.jobs where id=p_job)) end;
+$f$;
+
+-- Erster (frühester) Termin einer Regel
+create or replace function pg_temp.erster(p_parent uuid) returns uuid language sql as $f$
+  select id from public.jobs where parent_job_id=p_parent order by date, start_time limit 1;
+$f$;
+
+create or replace function pg_temp.angepasst(p_job uuid) returns boolean language sql as $f$
+  select exists(select 1 from public.job_occurrence_assignment_overrides where job_id=p_job);
+$f$;
+
+-- Regel R1: Wochentags-Regel, zunaechst Paul zugewiesen
+insert into public.jobs (id,company_id,assigned_to,created_by,customer_name,service_name,location_address,
+                         status,job_type,recurring_days,start_time,recurrence_start_date,is_active,created_at,updated_at)
+values ('cb000000-0000-0000-0000-000000000001','c9000000-0000-0000-0000-000000000001','ca000000-0000-0000-0000-00000000000d',
+        'ca000000-0000-0000-0000-000000000001','Kunde R1','Service R1','Ort R1','open','recurring',
+        array['mon','tue','wed','thu','fri','sat','sun'],'08:00',current_date,true,
+        timestamptz '2020-01-01 10:00+00', timestamptz '2020-01-01 10:00+00');
+
+
+-- =========================================================
+-- A. Generierung und Vererbung
+-- =========================================================
+
+-- CASE 1: Regel hat MEHRERE Mitarbeiter -> neue Termine erben die MENGE
+do $$
+declare v text; occ uuid;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  -- Regel auf {P, A} setzen (Regel selbst ist kein Termin -> keine Markierung)
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000d','ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  perform public.generate_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text;
+  insert into _oi values (1,'Neuer Termin erbt die vollstaendige Zuweisungsmenge der Regel','menge=A,P/angepasst=false',v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: Legacy assigned_to ist nach der Vererbung gedeckt
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  v := 'gedeckt='||(select (j.assigned_to is null or exists(
+         select 1 from public.job_assignments ja where ja.job_id=j.id and ja.employee_id=j.assigned_to))::text
+       from public.jobs j where j.id=occ);
+  insert into _oi values (2,'Legacy assigned_to bleibt durch eine Zuweisung gedeckt','gedeckt=true',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: Regel-Aenderung wirkt auf NICHT angepasste Termine
+do $$
+declare v text; occ uuid;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000b','ca000000-0000-0000-0000-00000000000c']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  v := 'menge='||pg_temp.menge(occ);
+  insert into _oi values (3,'Nicht angepasster Termin folgt der geaenderten Regelmenge','menge=B,C',v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- CASE 4: keine doppelten Zuweisungszeilen nach mehrfacher Synchronisierung
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  select 'duplikate='||count(*)::text into v from (
+    select job_id, employee_id from public.job_assignments
+    where employee_id is not null group by 1,2 having count(*)>1) d;
+  insert into _oi values (4,'Mehrfache Synchronisierung erzeugt keine Duplikate','duplikate=0',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- B. Individuelle Anpassung (Kern von Phase 4)
+-- =========================================================
+
+-- CASE 5: Anpassung markiert den Termin
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text
+     ||'/by='||(select pg_temp.kurz(customized_by) from public.job_occurrence_assignment_overrides where job_id=occ);
+  insert into _oi values (5,'Anpassung setzt Menge und markiert den Termin',
+    'menge=A/angepasst=true/by=ca000000-0000-0000-0000-000000000001',v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- CASE 6: URSACHEN-FALL — Regel-Edit an einem UNBETEILIGTEN Feld
+--   darf die angepasste Menge nicht mehr veraendern.
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  update public.jobs set customer_name='Kunde R1 neu' where id='cb000000-0000-0000-0000-000000000001';
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  v := 'menge='||pg_temp.menge(occ)
+     ||'/kunde_gesynct='||(select (customer_name='Kunde R1 neu')::text from public.jobs where id=occ);
+  insert into _oi values (6,'Angepasster Termin behaelt die Menge; andere Felder werden weiter gesynct',
+    'menge=A/kunde_gesynct=true',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: Regel-Zuweisung aendern beruehrt den angepassten Termin nicht
+do $$
+declare v text; occ uuid; occ2 uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000d']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  select id into occ2 from public.jobs
+   where parent_job_id='cb000000-0000-0000-0000-000000000001' and id <> occ order by date limit 1;
+  v := 'angepasst='||pg_temp.menge(occ)||'/geerbt='||pg_temp.menge(occ2);
+  insert into _oi values (7,'Regelmengen-Aenderung: angepasster Termin unveraendert, geerbter folgt',
+    'angepasst=A/geerbt=P',v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+-- CASE 8: LEERE angepasste Menge bleibt leer
+--   Genau dieser Fall waere mit einer Markierung je Zuweisungszeile
+--   nicht abbildbar (keine Zeile -> keine Markierung).
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, '{}'::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text
+     ||'/legacy='||pg_temp.legacy(occ);
+  insert into _oi values (8,'Leere angepasste Menge bleibt nach Regel-Sync leer',
+    'menge=LEER/angepasst=true/legacy=NULL',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- C. Zuruecksetzen auf "folgt der Regel"
+-- =========================================================
+
+-- CASE 9: Zuruecksetzen uebernimmt die Regelmenge sofort
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.reset_job_occurrence_assignments(occ);
+  v := 'menge='||pg_temp.menge(occ)||'/angepasst='||pg_temp.angepasst(occ)::text
+     ||'/legacy_gedeckt='||(select (j.assigned_to is null or exists(
+          select 1 from public.job_assignments ja where ja.job_id=j.id and ja.employee_id=j.assigned_to))::text
+        from public.jobs j where j.id=occ);
+  insert into _oi values (9,'Zuruecksetzen stellt die Regelmenge sofort wieder her',
+    'menge=P/angepasst=false/legacy_gedeckt=true',v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- CASE 10: nach dem Zuruecksetzen folgt der Termin wieder der Regel
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000b']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+  v := 'menge='||pg_temp.menge(occ);
+  insert into _oi values (10,'Zurueckgesetzter Termin folgt wieder der Regel','menge=B',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- CASE 11: Zuruecksetzen auf einem Nicht-Termin wird abgelehnt
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  begin
+    perform public.reset_job_occurrence_assignments('cb000000-0000-0000-0000-000000000001');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT'; end;
+  insert into _oi values (11,'Zuruecksetzen auf der Regel selbst abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: Zuruecksetzen durch Employee abgelehnt
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-00000000000a');
+  begin
+    perform public.reset_job_occurrence_assignments(occ);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT'; end;
+  insert into _oi values (12,'Employee darf nicht zuruecksetzen','ABGELEHNT',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- CASE 13: Zuruecksetzen durch Admin einer FREMDEN Firma abgelehnt
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-00000000000f');
+  begin
+    perform public.reset_job_occurrence_assignments(occ);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT'; end;
+  insert into _oi values (13,'Fremder Admin darf nicht zuruecksetzen','ABGELEHNT',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- D. Nachweis-Bewahrung
+-- =========================================================
+
+-- CASE 14: Zuweisung MIT Anwesenheit ueberlebt die Regel-Synchronisierung
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  -- B hat auf dem geerbten Termin bereits gestartet
+  update public.job_assignments set attendance='started', employee_started_at=now()
+   where job_id=occ and employee_id='ca000000-0000-0000-0000-00000000000b';
+
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000c']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+
+  select coalesce(string_agg(pg_temp.kurz(ja.employee_id)||':'||ja.attendance::text
+         ||'/'||ja.counts_for_timesheet::text, ',' order by pg_temp.kurz(ja.employee_id)),'LEER')
+    into v from public.job_assignments ja where ja.job_id=occ;
+  insert into _oi values (14,'Nachweis-Zuweisung (started) ueberlebt den Mengenabgleich',
+    'B:started/true,C:assigned/false',v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: Nachweis ueberlebt auch das Zuruecksetzen
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  perform public.reset_job_occurrence_assignments(occ);
+  select coalesce(string_agg(pg_temp.kurz(ja.employee_id)||':'||ja.attendance::text, ',' order by pg_temp.kurz(ja.employee_id)),'LEER')
+    into v from public.job_assignments ja where ja.job_id=occ;
+  insert into _oi values (15,'Nachweis-Zuweisung ueberlebt Anpassung und Zuruecksetzen',
+    'B:started,C:assigned',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: gestarteter Termin wird vom Mengenabgleich gar nicht angefasst
+do $$
+declare v text; occ uuid;
+begin
+  select id into occ from public.jobs
+   where parent_job_id='cb000000-0000-0000-0000-000000000001'
+     and id <> pg_temp.erster('cb000000-0000-0000-0000-000000000001')
+   order by date limit 1;
+
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  update public.jobs set status='in_progress', started_at=now() where id=occ;
+  delete from public.job_occurrence_assignment_overrides where job_id=occ; -- als "geerbt" markieren
+
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000d']::uuid[]);
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+
+  v := 'menge='||pg_temp.menge(occ);
+  insert into _oi values (16,'Gestarteter Termin bleibt vom Mengenabgleich ausgenommen','menge=A',v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+-- CASE 17: anonymisierte Zeile (geloeschtes Konto) ueberlebt den Abgleich
+do $$
+declare v text; occ uuid;
+begin
+  occ := pg_temp.erster('cb000000-0000-0000-0000-000000000001');
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000d']::uuid[]);
+  delete from auth.users where id='ca000000-0000-0000-0000-00000000000d';
+  perform public.reset_job_occurrence_assignments(occ);
+
+  select coalesce(string_agg(coalesce(pg_temp.kurz(ja.employee_id),'ANON')||':'||ja.employee_name_snapshot,
+         ',' order by ja.employee_name_snapshot),'LEER')
+    into v from public.job_assignments ja where ja.job_id=occ and ja.employee_id is null;
+  insert into _oi values (17,'Anonymisierte Zeile ueberlebt Zuruecksetzen und Abgleich','ANON:Paul',v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- E. Struktur, Rechte und Sperrreihenfolge
+-- =========================================================
+
+-- CASE 18: Markierung verschwindet mit dem Termin (ON DELETE CASCADE)
+do $$
+declare v text; occ uuid; n_vor int; n_nach int;
+begin
+  select id into occ from public.jobs
+   where parent_job_id='cb000000-0000-0000-0000-000000000001'
+   order by date desc limit 1;
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments(occ, array['ca000000-0000-0000-0000-00000000000a']::uuid[]);
+  select count(*) into n_vor from public.job_occurrence_assignment_overrides where job_id=occ;
+  delete from public.jobs where id=occ;
+  select count(*) into n_nach from public.job_occurrence_assignment_overrides where job_id=occ;
+  v := 'vor='||n_vor::text||'/nach='||n_nach::text;
+  insert into _oi values (18,'Markierung kaskadiert mit dem geloeschten Termin','vor=1/nach=0',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: Rechte auf der Markierungstabelle
+do $$
+declare v text;
+begin
+  v := 'anon='||coalesce((select string_agg(distinct privilege_type,'+') from information_schema.role_table_grants
+        where table_schema='public' and table_name='job_occurrence_assignment_overrides' and grantee='anon'),'KEINE')
+     ||'/auth='||coalesce((select string_agg(distinct privilege_type,'+' order by privilege_type) from information_schema.role_table_grants
+        where table_schema='public' and table_name='job_occurrence_assignment_overrides' and grantee='authenticated'),'KEINE')
+     ||'/schreib_policies='||(select count(*)::text from pg_policies
+        where schemaname='public' and tablename='job_occurrence_assignment_overrides' and cmd <> 'SELECT')
+     ||'/rls='||(select relrowsecurity::text from pg_class where oid='public.job_occurrence_assignment_overrides'::regclass);
+  insert into _oi values (19,'Markierungstabelle: anon rechtelos, authenticated nur SELECT, keine Schreib-Policy',
+    'anon=KEINE/auth=SELECT/schreib_policies=0/rls=true',v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- CASE 20: interne Hilfsfunktion ist fuer Clients nicht aufrufbar
+do $$
+declare v text;
+begin
+  v := 'inherit_auth='||has_function_privilege('authenticated','public.inherit_occurrence_assignments(uuid,uuid)','EXECUTE')::text
+     ||'/inherit_anon='||has_function_privilege('anon','public.inherit_occurrence_assignments(uuid,uuid)','EXECUTE')::text
+     ||'/reset_auth='||has_function_privilege('authenticated','public.reset_job_occurrence_assignments(uuid)','EXECUTE')::text
+     ||'/reset_anon='||has_function_privilege('anon','public.reset_job_occurrence_assignments(uuid)','EXECUTE')::text;
+  insert into _oi values (20,'EXECUTE: Hilfsfunktion gesperrt, Reset-RPC nur fuer authenticated',
+    'inherit_auth=false/inherit_anon=false/reset_auth=true/reset_anon=false',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: Sperrreihenfolge Regel -> Termin ist im Code verankert
+--   (strukturelle Zusicherung gegen Deadlocks; echte Nebenlaeufigkeit
+--    laesst sich in einer Transaktion nicht darstellen)
+do $$
+declare v text; src text; pos_parent int; pos_child int;
+begin
+  select pg_get_functiondef('public.set_job_assignments(uuid,uuid[])'::regprocedure) into src;
+  pos_parent := position('where id = v_parent for update' in src);
+  pos_child  := position('and j.company_id = public.current_user_company_id()' in src);
+  v := 'parent_lock_vorhanden='||(pos_parent > 0)::text
+     ||'/parent_vor_child='||(pos_parent > 0 and pos_parent < pos_child)::text;
+  insert into _oi values (21,'set_job_assignments sperrt die Regel VOR dem Termin',
+    'parent_lock_vorhanden=true/parent_vor_child=true',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- CASE 22: inaktiver Mitarbeiter wird nicht vererbt
+--   Geprueft wird gezielt die Abwesenheit des inaktiven Mitarbeiters.
+--   Bereits vorhandene anonymisierte Nachweiszeilen duerfen bleiben.
+do $$
+declare v text; occ uuid;
+begin
+  perform pg_temp.act_as('ca000000-0000-0000-0000-000000000001');
+  perform public.set_job_assignments('cb000000-0000-0000-0000-000000000001',
+    array['ca000000-0000-0000-0000-00000000000c']::uuid[]);
+  update public.profiles set is_active=false where id='ca000000-0000-0000-0000-00000000000c';
+
+  select id into occ from public.jobs
+   where parent_job_id='cb000000-0000-0000-0000-000000000001' and status='open'
+     and not exists (select 1 from public.job_occurrence_assignment_overrides o where o.job_id=jobs.id)
+   order by date desc limit 1;
+
+  perform public.update_job_occurrences('cb000000-0000-0000-0000-000000000001');
+
+  v := 'inaktiver_vererbt='||(exists(
+         select 1 from public.job_assignments ja
+         where ja.job_id=occ and ja.employee_id='ca000000-0000-0000-0000-00000000000c'))::text;
+  update public.profiles set is_active=true where id='ca000000-0000-0000-0000-00000000000c';
+  insert into _oi values (22,'Inaktiver Mitarbeiter wird nicht auf Termine vererbt','inaktiver_vererbt=false',v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: Invariante ueber ALLE Auftraege des Tests
+do $$
+declare v text;
+begin
+  select 'verletzungen='||count(*)::text into v
+  from public.jobs j
+  where j.assigned_to is not null
+    and not exists (select 1 from public.job_assignments ja
+                    where ja.job_id=j.id and ja.employee_id=j.assigned_to);
+  insert into _oi values (23,'Invariante: assigned_to IS NULL ODER durch Zuweisung gedeckt','verletzungen=0',v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+-- CASE 24: keine doppelten Zuweisungen ueber den gesamten Testlauf
+do $$
+declare v text;
+begin
+  select 'duplikate='||count(*)::text into v from (
+    select job_id, employee_id from public.job_assignments
+    where employee_id is not null group by 1,2 having count(*)>1) d;
+  insert into _oi values (24,'Keine doppelten (job_id, employee_id) nach allen Operationen','duplikate=0',v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _oi order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _oi where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'OCCURRENCE ASSIGNMENT INHERITANCE TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 24 FAELLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 4 von 11. **Reine Datenschicht** — kein App-Code, keine Änderung an `public.jobs`, an der RLS von `jobs`/`job_comments`/`job_photos`/`storage.objects`, an Benachrichtigungen oder an der offiziellen Zeit-Semantik.

Ziel: Zuweisungsmengen auf generierten Terminen dauerhaft und vorhersagbar machen. Ein Admin muss **einen** Termin individuell anpassen können, ohne dass eine spätere Regel-Änderung diese Anpassung still überschreibt.

---

## Exakte Ursache (reproduziert, nicht vermutet)

Regel R ist Mitarbeiter P zugewiesen, Termin O erbt P. Der Admin passt O individuell auf `{A, B}` an und ändert danach an der **Regel nur den Kundennamen**.

Beobachtetes Ergebnis über 5 identische Läufe:

```
{A,P} / {B,P} / {A,P} / {B,P} / {A,P}
```

Ablauf:

1. Der SYNC-Block von `update_job_occurrences` setzt auf **jedem** zukünftigen offenen Termin `assigned_to = effective_assigned_to` — und zwar bereits dann, wenn **irgendein** Regelfeld abweicht, im Beispiel nur `customer_name`.
2. Dieses UPDATE löst den Phase-2-Trigger `compat_sync_assignments_from_legacy` (Richtung A) aus. Der löscht die **saubere** Zuweisung von `OLD.assigned_to` und legt eine für `NEW.assigned_to` an.
3. `OLD.assigned_to` ist der von Phase 2 bestimmte **Primär** der angepassten Menge. Welcher der beiden das ist, entscheidet bei gleichem `assigned_at` der **zufällige id-Tiebreaker**.

Folge: Von `{A,B}` wird genau **ein** Mitarbeiter gelöscht — nicht deterministisch welcher — und der Regel-Mitarbeiter P wieder ergänzt. Weder sauberes Überschreiben noch sauberes Bewahren, sondern ein nicht reproduzierbarer Mischzustand, ausgelöst durch eine völlig unbeteiligte Feldänderung.

Nach dieser Änderung, gleiche Reproduktion, 3 Läufe: `{A,B}` / `{A,B}` / `{A,B}`.

---

## Architektur-Entscheidung: Markierungstabelle je Termin (Variante D)

`job_occurrence_assignment_overrides`: **Zeile vorhanden = individuell angepasst**, **Zeile fehlt = folgt der Regel**.

**Variante B (Herkunfts-Metadatum je `job_assignments`-Zeile) wurde wegen einer konkreten Lücke verworfen:** Passt ein Admin einen Termin auf die **leere** Menge an („heute niemand"), existiert keine einzige Zeile mehr, die die Markierung tragen könnte. Der Termin sähe wieder wie „geerbt" aus und die nächste Regel-Änderung würde ihn neu befüllen — Anforderung 3 wäre für den Leerfall verletzt. „Folgt der Regel" ist eine Eigenschaft des **Termins**, nicht der einzelnen Zuweisungszeile. Fall 8 der Suite deckt genau das ab.

**Variante A (Boolean auf `public.jobs`) verworfen:** fasst die am stärksten belastete Tabelle an, die zusätzlich Teil der `supabase_realtime`-Publication ist, und trägt kein Audit. **Variante C** ist dasselbe Konzept; D ist dessen Umsetzung — `jobs` bleibt vollständig unverändert, Audit (wer/wann) ist enthalten, Rückbau = Tabelle löschen.

### Zusätzliche Korrektur: `assigned_to` verlässt den SYNC-Block

Die eigentliche Beschädigung entsteht dadurch, dass die Regel-Synchronisierung die **Legacy-Spalte** schreibt und damit den Phase-2-Trigger als **Mengen-Mutator** missbraucht. `assigned_to` fällt deshalb aus dem SYNC-UPDATE heraus; stattdessen wird die Zuweisungs**menge** direkt abgeglichen. Den primären Mitarbeiter leitet weiterhin allein Phase 2 Richtung B ab — es bleibt bei **genau einer** Stelle dafür.

Für den heutigen Einzel-Mitarbeiter-Fall ist das verhaltensgleich: die Regel hat genau eine Zuweisung, der Termin erhält genau diese, `assigned_to` zeigt danach auf denselben Mitarbeiter wie zuvor. `non_destructive_update_job_occurrences` bleibt unverändert grün (20/20).

---

## Migration

`supabase/migrations/20260728000000_occurrence_assignment_inheritance.sql`

### Neue Datenbank-Objekte

| Objekt | Zweck |
|---|---|
| `job_occurrence_assignment_overrides` | Markierung je Termin (`job_id` PK, `customized_at`, `customized_by`), `ON DELETE CASCADE` auf `jobs` |
| `idx_job_occ_overrides_customized_by` | partieller FK-Rückwärtsindex |
| Policy `admin read occurrence overrides in own company` | nur Lesen, nur Admin der eigenen Firma |
| `inherit_occurrence_assignments(uuid, uuid)` | interner Mengenabgleich Regel → Termine, EXECUTE vollständig entzogen |
| `reset_job_occurrence_assignments(uuid)` | Admin-RPC: zurück auf „folgt der Regel" + sofortige Neuvererbung |

### Geänderte Funktionen

| Funktion | Änderung |
|---|---|
| `generate_job_occurrences` | überträgt jetzt die **vollständige** Regelmenge statt nur des Legacy-Mitarbeiters |
| `update_job_occurrences` | `assigned_to` aus SYNC entfernt; Mengenabgleich ergänzt (spart angepasste Termine aus). PRUNE und GENERATE unverändert |
| `set_job_assignments` | sperrt bei Terminen zuerst die Regel; markiert den Termin nach erfolgreicher Änderung als angepasst |

---

## Nebenläufigkeit

Durchgängige Sperrreihenfolge **Regel → Termin**. `update_job_occurrences` sperrt die Regel und danach implizit die Kind-Zeilen; `set_job_assignments` und `reset_job_occurrence_assignments` sperren bei einem Termin **zuerst** den Parent, dann den Termin. Dadurch entsteht kein Zyklus und damit kein Deadlock.

Im echten Zwei-Sitzungs-Test verifiziert: während ein Regel-Update die Parent-Sperre hielt, wartete die parallele Termin-Anpassung **3 065 ms**, lief danach korrekt durch, kein Deadlock, Endzustand wie erwartet (`angepasst=true`).

---

## RLS und Rechte-Härtung

⚠️ **Während der Testentwicklung gefunden und behoben.** Supabase vergibt auf **neue** Tabellen im `public`-Schema per Default-Privilegien automatisch **alle** Rechte an `anon` **und** `authenticated` (`SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER`). Ein bloßes `grant select` härtet daher **nichts** — jeder eingeloggte Nutzer hätte die Markierungen direkt setzen, löschen oder die Tabelle leeren und damit die gesamte Anpassungs-Garantie aushebeln können.

Korrigiert auf: erst vollständiger `REVOKE ALL … FROM anon, authenticated`, dann gezielt nur `GRANT SELECT TO authenticated` — exakt wie Phase 1 für `job_assignments`. Testfall 19 sichert das dauerhaft ab und überlebt einen vollständigen `db reset`.

Keine INSERT/UPDATE/DELETE-Policy und kein Schreibrecht: die Markierung setzt ausschließlich `set_job_assignments`, entfernt ausschließlich `reset_job_occurrence_assignments`.

---

## Bekannte Grenzen

- **Spurenbehaftete Zuweisungen werden nie entfernt**, auch nicht auf einem geerbten Termin. Ein solcher Termin kann dauerhaft mehr Mitarbeiter tragen als die Regel — bewusst, weil Nachweise Vorrang haben.
- Gestartete/abgeschlossene und vergangene Termine werden vom Mengenabgleich nie angefasst (bisheriges Verhalten).
- **Kein Backfill.** Bestehende Termine gelten alle als „folgt der Regel" — exakt das heutige Verhalten. Ein Backfill wäre eine Verhaltensänderung an Bestandsdaten.

---

## Tests

**Neue Suite `occurrence_assignment_inheritance.test.sql` — 24/24 PASS**

Vererbung (1–4): Termin erbt vollständige Regelmenge · Legacy gedeckt · nicht angepasster Termin folgt · keine Duplikate bei mehrfacher Synchronisierung.
Anpassung (5–8): Markierung gesetzt inkl. Audit · **Ursachen-Fall: unbeteiligtes Regelfeld ändert die Menge nicht mehr** · Regelmengen-Änderung lässt angepassten Termin unberührt · **leere angepasste Menge bleibt leer**.
Zurücksetzen (9–13): Regelmenge sofort wiederhergestellt · folgt danach wieder der Regel · auf Nicht-Termin abgelehnt · durch Employee abgelehnt · durch fremden Admin abgelehnt.
Nachweise (14–17): `started` überlebt Mengenabgleich · überlebt Anpassung und Zurücksetzen · gestarteter Termin ausgenommen · anonymisierte Zeile überlebt.
Struktur (18–24): Markierung kaskadiert mit dem Termin · **Rechte auf der Markierungstabelle** · EXECUTE-Rechte · Sperrreihenfolge im Code verankert · inaktiver Mitarbeiter nicht vererbt · Invariante · keine Duplikate.

**Regression: 211/211 grün** über 10 Suiten:

| Suite | Fälle |
|---|---|
| `occurrence_assignment_inheritance` | **24/24** |
| `job_assignments` | 25/25 |
| `job_assignments_dual_write` | 25/25 |
| `job_assignments_rls` | 30/30 |
| `non_destructive_update_job_occurrences` | 20/20 |
| `protect_recurring_job_history` | 7/7 |
| `recurring_jobs_display` | 38/38 |
| `admin_status_notifications` | 16/16 |
| `last_admin_deletion_reservation` | 14/14 |
| `profile_field_guard` | 12/12 |

`tsc --noEmit` und `expo lint` sauber. Vollständiger `supabase db reset` wendet alle 20 Migrationen fehlerfrei an.

---

## 🔍 Explizite Review-Punkte

1. **Override-Tabellen-Modell und Leerfall** — ist die Termin-Ebene (statt Herkunft je Zuweisungszeile) die richtige Wahl? Das Leermengen-Argument ist der entscheidende Punkt (Fall 8).
2. **Entfernung von `assigned_to` aus dem Recurring-SYNC** — ändert, wie die Legacy-Spalte für Termine gepflegt wird. Als verhaltensgleich für den Einzel-Mitarbeiter-Fall verifiziert; bitte gegenprüfen.
3. **Sperrreihenfolge Regel → Termin** — in `set_job_assignments` und `reset_job_occurrence_assignments`; Deadlock-Freiheit hängt daran.
4. **Reset-Semantik** — sofortige Neuvererbung statt Warten auf die nächste Regel-Änderung.
5. **Nachweis-Bewahrung** — entfernt werden ausschließlich spurenfreie Zeilen; Anwesenheit, Review, Zeitstempel, Namens-Schnappschüsse und anonymisierte Zeilen überleben Vererbung, Anpassung und Zurücksetzen.
6. **Rechte-Entzug auf der Markierungstabelle** — die oben beschriebene Default-Privilegien-Falle.
7. **Alt-Client-Mischmengen-Problem bleibt auf Phase 6 vertagt** — unverändert offen aus dem Phase-3-Review: ein alter Client, der `updateJob` auf einem mehrfach zugewiesenen Auftrag ausführt, erzeugt weiterhin eine Mischmenge (`{A,B}` + `updateJob(C)` → `{B,C}`). Nicht Teil dieser Phase, aber **vor Phase 6 zu lösen**.

---

## Staging und Produktion unberührt

`20260728000000` ist ausschließlich lokal vorhanden. Produktion (`ivzsbspopudqgobunsdv`) ist weiterhin auf `20260727000000`, Staging (`legzogskvcmicdgowyax`) wurde in dieser Phase nicht angefasst. **Nicht deployen, nicht mergen.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)