### PR TITLE
feat(db): allow employee reads through job assignments

### DIFF
--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -993,6 +993,10 @@ as $$
       public.current_user_role() = 'admin'
       or (
         public.current_user_role() = 'employee'
+        -- BEWUSST weiterhin nur der Legacy-Primär: das Markieren als
+        -- gelesen schreibt auf job_comment_reads, dessen Policies denselben
+        -- Primär verlangen. Ein Erweitern nur hier erzeugte einen dauerhaft
+        -- hängenden Ungelesen-Punkt (siehe 20260730000000, Abschnitt 5).
         and j.assigned_to = auth.uid()
       )
     )
@@ -1244,6 +1248,16 @@ using (
 -- Das schließt Parent-Recurring-Regeln (job_type = 'recurring') aus.
 -- Gilt für normale Single-Jobs (parent_job_id IS NULL) und
 -- generierte Occurrences (parent_job_id IS NOT NULL) gleichermaßen.
+--
+-- Zugewiesen gilt seit Phase 5 (20260730000000) über die Zuweisungsmenge
+-- job_assignments ODER den Legacy-Zeiger assigned_to. Der Legacy-Zweig
+-- bleibt als Obermenge stehen und fällt erst in Phase 11 mit der Spalte.
+--
+-- WICHTIG: job_type = 'single' steht bewusst AUSSERHALB der ODER-Klammer.
+-- Recurring-Parent-Regeln tragen seit Phase 4 selbst Zuweisungen (als
+-- Vorlage für ihre Occurrences); is_assigned_to_job() kennt job_type
+-- nicht. Innerhalb der Klammer würden Mitarbeiter deshalb plötzlich
+-- Parent-Regeln in ihrer Jobliste sehen.
 create policy "employee read own assigned jobs"
 on public.jobs
 for select
@@ -1251,8 +1265,11 @@ to authenticated
 using (
   public.current_user_role() = 'employee'
   and job_type = 'single'
-  and assigned_to = auth.uid()
   and company_id = public.current_user_company_id()
+  and (
+    assigned_to = auth.uid()
+    or public.is_assigned_to_job(id)
+  )
 );
 
 create policy "admin insert jobs in own company"
@@ -1306,7 +1323,8 @@ using (
   and company_id = public.current_user_company_id()
 );
 
--- Employee liest nur Kommentare zu den ihm zugewiesenen Jobs.
+-- Employee liest nur Kommentare zu den ihm zugewiesenen Jobs
+-- (Zuweisungsmenge oder Legacy-Zeiger, siehe Phase 5).
 create policy "employee read comments on own jobs"
 on public.job_comments
 for select
@@ -1318,7 +1336,10 @@ using (
     select 1
     from public.jobs j
     where j.id = job_comments.job_id
-      and j.assigned_to = auth.uid()
+      and (
+        j.assigned_to = auth.uid()
+        or public.is_assigned_to_job(j.id)
+      )
   )
 );
 
@@ -1445,6 +1466,15 @@ using (
 );
 
 -- Employee liest nur Fotos zu den ihm zugewiesenen Jobs.
+-- Zwei weite Policies aus der Remote-Baseline (20260713000000) prüfen die
+-- Zuweisung NICHT selbst, sondern verlassen sich allein darauf, ob der
+-- Aufrufer die jobs-Zeile sehen kann. Seit Phase 5 ist diese Sichtbarkeit
+-- weiter — sie würden dadurch transitiv ein Schreibrecht öffnen. Beide
+-- sind durch die strengen Policies unten vollständig abgedeckt und in
+-- 20260730000000 entfernt worden.
+drop policy if exists "job_photos: Firma darf Fotos lesen"     on public.job_photos;
+drop policy if exists "job_photos: Firma darf Fotos hochladen" on public.job_photos;
+
 drop policy if exists "employee read photos on own jobs" on public.job_photos;
 create policy "employee read photos on own jobs"
 on public.job_photos
@@ -1457,7 +1487,10 @@ using (
     select 1
     from public.jobs j
     where j.id = job_photos.job_id
-      and j.assigned_to = auth.uid()
+      and (
+        j.assigned_to = auth.uid()
+        or public.is_assigned_to_job(j.id)
+      )
   )
 );
 
@@ -1551,13 +1584,17 @@ using (
         public.current_user_role() = 'admin'
         or (
           public.current_user_role() = 'employee'
-          and j.assigned_to = auth.uid()
+          and (
+            j.assigned_to = auth.uid()
+            or public.is_assigned_to_job(j.id)
+          )
         )
       )
   )
 );
 
 -- INSERT (= Upload): nur in den eigenen Firmen-Pfad und nur für erlaubte Jobs.
+-- BEWUSST weiterhin an j.assigned_to gebunden (Schreibpfad, Phase 6/7).
 drop policy if exists "job-photos insert allowed" on storage.objects;
 create policy "job-photos insert allowed"
 on storage.objects

--- a/supabase/migrations/20260730000000_employee_read_via_assignments.sql
+++ b/supabase/migrations/20260730000000_employee_read_via_assignments.sql
@@ -1,0 +1,394 @@
+-- =========================================================
+-- MIGRATION: Employee-LESEZUGRIFF ueber job_assignments
+-- Datum: 2026-07-30   (Phase 5 von 11 — begleitende Sicherheitsschicht)
+-- =========================================================
+-- ZWECK
+--   Phase 5 stellt den React-Native-LESEPFAD von jobs.assigned_to auf die
+--   Zuweisungsmenge (job_assignments) um. Ohne diese Migration liefe die
+--   Umstellung ins Leere: ein Mitarbeiter, der einem Auftrag zugewiesen
+--   ist, ohne der von der Kompatibilitaetsschicht bestimmte PRIMAER zu
+--   sein, sieht die jobs-Zeile ueberhaupt nicht — er darf zwar die
+--   job_assignments-Zeilen lesen (Phase 3), aber die zugehoerige
+--   jobs-Zeile bleibt ihm durch die Employee-SELECT-Policy verborgen.
+--
+--   Genau diese Policies haengen bis heute an der Einzel-Spalte
+--   jobs.assigned_to. Keine der Migrationen aus Phase 1 bis 4.1 hat sie
+--   angefasst (verifiziert: kein "create policy ... on public.jobs" in
+--   supabase/migrations/).
+--
+-- =========================================================
+-- DIESE MIGRATION IST AUSSCHLIESSLICH EINE LESE-AENDERUNG
+-- =========================================================
+-- Geaendert werden GENAU VIER Policies, alle rein lesend:
+--
+--   1. public.jobs          Policy "employee read own assigned jobs"   (SELECT)
+--   2. public.job_comments  Policy "employee read comments on own jobs"(SELECT)
+--   3. public.job_photos    Policy "employee read photos on own jobs"  (SELECT)
+--   4. storage.objects      Policy "job-photos read allowed"           (SELECT)
+--
+-- Dazu kommt in Abschnitt 6 das Entfernen zweier redundanter, ZU WEITER
+-- Bestands-Policies auf public.job_photos — ohne das waere die Migration
+-- NICHT lesend (Begruendung dort, mit reproduziertem Testfall).
+--
+-- BEWUSST NICHT ANGEFASST — alle Schreibpfade bleiben exakt wie sie sind
+-- und haengen weiterhin an jobs.assigned_to:
+--
+--   * "employee insert comments on own jobs"   (job_comments INSERT)
+--   * "employee insert photos on own jobs"     (job_photos  INSERT)
+--   * "insert/update own comment-read state"   (job_comment_reads)
+--   * "job-photos insert allowed"              (storage     INSERT)
+--   * public.start_own_job() / public.complete_own_job()
+--   * public.get_unread_comment_job_ids()      (siehe Abschnitt 5)
+--   * saemtliche Admin-Policies auf jobs/job_comments/job_photos
+--   * saemtliche Policies und Grants auf public.job_assignments (Phase 3)
+--
+-- KEIN neuer GRANT, KEINE neue Funktion, KEINE Tabellen-, Trigger- oder
+-- Enum-Aenderung, KEINE einzige DML-Anweisung.
+--
+-- =========================================================
+-- EINE BEKANNTE, NICHT HIER BEHOBENE NEBENWIRKUNG
+-- =========================================================
+-- Die Storage-Policy "job-photos delete own upload" (existiert nur in der
+-- Produktionsdatenbank, in keiner Migration) prueft
+--     owner = auth.uid()  AND  EXISTS (select 1 from jobs j
+--                                      where j.id = <aus dem Pfad>
+--                                        and j.company_id = <eigene Firma>)
+-- Der jobs-Teilausdruck ist NUR auf die Firma eingeschraenkt und laeuft
+-- unter der jobs-RLS des Aufrufers. Abschnitt 1 erweitert genau diese
+-- Sichtbarkeit — ein sekundaer Zugewiesener kann danach also eine SELBST
+-- hochgeladene Datei auch an einem Auftrag loeschen, an dem er nicht der
+-- Legacy-Primaer ist. Betroffen sind ausschliesslich eigene Uploads.
+--
+-- Diese Policy wird hier BEWUSST NICHT angefasst: sie gehoert zur
+-- Produktions-Drift des storage-Schemas (dort existieren weitere, in
+-- keiner Migration gefuehrte Policies), die in einem eigenen PR
+-- aufgearbeitet wird. Die Aussage "diese Migration aendert keinerlei
+-- Schreibrechte" waere ohne diesen Hinweis unzutreffend.
+--
+-- =========================================================
+-- BEWUSSTE ASYMMETRIE (dokumentiert, kein Versehen)
+-- =========================================================
+-- Nach dieser Migration kann ein NICHT-primaerer Zugewiesener einen
+-- Auftrag, seine Kommentare und seine Fotos LESEN, aber
+--   * keinen Kommentar schreiben,
+--   * kein Foto hochladen,
+--   * den Auftrag nicht starten/abschliessen.
+-- Das ist fuer eine reine Lese-Phase korrekt und beabsichtigt. Die
+-- Schreibpfade folgen in Phase 6/7 zusammen mit der Umstellung von
+-- start_own_job/complete_own_job. Bis dahin muss der Client seine
+-- Aktions-Buttons weiterhin am Legacy-Primaer (jobs.assigned_to)
+-- ausrichten, NICHT an der Zuweisungsmenge — sonst bietet er einem
+-- sekundaeren Zugewiesenen einen Button an, der serverseitig mit
+-- "Job not found or not allowed" fehlschlaegt.
+--
+-- =========================================================
+-- DREI TRAGENDE ENTWURFSENTSCHEIDUNGEN
+-- =========================================================
+-- (A) DER LEGACY-VERGLEICH BLEIBT STEHEN.
+--     Das Praedikat lautet ueberall
+--         assigned_to = auth.uid()  OR  public.is_assigned_to_job(<job>)
+--     also eine echte OBERMENGE des heutigen Verhaltens. Kein Mitarbeiter
+--     kann durch diese Migration Zugriff VERLIEREN — auch nicht in den
+--     Bestandsfaellen, die der Guard aus Phase 1 heute nicht mehr
+--     erzeugen wuerde (im Backfill als "nicht konform" ausgewiesen) und
+--     fuer die deshalb keine Garantie besteht, dass jede assigned_to-
+--     Zuweisung eine passende job_assignments-Zeile besitzt. Der
+--     Legacy-Zweig faellt erst in Phase 11 mit der Spalte selbst.
+--
+-- (B) job_type = 'single' MUSS AUSSERHALB DER ODER-KLAMMER BLEIBEN.
+--     Das ist die eigentliche Falle dieser Migration: Recurring-PARENT-
+--     Regeln tragen seit Phase 4 SELBST Zuweisungen (sie sind die
+--     Vorlage, von der Occurrences erben). is_assigned_to_job() kennt
+--     job_type nicht und liefert fuer eine Parent-Regel deshalb true.
+--     Wuerde man die neue Bedingung naiv an die bestehende Policy
+--     anhaengen, saehen Mitarbeiter ab sofort Parent-Regeln in ihrer
+--     Jobliste — eine stille Ausweitung, die es heute nicht gibt und die
+--     das gesamte Modell "Employees sehen nur ausfuehrbare Termine"
+--     bricht. Die Einschraenkung steht daher als eigenstaendiges AND
+--     VOR der Klammer.
+--
+-- (C) KEINE REKURSION.
+--     public.is_assigned_to_job(uuid) ist SECURITY DEFINER (Phase 3,
+--     20260727000000). Ihre Lesezugriffe auf job_assignments und jobs
+--     laufen im Rechtekontext des Eigentuemers und unterliegen keiner
+--     RLS — sie kann die Policy, die sie aufruft, also nicht erneut
+--     betreten. Die Funktion ist bereits fuer authenticated ausfuehrbar
+--     (grant execute in Phase 3); diese Migration vergibt KEIN neues
+--     Recht. Zur Begruendung, warum Policy-Helfer fuer authenticated
+--     ausfuehrbar sein MUESSEN, siehe den Kommentarblock in
+--     20260727000000_job_assignments_rls.sql.
+--
+-- IDEMPOTENZ
+--   Vollstaendig wiederholbar: alle Policies via DROP IF EXISTS + CREATE,
+--   die Funktion via CREATE OR REPLACE.
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md).
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. public.jobs — Employee-Lesepolicy
+-- ---------------------------------------------------------
+-- Vorher:  ... and assigned_to = auth.uid() and company_id = ...
+-- Nachher: identisch, plus ODER-Zweig ueber die Zuweisungsmenge.
+-- job_type = 'single' bleibt eigenstaendige Bedingung (siehe (B)).
+drop policy if exists "employee read own assigned jobs" on public.jobs;
+create policy "employee read own assigned jobs"
+on public.jobs
+for select
+to authenticated
+using (
+  public.current_user_role() = 'employee'
+  and job_type = 'single'
+  and company_id = public.current_user_company_id()
+  and (
+    assigned_to = auth.uid()
+    or public.is_assigned_to_job(id)
+  )
+);
+
+
+-- ---------------------------------------------------------
+-- 2. public.job_comments — Employee-Lesepolicy
+-- ---------------------------------------------------------
+-- Der EXISTS-Block auf jobs bleibt erhalten (er traegt die Verknuepfung
+-- Kommentar -> Auftrag); erweitert wird ausschliesslich die Bedingung,
+-- WER als zugewiesen gilt.
+--
+-- Hier ist KEINE job_type-Einschraenkung noetig und es waere falsch, eine
+-- einzufuehren: an einer Parent-Regel existieren fachlich keine
+-- Kommentare fuer Mitarbeiter, und die bestehende Policy kennt die
+-- Einschraenkung ebenfalls nicht. Sichtbarkeit entsteht ohnehin erst
+-- ueber einen konkreten Kommentar zu einem konkreten Auftrag.
+drop policy if exists "employee read comments on own jobs" on public.job_comments;
+create policy "employee read comments on own jobs"
+on public.job_comments
+for select
+to authenticated
+using (
+  public.current_user_role() = 'employee'
+  and company_id = public.current_user_company_id()
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = job_comments.job_id
+      and (
+        j.assigned_to = auth.uid()
+        or public.is_assigned_to_job(j.id)
+      )
+  )
+);
+
+-- HINWEIS: "employee insert comments on own jobs" bleibt UNVERAENDERT
+-- und weiterhin an j.assigned_to = auth.uid() gebunden. Schreibrechte
+-- sind nicht Teil dieser Migration (Phase 6/7).
+
+
+-- ---------------------------------------------------------
+-- 3. public.job_photos — Employee-Lesepolicy
+-- ---------------------------------------------------------
+drop policy if exists "employee read photos on own jobs" on public.job_photos;
+create policy "employee read photos on own jobs"
+on public.job_photos
+for select
+to authenticated
+using (
+  public.current_user_role() = 'employee'
+  and company_id = public.current_user_company_id()
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = job_photos.job_id
+      and (
+        j.assigned_to = auth.uid()
+        or public.is_assigned_to_job(j.id)
+      )
+  )
+);
+
+-- HINWEIS: "employee insert photos on own jobs" bleibt UNVERAENDERT.
+
+
+-- ---------------------------------------------------------
+-- 4. storage.objects — Lesepolicy des Buckets job-photos
+-- ---------------------------------------------------------
+-- Ohne diese Anpassung sieht ein sekundaerer Zugewiesener zwar die
+-- job_photos-Zeile (Punkt 3), bekommt aber beim Laden der Datei einen
+-- Zugriffsfehler — die Galerie zeigte dann leere Kacheln.
+--
+-- ZWEI AUSGANGSLAGEN — die Anweisung unten ist fuer beide korrekt, das
+-- ERGEBNIS ist es ebenfalls, aber der Weg dorthin unterscheidet sich:
+--
+--   a) PRODUKTION: die Policy existiert bereits (dort manuell angewandt,
+--      siehe lib/schema.sql — Storage-Policies sind in KEINER Migration
+--      gefuehrt). DROP + CREATE ERSETZT sie; Pfadaufbau und Firmenpruefung
+--      bleiben identisch, erweitert wird nur der Employee-Zweig.
+--
+--   b) AUS MIGRATIONEN GEBAUTE UMGEBUNG (lokaler Reset, frisches Staging):
+--      die Policy existiert NICHT — das DROP laeuft ins Leere ("does not
+--      exist, skipping") und das CREATE legt sie ERSTMALS an. Dort ist das
+--      also keine Erweiterung, sondern die Erstvergabe eines Leserechts.
+--      Vorher konnte in so einer Umgebung NIEMAND Dateien des Buckets
+--      lesen, weil ueberhaupt keine SELECT-Policy existierte.
+--
+-- Diese Divergenz ist ein Symptom der Storage-Drift (die INSERT-/DELETE-
+-- Policies fehlen in Migrationen ebenfalls, und in Produktion existieren
+-- zusaetzliche, weiter gefasste Storage-Policies). Sie wird hier NICHT
+-- behoben — dafuer ist der eigene Storage-PR zustaendig. Konsequenz fuer
+-- Reviews: ein gruener Lauf gegen eine aus Migrationen gebaute Datenbank
+-- sagt NICHTS ueber das Storage-Verhalten in Produktion aus.
+drop policy if exists "job-photos read allowed" on storage.objects;
+create policy "job-photos read allowed"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'job-photos'
+  and (storage.foldername(name))[1] = public.current_user_company_id()::text
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = ((storage.foldername(name))[2])::uuid
+      and j.company_id = public.current_user_company_id()
+      and (
+        public.current_user_role() = 'admin'
+        or (
+          public.current_user_role() = 'employee'
+          and (
+            j.assigned_to = auth.uid()
+            or public.is_assigned_to_job(j.id)
+          )
+        )
+      )
+  )
+);
+
+-- HINWEIS: "job-photos insert allowed" und "job-photos delete own upload"
+-- bleiben UNVERAENDERT an j.assigned_to = auth.uid() gebunden.
+
+
+-- ---------------------------------------------------------
+-- 5. BEWUSST NICHT GEAENDERT: get_unread_comment_job_ids()
+-- ---------------------------------------------------------
+-- Ein frueherer Entwurf dieser Migration hat die RPC ebenfalls um den
+-- Zuweisungs-Zweig erweitert, damit die Ungelesen-Kennzeichnung zur neuen
+-- Kommentar-Sichtbarkeit passt. Das war FALSCH und wird hier bewusst
+-- unterlassen:
+--
+--   Das Markieren als gelesen ist ein SCHREIBVORGANG auf
+--   public.job_comment_reads. Dessen INSERT- und UPDATE-Policies
+--   ("insert own comment-read state" / "update own comment-read state")
+--   verlangen weiterhin
+--       EXISTS (select 1 from jobs j
+--               where j.id = job_comment_reads.job_id
+--                 and (admin or (employee and j.assigned_to = auth.uid())))
+--   also den LEGACY-PRIMAER. Sie gehoeren zum Schreibpfad und duerfen in
+--   dieser rein lesenden Phase nicht angefasst werden.
+--
+--   Haette man nur die RPC erweitert, waere fuer einen sekundaer
+--   Zugewiesenen ein DAUERHAFT HAENGENDER Zustand entstanden: die RPC
+--   meldet den Auftrag als ungelesen, das Markieren scheitert mit 42501,
+--   der Fehler wird im JobContext geschluckt — der rote Punkt kaeme nach
+--   jedem Refresh zurueck und liesse sich nie entfernen. Lokal
+--   reproduziert (SEC-READ sichtbar=1 / SEC-UNREAD ungelesen=1 /
+--   SEC-MARKREAD ABGELEHNT 42501).
+--
+-- GEWAEHLTE LOESUNG (die kleinere und sichere): die RPC bleibt
+-- unveraendert. Ein sekundaer Zugewiesener sieht die Kommentare eines
+-- Auftrags, bekommt dafuer aber (noch) keine Ungelesen-Kennzeichnung.
+-- Das ist ein fehlender Hinweis, KEIN kaputter Zustand — und exakt das
+-- heutige Verhalten. Die Kennzeichnung folgt in Phase 6/7 gemeinsam mit
+-- den Schreibpfaden, dann konsistent mit job_comment_reads.
+--
+-- Der Client stellt zusaetzlich sicher, dass fuer einen sekundaer
+-- Zugewiesenen gar kein Markier-Versuch mehr abgesetzt wird
+-- (JobDetailScreen), damit kein stiller 42501 im Log landet.
+-- ---------------------------------------------------------
+-- 6. Zwei veraltete, ZU WEITE job_photos-Policies entfernen
+-- ---------------------------------------------------------
+-- WARUM DAS HIER STEHT — sonst waere diese Migration NICHT read-only:
+--
+-- In der Produktionsdatenbank existieren zwei Policies aus der Zeit vor
+-- der heutigen Rechtestruktur (uebernommen in
+-- 20260713000000_remote_baseline.sql, Zeilen 965 und 971):
+--
+--   "job_photos: Firma darf Fotos lesen"      (SELECT)
+--   "job_photos: Firma darf Fotos hochladen"  (INSERT)
+--
+-- Beide pruefen NICHT die Zuweisung, sondern nur:
+--   company_id = current_user_company_id()
+--   AND EXISTS (select 1 from public.jobs j
+--               where j.id = job_photos.job_id
+--                 and j.company_id = current_user_company_id())
+--
+-- Entscheidend ist, dass diese Unterabfrage auf public.jobs der
+-- JOBS-RLS DES AUFRUFERS unterliegt (sie steht in einer Policy, nicht in
+-- einer SECURITY-DEFINER-Funktion). Ihre gesamte Schutzwirkung stammt
+-- also nicht aus der Policy selbst, sondern daraus, WELCHE jobs-Zeilen
+-- der Aufrufer sehen darf. Bis heute war das genau die Menge
+-- "assigned_to = auth.uid()", weshalb die beiden weiten Policies faktisch
+-- dasselbe erlaubten wie die strengen aus lib/schema.sql und nie
+-- auffielen.
+--
+-- Abschnitt 1 dieser Migration erweitert exakt jene jobs-Sichtbarkeit.
+-- Damit wuerde die weite INSERT-Policy ab sofort auch einem SEKUNDAEREN
+-- Zugewiesenen das Anlegen von job_photos-Zeilen erlauben — eine
+-- SCHREIBRECHTS-Erweiterung als Nebenwirkung einer Lese-Aenderung. Genau
+-- das ist ausgeschlossen. (Im lokalen Testlauf ist das reproduziert
+-- worden, bevor dieser Abschnitt existierte: Fall 16 schlug fehl,
+-- der Upload wurde AKZEPTIERT.)
+--
+-- Die weite SELECT-Policy traegt dasselbe Problem in harmloserer Form:
+-- sie waere ab sofort die eigentlich wirksame Lese-Regel, waehrend die
+-- dokumentierte, strenge Policy nur noch danebensteht.
+--
+-- BEIDE SIND VOLLSTAENDIG REDUNDANT und werden deshalb entfernt:
+--   * Lesen:  "admin read photos in own company" deckt Admins ab,
+--             "employee read photos on own jobs" (Abschnitt 3) deckt
+--             Zugewiesene ab — inklusive der neuen Zuweisungsmenge.
+--   * Anlegen:"admin insert photos in own company" deckt Admins ab,
+--             "employee insert photos on own jobs" deckt Zugewiesene ab
+--             (unveraendert an assigned_to gebunden).
+--
+-- NETTOWIRKUNG AUF SCHREIBRECHTE = NULL. Verglichen mit dem Zustand VOR
+-- dieser Migration kann nach ihr exakt derselbe Personenkreis Fotos
+-- anlegen wie vorher. Das Entfernen nimmt niemandem ein heute
+-- tatsaechlich nutzbares Recht — es verhindert nur, dass Abschnitt 1
+-- eines dazugibt.
+--
+-- KORREKTUR EINER FRUEHEREN BEGRUENDUNG: hier stand zunaechst, ein
+-- sekundaer Zugewiesener haette ueber die weite Policy zwar eine
+-- Foto-ZEILE anlegen koennen, aber nicht die Datei hochladen duerfen.
+-- Das ist fuer die PRODUKTIONSDATENBANK nachweislich falsch: dort
+-- existiert zusaetzlich die Policy
+--     "job-photos storage: Hochladen in eigenen Firma-Ordner"
+-- die ausschliesslich Bucket und Firmen-Ordner prueft und damit jedem
+-- Mitarbeiter der Firma den Upload in JEDEN Auftragsordner erlaubt
+-- (lokal mit dem Produktions-Policy-Stand reproduziert). Das Entfernen
+-- der beiden weiten job_photos-Policies bleibt trotzdem richtig und
+-- notwendig — die Begruendung ist schlicht die oben genannte
+-- Transitivitaet, nicht ein angeblicher Zwischenzustand. Die weiten
+-- STORAGE-Policies sind Teil der Produktions-Drift und werden in einem
+-- eigenen PR behandelt, nicht hier.
+drop policy if exists "job_photos: Firma darf Fotos lesen"     on public.job_photos;
+drop policy if exists "job_photos: Firma darf Fotos hochladen" on public.job_photos;
+
+
+-- =========================================================
+-- ROLLBACK
+-- =========================================================
+-- Rein lesende Aenderung ohne Datenmigration — der Rueckweg besteht
+-- darin, die vier Policies in ihrer Fassung aus lib/schema.sql (Stand vor
+-- dieser Migration) neu anzulegen, also jeweils den ODER-Zweig
+-- "or public.is_assigned_to_job(...)" zu entfernen.
+-- Danach sehen Mitarbeiter wieder ausschliesslich die Auftraege, bei
+-- denen sie der Legacy-Primaer sind. Es gehen dabei keine Daten
+-- verloren; job_assignments bleibt unberuehrt.
+--
+-- Die beiden in Abschnitt 6 entfernten job_photos-Policies muessen fuer
+-- einen Rollback NICHT wiederhergestellt werden: sie sind durch die
+-- strengen Policies vollstaendig abgedeckt (Begruendung dort). Wer sie
+-- dennoch exakt zurueckholen will, findet ihren Wortlaut in
+-- supabase/migrations/20260713000000_remote_baseline.sql, Zeilen 965/971.

--- a/supabase/tests/employee_read_via_assignments.test.sql
+++ b/supabase/tests/employee_read_via_assignments.test.sql
@@ -1,0 +1,670 @@
+-- =========================================================
+-- TEST: Employee-Lesezugriff ueber job_assignments
+-- (Migration 20260730000000_employee_read_via_assignments)
+-- =========================================================
+-- Prueft, dass ein SEKUNDAERER Zugewiesener (also einer, der NICHT der von
+-- der Kompatibilitaetsschicht bestimmte Legacy-Primaer ist) Auftrag,
+-- Kommentare und Fotos LESEN darf — und dass dabei WEDER Schreibrechte
+-- NOCH die Sichtbarkeit von Recurring-Parent-Regeln NOCH firmenfremde
+-- Daten aufgehen.
+--
+-- Die Ungelesen-Kennzeichnung (get_unread_comment_job_ids) bleibt
+-- ABSICHTLICH am Legacy-Primaer: sie haengt am Schreibpfad
+-- job_comment_reads, der in dieser Lese-Phase nicht angefasst wird. Die
+-- Faelle 12, 12b und 12c sichern genau diese Kopplung ab — sie ist der
+-- Grund, warum ein blosses Erweitern der RPC einen dauerhaft haengenden
+-- Ungelesen-Punkt erzeugt haette.
+--
+-- Alle Zugriffe laufen als echte Rollen (SET ROLE + request.jwt.claims),
+-- also ueber denselben Pfad wie die App ueber PostgREST.
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende, keine
+-- Produktionsdaten. Ausfuehren lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/employee_read_via_assignments.test.sql
+-- =========================================================
+
+begin;
+
+-- =========================================================
+-- HINWEIS ZU „VERWEIGERT"-PFADEN
+-- =========================================================
+-- Wie in job_assignments_rls.test.sql ausfuehrlich begruendet: der lokale
+-- Supabase-Container stuerzt bei einem permission-denied-Fehler ab. Alle
+-- Verweigerungen in DIESEM Test laufen jedoch ueber RLS-POLICIES (nicht
+-- ueber fehlende Privilegien) — ein Nutzer sieht schlicht keine Zeile
+-- bzw. ein INSERT wird durch die WITH-CHECK-Klausel abgelehnt. Solche
+-- Faelle loesen keinen permission-denied-Fehler aus und werden hier
+-- deshalb durch echte Zugriffe geprueft.
+-- =========================================================
+
+-- ── Fixdaten ──
+-- Firma A = e1…1 | Firma B = e1…2
+-- Admin A  = e2…1
+-- PRIMAER  = e2…2  (Legacy-Zeiger jobs.assigned_to zeigt auf ihn)
+-- SEKUNDAER= e2…3  (nur ueber job_assignments zugewiesen)
+-- FREMD A  = e2…4  (Firma A, diesem Auftrag NICHT zugewiesen)
+-- Admin B  = e2…5 | Employee B = e2…6 (andere Firma)
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000001','authenticated','authenticated','v-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000002','authenticated','authenticated','v-primaer@example.test','{"full_name":"Paula Primaer"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000003','authenticated','authenticated','v-sekundaer@example.test','{"full_name":"Simon Sekundaer"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000004','authenticated','authenticated','v-fremd@example.test','{"full_name":"Frida Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000005','authenticated','authenticated','v-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000006','authenticated','authenticated','v-b1@example.test','{"full_name":"Bea Fremdfirma"}');
+end $$;
+
+-- Der auth-Trigger handle_new_user ist in der lokalen Baseline nicht
+-- enthalten — Profile werden deshalb explizit angelegt.
+insert into public.profiles (id, full_name) values
+  ('e2000000-0000-0000-0000-000000000001','Admin A'),
+  ('e2000000-0000-0000-0000-000000000002','Paula Primaer'),
+  ('e2000000-0000-0000-0000-000000000003','Simon Sekundaer'),
+  ('e2000000-0000-0000-0000-000000000004','Frida Fremd'),
+  ('e2000000-0000-0000-0000-000000000005','Admin B'),
+  ('e2000000-0000-0000-0000-000000000006','Bea Fremdfirma')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('e1000000-0000-0000-0000-000000000001','Lese Firma A','lese-firma-a-test'),
+  ('e1000000-0000-0000-0000-000000000002','Lese Firma B','lese-firma-b-test');
+
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='admin',    is_active=true where id='e2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true where id in
+  ('e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000004');
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='admin',    is_active=true where id='e2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='employee', is_active=true where id='e2000000-0000-0000-0000-000000000006';
+
+-- Auftraege:
+--   J1 = Firma A, single, spaeter {PRIMAER, SEKUNDAER}
+--   J2 = Firma A, single, unzugewiesen (Kontrollgruppe)
+--   J3 = Firma B, single, dortiger Mitarbeiter zugewiesen (Firmengrenze)
+--   J4 = Firma A, RECURRING-PARENT — bekommt eine Zuweisung als Vorlage
+--   J5 = Firma A, single, Occurrence von J4
+insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                         location_address, status, job_type, date, start_time, recurring_days,
+                         is_active, created_at, updated_at, parent_job_id) values
+  ('e4000000-0000-0000-0000-000000000001','e1000000-0000-0000-0000-000000000001',null,'e2000000-0000-0000-0000-000000000001','K1','S1','O1','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('e4000000-0000-0000-0000-000000000002','e1000000-0000-0000-0000-000000000001',null,'e2000000-0000-0000-0000-000000000001','K2','S2','O2','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('e4000000-0000-0000-0000-000000000003','e1000000-0000-0000-0000-000000000002',null,'e2000000-0000-0000-0000-000000000005','K3','S3','O3','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('e4000000-0000-0000-0000-000000000004','e1000000-0000-0000-0000-000000000001',null,'e2000000-0000-0000-0000-000000000001','K4','S4','O4','open','recurring',null,'08:00',array['mon'],true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('e4000000-0000-0000-0000-000000000005','e1000000-0000-0000-0000-000000000001',null,'e2000000-0000-0000-0000-000000000001','K5','S5','O5','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00','e4000000-0000-0000-0000-000000000004');
+
+create temporary table _r (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+
+-- =========================================================
+-- Ausgangslage herstellen
+-- =========================================================
+-- WICHTIG fuer die Aussagekraft des gesamten Tests: der Legacy-Zeiger
+-- muss DETERMINISTISCH auf PRIMAER stehen, damit SEKUNDAER wirklich der
+-- nicht-primaere Fall ist. Phase 2 waehlt bei zeitgleichen Zuweisungen
+-- ueber den zufaelligen id-Tiebreaker. Deshalb wird PRIMAER zuerst
+-- gesetzt (Regel 1 von compat_primary_assignee behaelt einen gedeckten
+-- Zeiger bei) und SEKUNDAER erst danach ergaenzt.
+do $$
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  -- Schritt 1: nur PRIMAER -> Legacy-Zeiger steht eindeutig auf ihm.
+  perform public.set_job_assignments('e4000000-0000-0000-0000-000000000001',
+    array['e2000000-0000-0000-0000-000000000002']::uuid[]);
+  -- Schritt 2: SEKUNDAER ergaenzen -> Zeiger bleibt auf PRIMAER.
+  perform public.set_job_assignments('e4000000-0000-0000-0000-000000000001',
+    array['e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003']::uuid[]);
+  -- Recurring-Parent bekommt SEKUNDAER als Vorlage (Phase 4).
+  perform public.set_job_assignments('e4000000-0000-0000-0000-000000000004',
+    array['e2000000-0000-0000-0000-000000000003']::uuid[]);
+  execute 'reset role';
+end $$;
+
+-- Fremdfirmen-Auftrag J3 direkt verdrahten (kein RPC noetig, Admin B waere
+-- ein zweiter Rollenwechsel ohne zusaetzlichen Erkenntnisgewinn).
+insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+values ('e4000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000006','Bea Fremdfirma');
+
+-- Kommentare und Fotos an J1 (vom Admin verfasst — eigene Kommentare
+-- zaehlen nie als ungelesen, der Autor muss also ein anderer sein).
+insert into public.job_comments (id, company_id, job_id, author_id, message, created_at) values
+  ('e5000000-0000-0000-0000-000000000001','e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000001','Hinweis vom Admin', now());
+
+insert into public.job_photos (id, company_id, job_id, uploaded_by, storage_path, file_name) values
+  ('e6000000-0000-0000-0000-000000000001','e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000001',
+   'e1000000-0000-0000-0000-000000000001/e4000000-0000-0000-0000-000000000001/foto.jpg','foto.jpg');
+
+-- CASE 0: Ausgangslage — Legacy-Zeiger steht auf PRIMAER, Menge ist {P,S}
+do $$
+declare v text;
+begin
+  select 'legacy='||coalesce(j.assigned_to::text,'NULL')
+       ||'/anzahl='||(select count(*)::text from public.job_assignments ja where ja.job_id=j.id)
+    into v
+  from public.jobs j where j.id='e4000000-0000-0000-0000-000000000001';
+  insert into _r values (0,'Ausgangslage: Legacy-Primaer ist PRIMAER, Menge hat 2 Zuweisungen',
+    'legacy=e2000000-0000-0000-0000-000000000002/anzahl=2', v);
+  raise notice 'CASE 0 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- A. Die eigentliche Erweiterung: Lesen als SEKUNDAER
+-- =========================================================
+
+-- CASE 1: SEKUNDAER sieht die jobs-Zeile (vor der Migration: NICHT sichtbar)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (1,'Sekundaerer Zugewiesener sieht den Auftrag','sichtbar=1',v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: PRIMAER sieht ihn weiterhin (keine Regression)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  select 'sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (2,'Primaerer Zugewiesener sieht den Auftrag weiterhin','sichtbar=1',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: nicht zugewiesener Mitarbeiter derselben Firma sieht ihn NICHT
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select 'sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (3,'Nicht zugewiesener Mitarbeiter sieht den Auftrag nicht','sichtbar=0',v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- CASE 4: Mitarbeiter der FREMDEN Firma sieht ihn nicht (Firmengrenze haelt)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000006');
+  execute 'set local role authenticated';
+  select 'fremd_sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (4,'Mitarbeiter fremder Firma sieht den Auftrag nicht','fremd_sichtbar=0',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- CASE 5: SEKUNDAER sieht auch die Zuweisungszeilen der Kollegen (Phase 3)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'zuweisungen='||count(*)::text into v
+  from public.job_assignments where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (5,'Sekundaerer sieht die vollstaendige Zuweisungsmenge','zuweisungen=2',v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- B. Die Falle: Recurring-Parent-Regeln bleiben unsichtbar
+-- =========================================================
+
+-- CASE 6: SEKUNDAER ist der Parent-REGEL zugewiesen, darf sie aber NICHT
+-- sehen (job_type='single' steht ausserhalb der ODER-Klammer).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'parent_sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000004';
+  execute 'reset role';
+  insert into _r values (6,'Recurring-Parent-Regel bleibt fuer Mitarbeiter unsichtbar (trotz Zuweisung)',
+    'parent_sichtbar=0',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: Gegenprobe — eine Occurrence (job_type='single') derselben Regel
+-- ist sichtbar, sobald sie zugewiesen ist.
+do $$
+declare v text;
+begin
+  insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+  values ('e4000000-0000-0000-0000-000000000005','e2000000-0000-0000-0000-000000000003','Simon Sekundaer');
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'occurrence_sichtbar='||count(*)::text into v
+  from public.jobs where id='e4000000-0000-0000-0000-000000000005';
+  execute 'reset role';
+  insert into _r values (7,'Occurrence der Regel ist sichtbar (Gegenprobe zu Fall 6)',
+    'occurrence_sichtbar=1',v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- C. Kommentare, Fotos, Ungelesen-Kennzeichnung
+-- =========================================================
+
+-- CASE 8: SEKUNDAER liest die Kommentare des Auftrags
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'kommentare='||count(*)::text into v
+  from public.job_comments where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (8,'Sekundaerer liest Kommentare des Auftrags','kommentare=1',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- CASE 9: nicht Zugewiesener liest sie nicht
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select 'kommentare='||count(*)::text into v
+  from public.job_comments where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (9,'Nicht Zugewiesener liest keine Kommentare','kommentare=0',v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- CASE 10: SEKUNDAER sieht die Foto-Zeile
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'fotos='||count(*)::text into v
+  from public.job_photos where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (10,'Sekundaerer sieht die Fotos des Auftrags','fotos=1',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- CASE 11: nicht Zugewiesener sieht sie nicht
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select 'fotos='||count(*)::text into v
+  from public.job_photos where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (11,'Nicht Zugewiesener sieht keine Fotos','fotos=0',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: Ungelesen-RPC meldet dem SEKUNDAEREN NICHTS.
+--
+-- Das ist BEABSICHTIGT und der Kern der Entscheidung aus Abschnitt 5 der
+-- Migration: die RPC bleibt unveraendert am Legacy-Primaer. Wuerde man sie
+-- erweitern, ohne die Schreib-Policies von job_comment_reads mitzuziehen,
+-- entstuende ein dauerhaft haengender Ungelesen-Punkt (Fall 12b).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'ungelesen='||count(*)::text into v
+  from public.get_unread_comment_job_ids() g
+  where g = 'e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (12,'Ungelesen-RPC bleibt am Legacy-Primaer (Sekundaerer erhaelt nichts)','ungelesen=0',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- CASE 12b: der Grund dafuer, als harter Regressionsschutz.
+-- Der Sekundaere darf den Ungelesen-Status NICHT schreiben. Solange das so
+-- ist, DARF die RPC ihn ihm auch nicht melden — sonst haengt der Punkt.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_comment_reads (job_id, user_id, last_seen_at)
+    values ('e4000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000003', now())
+    on conflict (job_id, user_id) do update set last_seen_at = excluded.last_seen_at;
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (121,'Sekundaerer kann Ungelesen-Status nicht schreiben (Schreibpfad unveraendert)',
+    'ABGELEHNT',v);
+  raise notice 'CASE 12b -> %', v;
+end $$;
+
+-- CASE 12c: der PRIMAER kann es weiterhin — kein Rueckschritt.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_comment_reads (job_id, user_id, last_seen_at)
+    values ('e4000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002', now())
+    on conflict (job_id, user_id) do update set last_seen_at = excluded.last_seen_at;
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (122,'Primaerer kann den Ungelesen-Status weiterhin schreiben','AKZEPTIERT',v);
+  raise notice 'CASE 12c -> %', v;
+end $$;
+
+-- CASE 13: und NICHT dem nicht Zugewiesenen
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select 'ungelesen='||count(*)::text into v
+  from public.get_unread_comment_job_ids() g
+  where g = 'e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (13,'Ungelesen-RPC meldet nichts an Nicht-Zugewiesene','ungelesen=0',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- D. SCHREIBRECHTE BLEIBEN UNVERAENDERT (Kern der Read-Only-Zusicherung)
+-- =========================================================
+
+-- CASE 14: SEKUNDAER darf KEINEN Kommentar schreiben (Insert-Policy haengt
+-- weiterhin an jobs.assigned_to). Bewusst so — Phase 6/7.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_comments (company_id, job_id, author_id, message)
+    values ('e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001',
+            'e2000000-0000-0000-0000-000000000003','Versuch');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (14,'Sekundaerer darf KEINEN Kommentar schreiben (Schreibpfad unveraendert)',
+    'ABGELEHNT',v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: PRIMAER darf es weiterhin (keine Regression am Schreibpfad)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_comments (company_id, job_id, author_id, message)
+    values ('e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001',
+            'e2000000-0000-0000-0000-000000000002','Vom Primaer');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (15,'Primaerer darf weiterhin kommentieren','AKZEPTIERT',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: SEKUNDAER darf keine Foto-Zeile anlegen.
+--
+-- DIESER FALL IST DER GRUND FUER ABSCHNITT 6 DER MIGRATION. Vor dem
+-- Entfernen der beiden weiten Baseline-Policies schlug er fehl: die
+-- Policy "job_photos: Firma darf Fotos hochladen" prueft die Zuweisung
+-- nicht selbst, sondern nur, ob der Aufrufer die jobs-Zeile SEHEN kann —
+-- eine Bedingung, die Abschnitt 1 dieser Migration gerade erweitert.
+-- Damit haette eine reine Lese-Aenderung transitiv ein SCHREIBRECHT
+-- geoeffnet. Der Fall bleibt hier als Regressionsschutz stehen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_photos (company_id, job_id, uploaded_by, storage_path, file_name)
+    values ('e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001',
+            'e2000000-0000-0000-0000-000000000003','p/q/r.jpg','r.jpg');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (16,'Sekundaerer darf kein Foto anlegen (Schreibpfad unveraendert)','ABGELEHNT',v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+-- CASE 17: SEKUNDAER kann den Auftrag NICHT starten — start_own_job
+-- verlangt weiterhin assigned_to = auth.uid(). Genau deshalb muss der
+-- Client sein Aktions-Gating am Legacy-Primaer ausrichten.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('e4000000-0000-0000-0000-000000000001', now());
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (17,'Sekundaerer kann den Auftrag nicht starten (RPC unveraendert, Phase 7)',
+    'ABGELEHNT',v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: SEKUNDAER darf die jobs-Zeile nicht direkt aendern
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set notes='geaendert' where id='e4000000-0000-0000-0000-000000000001';
+    v := 'zeilen='||(select count(*)::text from public.jobs
+                     where id='e4000000-0000-0000-0000-000000000001' and notes='geaendert');
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  -- Es existiert keine employee-UPDATE-Policy auf jobs: das UPDATE trifft
+  -- 0 Zeilen (kein Fehler, aber auch keine Wirkung).
+  insert into _r values (18,'Sekundaerer kann die jobs-Zeile nicht veraendern','zeilen=0',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: SEKUNDAER darf keine Zuweisung schreiben (kein Grant, Phase 3)
+do $$
+declare v text;
+begin
+  select 'insert_grant='||has_table_privilege('authenticated','public.job_assignments','insert')::text
+       ||'/update_grant='||has_table_privilege('authenticated','public.job_assignments','update')::text
+       ||'/delete_grant='||has_table_privilege('authenticated','public.job_assignments','delete')::text
+    into v;
+  insert into _r values (19,'authenticated hat weiterhin KEIN Schreibrecht auf job_assignments',
+    'insert_grant=false/update_grant=false/delete_grant=false',v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- E. Strukturzusicherungen der Migration
+-- =========================================================
+
+-- CASE 20: genau die vier erwarteten Policies tragen den neuen Helfer —
+-- und zwar ausschliesslich SELECT-Policies.
+do $$
+declare v text;
+begin
+  select 'cmds='||coalesce(string_agg(distinct cmd, ',' order by cmd),'KEINE')
+       ||'/anzahl='||count(*)::text
+    into v
+  from pg_policies
+  where qual like '%is_assigned_to_job%'
+    and (schemaname, tablename) in
+        (('public','jobs'),('public','job_comments'),('public','job_photos'),('storage','objects'));
+  insert into _r values (20,'Nur SELECT-Policies nutzen is_assigned_to_job (4 Stueck)','cmds=SELECT/anzahl=4',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: KEINE Schreib-Policy (INSERT/UPDATE/DELETE) wurde erweitert.
+-- Geprueft wird die with_check-Seite ebenso wie die using-Seite.
+do $$
+declare v text;
+begin
+  select 'schreibpolicies_mit_helfer='||count(*)::text into v
+  from pg_policies
+  where cmd <> 'SELECT'
+    and (coalesce(qual,'') like '%is_assigned_to_job%'
+      or coalesce(with_check,'') like '%is_assigned_to_job%');
+  insert into _r values (21,'Keine INSERT/UPDATE/DELETE-Policy nutzt den Helfer',
+    'schreibpolicies_mit_helfer=0',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- CASE 22: die jobs-Policy behaelt die job_type-Einschraenkung UND den
+-- Legacy-Zweig (Obermengen-Eigenschaft, siehe Entscheidung (A)).
+do $$
+declare v text;
+begin
+  select 'job_type='||(qual like '%job_type%')::text
+       ||'/legacy='||(qual like '%assigned_to%')::text
+       ||'/neu='||(qual like '%is_assigned_to_job%')::text
+    into v
+  from pg_policies
+  where schemaname='public' and tablename='jobs' and policyname='employee read own assigned jobs';
+  insert into _r values (22,'jobs-Policy: job_type-Grenze, Legacy-Zweig und neuer Zweig vorhanden',
+    'job_type=true/legacy=true/neu=true',v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: get_unread_comment_job_ids wurde NICHT erweitert.
+-- Regressionsschutz: taucht is_assigned_to_job jemals im Funktionsrumpf auf,
+-- ohne dass die job_comment_reads-Schreibpolicies nachgezogen wurden, ist der
+-- haengende Ungelesen-Punkt zurueck.
+do $$
+declare v text;
+begin
+  select 'nutzt_helfer='||(pg_get_functiondef(p.oid) like '%is_assigned_to_job%')::text
+       ||'/volatilitaet='||p.provolatile::text
+       ||'/definer='||p.prosecdef::text into v
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+  where n.nspname='public' and p.proname='get_unread_comment_job_ids';
+  insert into _r values (23,'Ungelesen-RPC unveraendert (kein Helfer, weiterhin STABLE/DEFINER)',
+    'nutzt_helfer=false/volatilitaet=s/definer=true',v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+
+-- CASE 24: die beiden weiten Baseline-Policies auf job_photos sind fort.
+-- Sie waren die einzigen Policies dieses Schemas, deren Schutzwirkung
+-- allein aus der jobs-Sichtbarkeit stammte (Unterabfrage auf jobs unter
+-- der RLS des Aufrufers) — und damit die einzige Stelle, an der eine
+-- Lese-Erweiterung transitiv ein Schreibrecht oeffnen konnte.
+do $$
+declare v text;
+begin
+  select 'weite_policies='||count(*)::text into v
+  from pg_policies
+  where schemaname='public' and tablename='job_photos'
+    and policyname in ('job_photos: Firma darf Fotos lesen',
+                       'job_photos: Firma darf Fotos hochladen');
+  insert into _r values (24,'Weite Baseline-Policies auf job_photos entfernt','weite_policies=0',v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: der PRIMAER kann weiterhin ein Foto anlegen — das Entfernen in
+-- Fall 24 hat also niemandem ein heute nutzbares Recht genommen
+-- (Nettowirkung auf Schreibrechte = null).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_photos (company_id, job_id, uploaded_by, storage_path, file_name)
+    values ('e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000001',
+            'e2000000-0000-0000-0000-000000000002','x/y/z.jpg','z.jpg');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (25,'Primaerer kann weiterhin ein Foto anlegen','AKZEPTIERT',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+-- CASE 26: der Admin ebenfalls (die weite Policy war auch fuer ihn
+-- redundant — "admin insert photos in own company" deckt ihn ab).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_photos (company_id, job_id, uploaded_by, storage_path, file_name)
+    values ('e1000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000002',
+            'e2000000-0000-0000-0000-000000000001','a/b/admin.jpg','admin.jpg');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (26,'Admin kann weiterhin Fotos anlegen','AKZEPTIERT',v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+-- CASE 27: und der Admin liest weiterhin alle Fotos der eigenen Firma
+-- (Gegenprobe zum Entfernen der weiten LESE-Policy).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select 'admin_fotos='||count(*)::text into v
+  from public.job_photos where job_id='e4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (27,'Admin liest weiterhin die Fotos der eigenen Firma','admin_fotos=2',v);
+  raise notice 'CASE 27 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _r order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _r where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'EMPLOYEE READ VIA ASSIGNMENTS TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 30 FAELLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 5, part 1 of 2. **Server-side only.** Part 2 (`feat/phase5-react-native-read-path`) depends on this and should be reviewed after it.

Migration: `supabase/migrations/20260730000000_employee_read_via_assignments.sql`

## Exact scope — SELECT only

Four policies change. Each keeps its existing legacy check and gains `or public.is_assigned_to_job(...)`, using the helper already deployed in Phase 3 (no new function, no new grant):

| Object | Policy |
| --- | --- |
| `public.jobs` | `employee read own assigned jobs` |
| `public.job_comments` | `employee read comments on own jobs` |
| `public.job_photos` | `employee read photos on own jobs` |
| `storage.objects` | `job-photos read allowed` |

No grants, no functions, no triggers, no enums, **no DML**. The legacy disjunct is deliberately kept, so the predicate is a strict superset — no employee can lose access. It goes away in Phase 11 with the column.

## The two required `job_photos` policy drops

```sql
drop policy if exists "job_photos: Firma darf Fotos lesen"     on public.job_photos;
drop policy if exists "job_photos: Firma darf Fotos hochladen" on public.job_photos;
```

These baseline policies do not check the assignment themselves — they check only the company and then rely on whether the caller can *see* the `jobs` row, a subquery that runs under the caller's own RLS. Section 1 widens exactly that visibility, so **leaving them in place would have transitively opened `job_photos` INSERT** to secondary assignees. Reproduced in testing before the drops existed (case 16 failed, upload accepted).

Both are fully redundant: `admin read/insert photos in own company` and `employee read/insert photos on own jobs` already cover every legitimate case. Net effect on write permissions is zero (cases 24–27).

## Parent recurring rule protection

`job_type = 'single'` stays as its own `AND` **outside** the OR parentheses. Since Phase 4, recurring parent rules carry assignments as templates, and `is_assigned_to_job()` knows nothing about `job_type` — folding the condition inside would have shown parent rules in employees' job lists for the first time. Case 6 asserts they stay hidden; case 7 is the counter-check that a concrete occurrence *is* visible.

## Deliberately untouched

- `get_unread_comment_job_ids()` — **not modified.** Marking-as-read writes to `job_comment_reads`, whose INSERT/UPDATE policies still require the legacy primary. Widening only the RPC would have produced a permanently stuck unread dot for secondary assignees (RPC reports unread → upsert fails 42501 → error swallowed → dot returns on every refresh). Reproduced locally. A secondary assignee therefore reads comments but gets no unread marker yet — a missing hint, not a broken state. Cases 12 / 12b / 12c pin this coupling.
- All `job_comment_reads` policies, `start_own_job`/`complete_own_job`, every write policy, all admin policies, `jobs.assigned_to` itself, and the timesheet (still filters on `assigned_to`).

## Known production storage drift — not fixed here

Production carries two storage policies that exist in no migration and check only bucket + company folder, with no `jobs` subquery:

- `job-photos storage: Lesen aus eigenem Firma-Ordner` (SELECT)
- `job-photos storage: Hochladen in eigenen Firma-Ordner` (INSERT)

They make the strict `job-photos read allowed` policy effectively inert in production, where bucket read and upload are already company-wide. Reproduced locally against production's policy set: an unassigned employee reads the file and uploads succeed. Pre-existing, **not caused by this PR**, and deferred to a separate storage PR.

Related consequence: `storage.objects` INSERT/DELETE policies are also absent from all migrations, so a database built purely from migrations has only the SELECT policy this migration creates. Section 4's comment documents both starting states.

## Transitive storage DELETE limitation — documented, not fixed

`job-photos delete own upload` (production-only) checks `owner = auth.uid()` plus a **company-only** `jobs` subquery. Section 1 widens that visibility, so a secondary assignee can delete a file **they uploaded themselves** on a job where they are not the legacy primary. Limited to their own uploads. Left untouched on purpose — it belongs to the storage drift PR — and called out in the migration header rather than quietly fixed, because without it the claim "this migration changes no write permissions" would be untrue.

## Tests

`supabase/tests/employee_read_via_assignments.test.sql` — **30/30 PASS**, 5 consecutive runs, no flakes.

Covers: secondary assignee reads job/comments/photos; primary and admin unchanged; unassigned and foreign-company employees blocked; parent rule hidden with occurrence counter-check; every write path still denied; the unread RPC/`job_comment_reads` coupling; and structural assertions that only SELECT policies use the helper.

Mutation-tested for non-vacuousness — each mutation is caught by exactly the intended case:

| Mutation | Caught by |
| --- | --- |
| `job_type` moved inside the OR | case 6 |
| new disjunct removed | 5 cases |
| loose insert policy restored | 3 cases |
| unread RPC widened after all | cases 12, 23 |
| `job_comment_reads` opened to secondaries | case 12b |
| `job_comment_reads` closed to the primary | case 12c |

**Full SQL regression: 260/260 PASS**, 11 files, after a clean `supabase db reset` (migration applies from scratch).

## Not done

Not deployed anywhere. Staging verification still outstanding — run it before merge, and check staging's storage policies first: if staging lacks production's loose ones, a green staging run says nothing about production storage behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)