### PR TITLE
feat(app): display multi-employee job assignments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
 
 ### Typen (`types/`)
 - `types/job.ts` — `Job`, `JobStatus` (`open`|`in_progress`|`completed`), `JobType` (`single`|`recurring`),
+  `JobAssignee` (**maßgeblich für jede Mitarbeiter-Anzeige**, `Job.assignees[]`),
   `CreateJobInput`, `EmployeeOption`. Terminierung am `Job`: `jobType`, `date` (`YYYY-MM-DD`, nur single),
   `startTime` (`HH:mm`), `recurringDays` (Kurzcodes `mon`…`sun`, nur recurring), `isActive`.
   Job trägt zusätzlich `hasUnreadComments` (gemerged im JobContext, nicht in `mapJob`).
@@ -113,6 +114,8 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
 - `i18n/` — Übersetzungen (`translations.ts`, `useTranslation.ts`).
 - `utils/` — `date.ts` (inkl. Zeit-/Datum-Helfer `formatTimeHHmm`, `formatDateISO`, `isSameLocalDate`),
   `recurrence.ts` (Wochentage `WEEKDAYS`, `getWeekdayKey`, `isWeekdayInList`, `formatRecurringDays`),
+  `jobAssignees.ts` (zentrale Zuweisungs-Helfer `getAssignees`, `isAssignedTo`, `isPrimaryAssignee`,
+  `canRunJobActions`, `formatAssigneesShort/Full` — siehe Konvention unten),
   `jobSchedule.ts` (zentrale Terminierungs-Helfer `isJobToday`, `getJobDisplayTime`, `getRecurringDaysLabel`
   — genutzt von Employee-Übersicht, Admin-Dashboard und JobCard), `debug.ts`.
 - `data/` — statische/Beispiel-Daten (`jobs.ts`, `employees.ts`).
@@ -132,6 +135,15 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
   **Einmalig** (Datum + Uhrzeit) oder **Wiederkehrend** (Wochentage + Uhrzeit + Aktiv/Inaktiv). Validierung:
   single braucht Datum **und** Uhrzeit; recurring braucht mind. **einen** Wochentag **und** Uhrzeit. Kunde,
   Ort/Location, Service bleiben Pflicht; Mitarbeiter-Zuweisung und Notizen optional.
+- **Mehrere Mitarbeiter pro Auftrag (ab Phase 5, READ-ONLY):** Maßgeblich für jede ANZEIGE ist
+  `Job.assignees[]` (aus `job_assignments`, gemappt in `jobs.service.ts`). `Job.employeeId`/`employeeName`
+  sind `@deprecated` und tragen nur noch (a) den Schreibpfad (Phase 6) und (b) das **Aktions-Gating**.
+  Letzteres ist kein Versehen: `start_own_job`/`complete_own_job` und die Insert-Policies auf
+  `job_comments`/`job_photos`/`storage.objects` verlangen serverseitig weiterhin
+  `jobs.assigned_to = auth.uid()`. Start-/Fertig-/Upload-Buttons deshalb **immer** über
+  `canRunJobActions()` bzw. `isPrimaryAssignee()` gaten, **nie** über `isAssignedTo()` — sonst
+  erscheint für sekundär Zugewiesene ein Button, der mit „Job not found or not allowed" fehlschlägt.
+  Wird in Phase 7 aufgelöst. Zuweisungs-Anzeige nicht selbst formatieren: `utils/jobAssignees.ts` nutzen.
 - **Heute-Logik nicht duplizieren:** Die „heute fällig?"-Entscheidung liegt zentral in `utils/jobSchedule.ts`
   (`isJobToday`/`getJobDisplayTime`/`getRecurringDaysLabel`) und wird von `EmployeeOverviewScreen`,
   `AdminDashboardScreen` und `JobCard` genutzt. Neue Screens diesen Helper verwenden, keine eigene

--- a/components/JobCard.tsx
+++ b/components/JobCard.tsx
@@ -18,6 +18,11 @@ import { useJobWorkedTime } from "@/hooks/useJobWorkedTime";
 import { Ionicons } from "@expo/vector-icons";
 import { Job } from "@/types/job";
 import { getJobDisplayTime, getRecurringDaysLabel } from "@/utils/jobSchedule";
+import {
+  formatAssigneesFull,
+  formatAssigneesShort,
+  getAssignees,
+} from "@/utils/jobAssignees";
 import React, { useMemo } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import type { AppTheme } from "@/constants/theme";
@@ -173,7 +178,16 @@ export default function JobCard({
   // Bei Parent-Recurring-Regeln grundsätzlich keine Quick-Actions.
   const showStartAction = !isParentRule && job.status === "open" && !!onStart;
   const showCompleteAction = !isParentRule && job.status === "in_progress" && !!onComplete;
-  const employeeText = showEmployeeName ? job.employeeName : null;
+  // Mitarbeiter-Zeile: gekürzt („Anna, Bert +2"), das vollständige Register
+  // steckt im Screenreader-Label. Ohne Zuweisung bleibt die Zeile ganz weg —
+  // wie bisher, als employeeName schlicht null war.
+  const assigneeCount = getAssignees(job).length;
+  const employeeText =
+    showEmployeeName && assigneeCount > 0 ? formatAssigneesShort(job) : null;
+  const employeeA11yLabel =
+    showEmployeeName && assigneeCount > 0
+      ? `${assigneeCount === 1 ? "Mitarbeiter" : "Mitarbeitende"}: ${formatAssigneesFull(job)}`
+      : undefined;
 
   // Footer wird nur gerendert, wenn Mitarbeiter ODER Action vorhanden
   const hasFooter = !!employeeText || showStartAction || showCompleteAction;
@@ -315,9 +329,13 @@ export default function JobCard({
       {hasFooter ? (
         <View style={styles.footer}>
           {employeeText ? (
-            <View style={styles.employeeRow}>
+            <View
+              style={styles.employeeRow}
+              accessible
+              accessibilityLabel={employeeA11yLabel}
+            >
               <Ionicons
-                name="person-outline"
+                name={assigneeCount > 1 ? "people-outline" : "person-outline"}
                 size={14}
                 color={theme.colors.onSurfaceVariant}
               />

--- a/components/ui/InfoRow.tsx
+++ b/components/ui/InfoRow.tsx
@@ -20,6 +20,12 @@ interface InfoRowProps {
   onPress?: () => void;
   /** Trennlinie unter der Zeile anzeigen */
   divider?: boolean;
+  /**
+   * Maximale Zeilen des Werts (Default 2). Höher setzen, wo Abschneiden
+   * Information kostet — z. B. bei der Mitarbeiter-Liste eines Auftrags,
+   * die mehrere Namen enthalten kann.
+   */
+  valueNumberOfLines?: number;
 }
 
 export function InfoRow({
@@ -28,6 +34,7 @@ export function InfoRow({
   icon,
   onPress,
   divider = false,
+  valueNumberOfLines = 2,
 }: InfoRowProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -48,7 +55,10 @@ export function InfoRow({
       </View>
 
       {/* Wert-Zeile */}
-      <Text style={[styles.value, onPress && styles.valueLink]} numberOfLines={2}>
+      <Text
+        style={[styles.value, onPress && styles.valueLink]}
+        numberOfLines={valueNumberOfLines}
+      >
         {value}
       </Text>
 

--- a/docs/phase5-react-native-read-path.md
+++ b/docs/phase5-react-native-read-path.md
@@ -1,0 +1,335 @@
+# Phase 5 — React Native Read Path (`Job.assignees[]`)
+
+Status: UEBERARBEITET nach zwei adversarialen Reviews. Bereit fuer Feature-Branch + PR. Nicht gemergt, nicht deployt.
+Scope: **READ ONLY**. Kein Editing, kein Merge, kein Deploy.
+
+---
+
+## 1. Ausgangsbefund (am Code erhoben, nicht angenommen)
+
+### Wo `assigned_to` heute gelesen wird
+
+| Ort | Art des Lesens |
+| --- | --- |
+| `services/jobs/jobs.service.ts` — `JOB_SELECT` + 4 inline-Selects | Spalte + `profiles:assigned_to` Embed |
+| `services/jobs/jobs.service.ts` — `mapJob` | → `Job.employeeId` / `Job.employeeName` |
+| `services/jobs/jobs.service.ts` — `applyEmployeeFilter` | serverseitiger Filter (`.eq`/`.is`) |
+| `services/timesheets/timesheet.service.ts:98` | `.eq("assigned_to", employeeId)` |
+| `features/employees/EmployeeDetailScreen.tsx:83` | `jobs.filter(j => j.employeeId === id)` |
+| `features/admin/AdminDashboardScreen.tsx:137` | aktiver Job je Mitarbeiter |
+| `features/jobs/JobsListScreen.tsx:97,107` | Filter + Suchtext |
+| `features/jobs/JobDetailScreen.tsx:377,384,395` | Anzeige **und** Aktions-Gating |
+| `components/JobCard.tsx:176` | Anzeige `employeeName` |
+| `features/jobs/components/RuleOccurrences.tsx:266` | Anzeige |
+| `features/jobs/AdminRecurringRulesScreen.tsx:445,602` | Anzeige + Regel-Gesundheit |
+| `utils/recurringRule.ts`, `utils/recurringRuleFilter.ts`, `utils/scheduleView.ts` | Regel-Health / Filter / Suchindex |
+
+### Was die DB bereits liefert
+
+* `job_assignments` hat **SELECT-Grant + 2 Policies** (Admin: ganze Firma; Employee: alle Zuweisungen der Jobs, denen er selbst zugewiesen ist). Der Read-Path ist serverseitig also bereits freigeschaltet.
+* Realtime funktioniert **ohne Änderung**: `job_assignments` ist nicht in der Publication, aber `touch_job_on_assignment_change_trg` hebt `jobs.updated_at` an → das bestehende `jobs`-Realtime-Abo in `JobContext` feuert und lädt neu.
+* Occurrences besitzen dank Phase 4 **eigene** `job_assignments`-Zeilen → ein Embed pro Job-Zeile ist ausreichend, es braucht keine Parent-Auflösung im Client.
+
+---
+
+## 2. Blocker
+
+### B1 — `jobs`-RLS für Employees hängt weiter an `assigned_to` (**echter Blocker, DB**)
+
+`lib/schema.sql:1247` — Policy `employee read own assigned jobs`:
+
+```sql
+using (company_id = current_user_company_id() and assigned_to = auth.uid())
+```
+
+Keine Migration der Phasen 1–4.1 fasst die `jobs`-Policies an (verifiziert: kein `create policy … on public.jobs` in `supabase/migrations/`).
+
+**Folge:** ein *sekundärer* Zuweisungsempfänger sieht die Job-Zeile überhaupt nicht — er kann die zugehörigen `job_assignments`-Zeilen zwar lesen, aber `jobs` liefert kein Ergebnis. Dieselbe Kopplung besteht bei `job_comments` (`schema.sql:1321,1338`).
+
+**ENTSCHIEDEN UND UMGESETZT** in `20260730000000_employee_read_via_assignments.sql`: die Employee-**SELECT**-Policies auf `jobs`, `job_comments`, `job_photos`, `storage.objects` sowie die read-only RPC `get_unread_comment_job_ids()` wurden um `or public.is_assigned_to_job(...)` erweitert. Keine einzige Schreibberechtigung geändert. 28 SQL-Fälle in `supabase/tests/employee_read_via_assignments.test.sql`.
+
+**Beim Testen entdeckt (wichtigster Befund der Phase):** zwei Policies aus der Remote-Baseline — `job_photos: Firma darf Fotos lesen` und `… hochladen` — prüfen die Zuweisung nicht selbst, sondern nur, ob der Aufrufer die `jobs`-Zeile sehen kann (Unterabfrage auf `jobs` unter der RLS des Aufrufers). Genau diese Sichtbarkeit erweitert Abschnitt 1. Damit hätte die Lese-Änderung **transitiv ein Schreibrecht geöffnet**: ein sekundär Zugewiesener konnte `job_photos`-Zeilen anlegen (im Testlauf reproduziert, Fall 16 schlug fehl). Beide Policies sind vollständig redundant zu den strengen aus `lib/schema.sql` und wurden entfernt; die Nettowirkung auf Schreibrechte ist damit null (Fälle 24–27).
+
+### B2 — `start_own_job` / `complete_own_job` verlangen weiter `assigned_to = auth.uid()`
+
+Bestätigt in `lib/schema.sql:665,693,739,765`. Das Aktions-Gating in `JobDetailScreen` (`canStart`, `canComplete`, `canUploadPhotos`) und in `JobsListScreen` **darf deshalb NICHT** auf `assignees[]` umgestellt werden — ein sekundärer Zugewiesener bekäme sonst einen Button, der mit „Job not found or not allowed" fehlschlägt.
+
+→ Gating bleibt in Phase 5 bewusst auf `job.employeeId` (= Legacy-Primär), mit Kommentar-Verweis auf Phase 7. **Anzeige** und **Gating** werden getrennt.
+
+### B3 — `assigned_to IS NULL` ist **kein** verlässlicher Proxy für „keine Zuweisung"
+
+`compat_primary_assignee()` liefert NULL nicht nur bei leerer Menge, sondern auch dann, wenn keine Zuweisung *spurenfrei* (`attendance='assigned'`, kein Review, keine Zeitstempel) und der Mitarbeiter *aktiv* ist. Ein Auftrag mit einem gestarteten oder inaktiven Zugewiesenen kann `assigned_to IS NULL` haben und trotzdem Zuweisungen besitzen.
+
+→ Der Filter „Nicht zugewiesen" (`applyEmployeeFilter`, `AdminScheduleScreen`, `recurringRuleFilter`) muss auf die Zuweisungsmenge umgestellt werden, nicht auf die Legacy-Spalte.
+
+### B4 — PostgREST: Filter- und Anzeige-Embed derselben Relation (Risiko, kein Blocker)
+
+Für „Jobs des Mitarbeiters X" bei gleichzeitiger Anzeige **aller** Zugewiesenen braucht es zwei Embeds derselben Tabelle:
+
+```
+assignments:job_assignments(...)                  -- Anzeige, ungefiltert
+_f:job_assignments!inner(employee_id)             -- Prädikat
+&_f.employee_id=eq.<id>
+```
+
+Aliasierte Mehrfach-Embeds derselben Relation sind PostgREST-Standard, in diesem Projekt aber noch nirgends verwendet. **Erste Implementierungs-Aufgabe ist ein Spike gegen Staging**, bevor die Filter-Queries darauf aufgebaut werden. Fallback: zweistufige Abfrage (`job_assignments` → `job_id[]` → `.in("id", …)`), begrenzt durch die URL-Länge, deshalb nur Fallback.
+
+---
+
+## 3. Zielmodell
+
+`types/job.ts`:
+
+```ts
+export type JobAssignee = {
+  assignmentId: string;
+  employeeId: string | null;      // null = Konto gelöscht (anonymisiert)
+  fullName: string;               // lebender Profilname, sonst Snapshot
+  attendance: "assigned" | "started" | "completed";
+  countsForTimesheet: boolean;
+  isDeleted: boolean;             // employeeId === null
+};
+
+export type Job = {
+  …
+  /** Vollständige Zuweisungsmenge (Phase 5). Leeres Array = nicht zugewiesen. */
+  assignees: JobAssignee[];
+  /** @deprecated Legacy-Primär. Nur noch für Aktions-Gating (Phase 7 entfernt). */
+  employeeId?: string | null;
+  /** @deprecated → assignees. */
+  employeeName?: string | null;
+};
+```
+
+`employeeId`/`employeeName` bleiben in Phase 5 **erhalten und befüllt** — sie tragen das Aktions-Gating (B2) und den Offline-Cache alter App-Versionen. Sie werden `@deprecated` markiert und in Phase 7/11 entfernt.
+
+---
+
+## 4. Umsetzung
+
+**S0 — Spike. ERLEDIGT, B4 aufgelöst.** Gegen die lokale PostgREST-Instanz mit echten Daten verifiziert:
+* `assignments:job_assignments(...)` + `f:job_assignments!inner(employee_id)` mit `f.employee_id=eq.<id>` filtert die Zeilenmenge, lässt den Anzeige-Embed **vollständig** (Auftrag mit 2 Zugewiesenen zeigt beide) und dupliziert keine Zeilen.
+* „Nicht zugewiesen": `f:job_assignments!left(employee_id)` + `f=is.null` liefert genau die Aufträge ohne Zuweisung.
+Kein Fallback nötig — beide Filter laufen serverseitig.
+
+**S1 — Service-Layer.**
+* `JOB_SELECT` um `job_assignments(id, employee_id, employee_name_snapshot, attendance, counts_for_timesheet, profiles:employee_id(id, full_name))` erweitern.
+* Die **vier inline duplizierten Selects** (`getJobs`, `createJob`, `updateJob`, `getJobOccurrences`) auf `JOB_SELECT` konsolidieren — sie sind heute wortgleiche Kopien und würden sonst dreifach driften.
+* `mapJob` → `mapAssignees(row.job_assignments)`, stabil sortiert (`assigned_at`, dann Name), Name = lebendes Profil ?? Snapshot.
+* `applyEmployeeFilter` auf die Zuweisungsmenge umstellen (B3/B4).
+
+**S2 — Offline-Cache.** `getCachedJobs()` liefert bei Caches aus alten App-Versionen Jobs **ohne** `assignees`. Migrations-Shim beim Lesen: fehlt `assignees`, aus `employeeId`/`employeeName` ein Ein-Element-Array ableiten (bzw. `[]`). Ohne diesen Shim zeigt der erste Offline-Start nach dem Update „Nicht zugewiesen".
+
+**S3 — UI (Anzeige, kein Gating).**
+* `JobCard`: bis 2 Namen + „+N", `accessibilityLabel` mit voller Liste.
+* `JobDetailScreen`: Zeile „Mitarbeiter" → Liste aller Zugewiesenen (gelöschte Konten kursiv/als „(ehemalig)"). Gating unverändert (B2).
+* `EmployeeDetailScreen`: `assignees.some(a => a.employeeId === id)`.
+* `AdminDashboardScreen`: aktiver Job je Mitarbeiter über `assignees`.
+* `JobsListScreen`: Filter + Suchindex über alle Namen.
+* `RuleOccurrences`, `AdminRecurringRulesScreen`, `utils/recurringRule.ts`, `utils/recurringRuleFilter.ts`, `utils/scheduleView.ts` analog.
+
+**S4 — Timesheets.** `.eq("assigned_to", …)` → Join über `job_assignments` mit `counts_for_timesheet = true`. Das ist laut Phase-1-Migration die **einzige** zulässige Berechtigungsquelle. Der Phase-1-Backfill bildet `status='completed'` → `attendance='completed'` → `counts=true` ab, die historische Ausgabe bleibt also identisch. Wird als **eigener, separat prüfbarer Commit** geliefert, weil es eine Abrechnungsfläche ist.
+
+---
+
+## 5. Bewusst NICHT in Phase 5
+
+* Kein Schreiben von Zuweisungen, kein Aufruf von `set_job_assignments` (Phase 6).
+* Kein Umstellen von `start_own_job`/`complete_own_job` oder ihres Gatings (Phase 7).
+* Keine Änderung an Tabellen, Triggern, Kompatibilitätsschicht (per Auftrag).
+* Kein Entfernen von `jobs.assigned_to` oder `Job.employeeId` (Phase 11).
+* Offene Entscheidung: `jobs`/`job_comments`-RLS auf `is_assigned_to_job()` erweitern (B1).
+
+## 6. Verifikation
+
+Ausgeführt:
+* `npx tsc --noEmit` — sauber.
+* `npm run lint` — sauber.
+* Vollständige SQL-Suite lokal, inkl. der neuen Datei: **11/11 Dateien, 0 FAIL**.
+* PostgREST-Spike mit echten Zeilen (siehe S0).
+
+Noch offen (Review/Staging, bewusst nicht von mir ausgeführt):
+* Staging-Deploy der Migration und erneuter Suite-Lauf dort.
+* Manuell: Auftrag mit 0 / 1 / 2 / gelöschtem Zugewiesenen in Karte, Detail, Dashboard, Mitarbeiter-Detail, Filter, Suche.
+* Offline-Kaltstart mit einem VOR dem Update geschriebenen Cache (Shim S2).
+* Sicht des sekundär Zugewiesenen in der echten App: Auftrag sichtbar, **kein** Start-/Fertig-/Upload-Button.
+* Realtime: `set_job_assignments` per SQL absetzen und prüfen, dass die App ohne Pull-to-Refresh nachzieht.
+
+## 7. Was diese Phase NICHT liefert
+
+* Schreiben von Zuweisungen aus der App (Phase 6) — `set_job_assignments` wird weiterhin von keinem Client aufgerufen.
+* Sekundär Zugewiesene können weiterhin **nicht** starten/abschließen, kommentieren oder Fotos hochladen (Phase 7). Sie sehen den Auftrag, die Kommentare und die Fotos — schreiben dürfen sie nicht. Diese Asymmetrie ist in der Migration dokumentiert und in den Tests festgehalten.
+* `jobs.assigned_to` und `Job.employeeId` bleiben bestehen (Phase 11).
+
+## 8. Nebenbefund, NICHT in dieser Phase behoben
+
+`lib/schema.sql` dokumentiert „absichtlich KEINE direkte employee update policy auf jobs" — in der Datenbank existiert sie aber (`employee update own assigned jobs`, aus der Remote-Baseline, also auch produktiv). Sie ist hart an `assigned_to = auth.uid()` gebunden und daher von dieser Migration **nicht** betroffen. Trotzdem eine Abweichung zwischen Referenz und Realität, die eigenständig geprüft werden sollte.
+
+
+---
+
+## 9. Nacharbeit nach dem adversarialen Review (2026-07-26)
+
+Der Review hat einen release-blockierenden Befund und drei Folgefehler
+gefunden. Alle sind behoben; die Ursachen sind hier festgehalten, damit sie
+nicht erneut entstehen.
+
+### 1. Stundenzettel vollstaendig zurueckgenommen (BLOCKER)
+
+`counts_for_timesheet` wird nach dem Phase-1-Backfill von **nichts** mehr
+gepflegt — `attendance` zu schreiben ist Phase 7. Nachgewiesen mit dem
+echten Ablauf (zuweisen → `start_own_job` → `complete_own_job`):
+
+```
+NACH ABSCHLUSS: job_status=completed / attendance=assigned / counts=false
+Filter NEU (counts_for_timesheet): 0 Zeilen
+Filter ALT (assigned_to):          1 Zeile
+```
+
+Jeder nach dem Backfill abgeschlossene Auftrag waere lautlos aus dem
+Stundenzettel gefallen. `services/timesheets/timesheet.service.ts` ist
+wieder **byte-identisch mit HEAD** (`assigned_to`). Die Umstellung gehoert
+in Phase 7, gemeinsam mit dem Schreiben von `attendance`.
+
+### 2. Ungelesen-Kennzeichnung: RPC-Erweiterung zurueckgenommen
+
+Gewaehlt wurde die **kleinere** der beiden Optionen. Statt den Schreibpfad
+`job_comment_reads` zu oeffnen, bleibt `get_unread_comment_job_ids()`
+unveraendert am Legacy-Primaer. Grund: Markieren-als-gelesen ist ein
+Schreibvorgang; nur die RPC zu erweitern erzeugte einen dauerhaft
+haengenden roten Punkt (RPC meldet ungelesen → Upsert scheitert mit 42501 →
+Fehler wird im JobContext geschluckt → Punkt kommt bei jedem Refresh
+zurueck).
+
+Folge: ein sekundaer Zugewiesener liest Kommentare mit, bekommt dafuer aber
+(noch) keine Ungelesen-Kennzeichnung — ein fehlender Hinweis, kein kaputter
+Zustand, und exakt das heutige Verhalten. `JobDetailScreen` setzt fuer ihn
+zusaetzlich gar keinen Markier-Versuch mehr ab. Abgesichert durch die
+Faelle 12 / 12b / 12c.
+
+### 3. `JobComments` hat jetzt ein Pflicht-Prop `canComment`
+
+Vorher: `canSend = draft.trim().length > 0 && !submitting` — jeder Leser sah
+ein aktives Senden-Feld und lief in einen RLS-Fehler. Jetzt wird ohne
+Schreibrecht gar kein Eingabefeld gerendert, sondern ein erklaerender Satz.
+Bewusst **kein** Default `true`: ein vergessenes Prop soll ausblenden, nicht
+freischalten.
+
+### 4. Frisches Nachlesen nach Anlegen/Bearbeiten
+
+Der RETURNING-Embed sieht die von den Phase-2-AFTER-Triggern geschriebenen
+`job_assignments` nicht:
+
+```
+INSERT (assigned_to=Erika) -> assignments: []        | frisch: [Erika]
+UPDATE (assigned_to=Zoe)   -> assignments: [Erika]   | frisch: [Zoe]
+```
+
+`createJob`/`updateJob` lesen den Job jetzt ueber `readBackJob()` einmal
+frisch nach. Faellt das Nachlesen aus, wird die RETURNING-Zeile
+zurueckgegeben — ein erfolgreicher Schreibvorgang darf nie nachtraeglich
+als Fehler erscheinen.
+
+### 5. Bewusst NICHT in diesem PR
+
+* **`employee update own assigned jobs`** (jobs UPDATE, existiert in
+  Baseline, nach Clean Reset und in Produktion): erlaubt dem Legacy-Primaer,
+  jede Spalte seines Auftrags per REST zu aendern — inklusive `status`,
+  `started_at`, `completed_at`, also der Grundlage der Stundenzettel-Dauer.
+  Vorbestehend und von Phase 5 **nicht** beruehrt (haengt an `assigned_to`,
+  das hier nicht erweitert wird). → eigener Security-PR.
+* **Produktions-Drift im storage-Schema**: die prod-only Policies
+  `job-photos storage: Lesen/Hochladen in eigenen Firma-Ordner` pruefen nur
+  Bucket und Firmenordner und machen die strenge Lese-Policy dort wirkungslos
+  (lokal mit dem Produktionsstand reproduziert: fremder Mitarbeiter liest und
+  laedt hoch). Ausserdem fehlen die storage-INSERT/DELETE-Policies in jeder
+  Migration. → eigener PR.
+* **`job-photos delete own upload`**: einzige verbliebene transitive
+  Nebenwirkung dieser Migration (Firmen-only-Unterabfrage), begrenzt auf
+  eigene Uploads. Im Migrations-Header ausdruecklich dokumentiert statt still
+  mitgefixt.
+
+### Verifikation nach der Nacharbeit
+
+* `npx supabase db reset` (Clean Reset, alle Migrationen from scratch) ✓
+* Volle SQL-Regression: 11 Dateien, **260 Faelle, 0 FAIL** ✓
+* Neue Suite 3x hintereinander: 30/30, nicht flaky ✓
+* `npx tsc --noEmit` ✓, `npm run lint` ✓
+* Staging: siehe offene Frage im PR — das CLI kann `db query` nur gegen das
+  **verlinkte** Projekt ausfuehren, und verlinkt ist derzeit PRODUKTION.
+
+
+---
+
+## 10. Nacharbeit nach dem zweiten Review (2026-07-27)
+
+Verdikt war APPROVE WITH FOLLOW-UP mit einem Medium (M-1) und zwei Lows.
+
+### M-1 — Fallback von `readBackJob()` (behoben)
+
+Vorher fiel `readBackJob()` auf `mapJob(row)` zurueck. Das trug exakt die
+unzuverlaessige Embed-Menge: nach dem Anlegen `[]` (ununterscheidbar von
+„niemandem zugewiesen"), nach dem Bearbeiten die ALTE Menge — und der
+JobContext schrieb das in State UND AsyncStorage. Der Null-Pfad
+(`getJobById` liefert keinen Datensatz) wurde ausserdem gar nicht geloggt.
+
+Jetzt:
+
+* **beide** Fehlerpfade loggen (Ausnahme und leeres Ergebnis), jeweils mit
+  Job-ID und dem Hinweis, dass abgeleitet wird;
+* der Fallback leitet die Menge aus dem Legacy-Zeiger ab
+  (`buildLegacyAssignees`) — genau ein Mitarbeiter, nie mehrere, nie geraten;
+* ein erfolgreicher Schreibvorgang wird weiterhin nie zum Fehler.
+
+Tragende Voraussetzung, gegen PostgREST verifiziert: `assigned_to` im
+RETURNING ist **frisch**, nur die eingebettete Beziehung hinkt hinterher.
+
+```
+INSERT RETURNING : assigned_to=Erika | embed=[]        -> Fallback: Erika
+PATCH  RETURNING : assigned_to=Zoe   | embed=[Erika]   -> Fallback: Zoe
+Nachlesen (ok)   : [Erika] bzw. [Zoe]                  -> vollstaendige Menge
+```
+
+Die Ableitung ist jetzt EIN gemeinsamer Helfer fuer beide Stellen, die
+dasselbe Problem haben (`readBackJob` und `normalizeCachedJob` im
+Offline-Cache) — vorher zwei Implementierungen, die auseinanderlaufen konnten.
+
+### L-1 — `countsForTimesheet` (entfernt)
+
+Ersatzlos aus `JobAssignee`, aus `JOB_SELECT`, aus dem Row-Typ und aus dem
+Mapping entfernt. Es hatte keinen Konsumenten, und der Offline-Shim erfand
+den Wert aus `job.status` — ein erfundener Wert fuer die Stundenzettel-
+BERECHTIGUNG ist eine Abrechnungsfalle.
+
+`attendance` wurde aus demselben Grund mitentfernt: ebenfalls ohne
+Konsumenten, ebenfalls im Fallback erfunden. Ohne diese Entfernung haette der
+neue Fallback weiterhin Anwesenheitsdaten erfinden muessen. Beide Felder
+kommen in Phase 7 zurueck, wenn `attendance` serverseitig gepflegt wird.
+
+### L-2 — Migrations-Kommentar zu Abschnitt 4 (korrigiert)
+
+Der Kommentar beschreibt jetzt beide Ausgangslagen: in Produktion ERSETZT
+das DROP+CREATE eine bereits vorhandene Policy, in einer aus Migrationen
+gebauten Umgebung legt es sie ERSTMALS an (dort existierte vorher gar keine
+SELECT-Policy auf dem Bucket). Ausfuehrbares SQL unveraendert.
+
+### Verifikation des Fallbacks
+
+Das Repo hat keinen JS-Test-Runner. Die Ableitung wurde deshalb als **reine
+Funktion** herausgezogen und ist ueber ein eigenes Skript pruefbar:
+
+```
+node scripts/verify-job-assignees.mjs
+```
+
+Es kompiliert `utils/jobAssignees.ts` isoliert (echte Quelle, keine Kopie)
+und prueft 8 Zusicherungen: create-Fallback liefert einen Zugewiesenen statt
+`[]`; update-Fallback liefert den NEUEN statt des alten; nie mehr als einer;
+geloeschtes Konto -> leer ohne Platzhalter; leerer Name -> „Unbekannt";
+stabile, als abgeleitet erkennbare `assignmentId`; keine Abrechnungs-/
+Anwesenheitsfelder; Ergebnis rendert korrekt in den Anzeige-Helfern.
+
+Nicht per Skript pruefbar (braucht Netz/Supabase) und deshalb manuell gegen
+PostgREST verifiziert — Vorgehen oben dokumentiert:
+* dass beide Fehlerpfade in `readBackJob()` loggen (Code-Inspektion),
+* dass ein erfolgreiches Nachlesen die vollstaendige Menge liefert.

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -29,6 +29,7 @@ import {
   type ScheduleKpis,
 } from "@/services/jobs/jobs.service";
 import { formatDateISO } from "@/utils/date";
+import { isAssignedTo } from "@/utils/jobAssignees";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
@@ -134,7 +135,7 @@ export default function AdminDashboardScreen() {
         .filter((emp) => emp.isActive !== false)
         .map((emp) => {
           const activeJob = jobs.find(
-            (j) => j.employeeId === emp.id && j.status === "in_progress",
+            (j) => isAssignedTo(j, emp.id) && j.status === "in_progress",
           );
           return { id: emp.id, name: emp.fullName, activeJob };
         }),

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -25,6 +25,7 @@ import type { AppTheme } from "@/constants/theme";
 import type { Job, JobStatus } from "@/types/job";
 import { formatForDisplay } from "@/utils/date";
 import { getEmployeeStatus } from "@/utils/employeeStatus";
+import { isAssignedTo } from "@/utils/jobAssignees";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useMemo, useState } from "react";
@@ -78,9 +79,10 @@ export default function EmployeeDetailScreen() {
     [employees, id],
   );
 
-  // Alle Jobs dieses Mitarbeiters
+  // Alle Jobs dieses Mitarbeiters — über die Zuweisungsmenge, damit auch
+  // Aufträge zählen, bei denen er nicht der Legacy-Primär ist.
   const assignedJobs = useMemo(
-    () => jobs.filter((j) => j.employeeId === id),
+    () => jobs.filter((j) => isAssignedTo(j, id)),
     [jobs, id],
   );
 

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui";
 import JobCard from "@/components/JobCard";
 import { useAuth } from "@/context/AuthContext";
+import { canRunJobActions } from "@/utils/jobAssignees";
 import { useJobs } from "@/context/JobContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
@@ -76,7 +77,7 @@ export default function EmployeeOverviewScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const { profile } = useAuth();
+  const { profile, role } = useAuth();
   const { jobs, startJob, completeJob, loading } = useJobs();
 
   const [filter, setFilter] = useState<Filter>("all");
@@ -124,9 +125,16 @@ export default function EmployeeOverviewScreen() {
   ).length;
 
   // ── Aktiver Job (erster in_progress über alle eigenen Jobs)
+  // Nur der eigene laufende Auftrag: seit Phase 5 sieht ein Mitarbeiter auch
+  // Aufträge, die eine Kollegin gestartet hat und bei denen er nur sekundär
+  // zugewiesen ist. Die Abschluss-Karte gehört ihm dann nicht.
   const activeJob = useMemo(
-    () => jobs.find((j) => j.status === "in_progress"),
-    [jobs],
+    () =>
+      jobs.find(
+        (j) =>
+          j.status === "in_progress" && canRunJobActions(j, role, profile?.id),
+      ),
+    [jobs, role, profile?.id],
   );
 
   // ── "Heute anstehend": gefiltert + nach Status sortiert, max. 5
@@ -336,8 +344,16 @@ export default function EmployeeOverviewScreen() {
                 job={job}
                 dueToday
                 onPress={() => router.push(`/jobs/${job.id}`)}
-                onStart={() => startJob(job.id)}
-                onComplete={() => completeJob(job.id)}
+                onStart={
+                  canRunJobActions(job, role, profile?.id)
+                    ? () => startJob(job.id)
+                    : undefined
+                }
+                onComplete={
+                  canRunJobActions(job, role, profile?.id)
+                    ? () => completeJob(job.id)
+                    : undefined
+                }
               />
             ))}
           </View>

--- a/features/home/HomeScreen.tsx
+++ b/features/home/HomeScreen.tsx
@@ -6,6 +6,7 @@
 import { EmptyState, LoadingScreen } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
+import { canRunJobActions } from "@/utils/jobAssignees";
 import HomeHeader from "@/features/home/components/HomeHeader";
 import HomeStats from "@/features/home/components/HomeStats";
 import { router } from "expo-router";
@@ -53,7 +54,7 @@ export default function HomeScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const { role, user } = useAuth();
+  const { role, user, profile } = useAuth();
   const { jobs, startJob, completeJob, loading } = useJobs();
   const { t } = useTranslation();
 
@@ -148,8 +149,16 @@ export default function HomeScreen() {
             item={item}
             index={index}
             onPress={() => router.push(`/jobs/${item.id}`)}
-            onStart={() => startJob(item.id)}
-            onComplete={() => completeJob(item.id)}
+            onStart={
+              canRunJobActions(item, role, profile?.id)
+                ? () => startJob(item.id)
+                : undefined
+            }
+            onComplete={
+              canRunJobActions(item, role, profile?.id)
+                ? () => completeJob(item.id)
+                : undefined
+            }
             // Admins sehen Mitarbeiter-Name in der Card (Übersicht über Zuweisungen).
             // Employees sehen ihn nicht — wäre redundant (sie sehen nur eigene Jobs).
             showEmployeeName={role === "admin"}
@@ -172,8 +181,11 @@ function AnimatedJobCard({
 }: {
   item: any;
   index: number;
-  onStart: () => void;
-  onComplete: () => void;
+  // Optional: ohne Handler blendet JobCard die Quick-Action aus. Seit Phase 5
+  // ist das der Normalfall für Aufträge, bei denen der Nutzer nicht der
+  // Legacy-Primär ist (siehe canRunJobActions).
+  onStart?: () => void;
+  onComplete?: () => void;
   onPress?: () => void;
   showEmployeeName?: boolean;
 }) {

--- a/features/jobs/AdminRecurringRulesScreen.tsx
+++ b/features/jobs/AdminRecurringRulesScreen.tsx
@@ -43,6 +43,7 @@ import {
   type ActionMenuItem,
 } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { formatAssigneesShort, getAssignees } from "@/utils/jobAssignees";
 import type { AppTheme } from "@/constants/theme";
 import { useJobs } from "@/context/JobContext";
 import { employeeSelectionLabel } from "@/features/jobs/components/EmployeeFilterControl";
@@ -442,9 +443,16 @@ export default function AdminRecurringRulesScreen() {
               nextOccurrenceDate: null,
               hasOccurrences: false,
             };
-            const assigneeActive = rule.employeeId
-              ? employeeActive.get(rule.employeeId) ?? null
-              : null;
+            // Zusammenfassung über ALLE Zugewiesenen: false, sobald einer
+            // deaktiviert ist; null, wenn zu keinem eine Auskunft vorliegt
+            // (z. B. gelöschtes Konto) oder die Regel niemandem zugewiesen ist.
+            const assigneeStates = getAssignees(rule)
+              .map((a) => (a.employeeId ? employeeActive.get(a.employeeId) : undefined))
+              .filter((v): v is boolean => typeof v === "boolean");
+            const assigneeActive =
+              assigneeStates.length === 0
+                ? null
+                : assigneeStates.every((active) => active);
             const health = deriveRuleHealth(
               rule,
               {
@@ -598,8 +606,10 @@ function RuleCard({
             styles={styles}
           />
           <MetaRow
-            icon="person-outline"
-            text={rule.employeeName ?? "Nicht zugewiesen"}
+            icon={
+              getAssignees(rule).length > 1 ? "people-outline" : "person-outline"
+            }
+            text={formatAssigneesShort(rule)}
             theme={theme}
             styles={styles}
           />

--- a/features/jobs/EmployeeJobsCalendarScreen.tsx
+++ b/features/jobs/EmployeeJobsCalendarScreen.tsx
@@ -8,7 +8,9 @@
 import { EmptyState, ErrorBanner, LoadingScreen, OfflineBanner } from "@/components/ui";
 import JobCard from "@/components/JobCard";
 import { MonthCalendar } from "@/features/jobs/components/MonthCalendar";
+import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
+import { canRunJobActions } from "@/utils/jobAssignees";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { formatDateISO } from "@/utils/date";
 import { getJobDisplayTime } from "@/utils/jobSchedule";
@@ -53,6 +55,7 @@ export default function EmployeeJobsCalendarScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
+  const { role, profile } = useAuth();
   const { jobs, startJob, completeJob, loading, refreshJobs } = useJobs();
 
   const todayKey = useMemo(() => formatDateISO(new Date()) ?? "", []);
@@ -287,8 +290,17 @@ export default function EmployeeJobsCalendarScreen() {
             job={item}
             // Start/Fertig sind Employee-Aktionen (RPCs start_own_job/
             // complete_own_job). JobCard zeigt je Status genau eine Action.
-            onStart={() => handleStart(item.id)}
-            onComplete={() => handleComplete(item.id)}
+            // Seit Phase 5 nur für den Legacy-Primär — siehe canRunJobActions.
+            onStart={
+              canRunJobActions(item, role, profile?.id)
+                ? () => handleStart(item.id)
+                : undefined
+            }
+            onComplete={
+              canRunJobActions(item, role, profile?.id)
+                ? () => handleComplete(item.id)
+                : undefined
+            }
             onPress={() => router.push(`/jobs/${item.id}`)}
           />
         )}

--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -30,6 +30,12 @@ import {
 } from "@/services/jobs/jobs.service";
 import { WorkedTimeCard } from "@/features/jobs/components/WorkedTimeCard";
 import { formatRecurringDays } from "@/utils/recurrence";
+import {
+  formatAssigneesFull,
+  getAssignees,
+  isPrimaryAssignee,
+  UNASSIGNED_LABEL,
+} from "@/utils/jobAssignees";
 import type { Job } from "@/types/job";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
@@ -168,13 +174,24 @@ export default function JobDetailScreen() {
   const isParentRule =
     !!job && job.jobType === "recurring" && !job.parentJobId;
 
+  // Darf der Nutzer den Ungelesen-Status dieses Jobs schreiben?
+  //
+  // job_comment_reads hat eigene INSERT/UPDATE-Policies, die — wie alle
+  // Schreibpfade — weiterhin den LEGACY-PRIMÄR verlangen. Ein sekundär
+  // Zugewiesener darf die Kommentare zwar lesen (Phase 5), das Markieren
+  // schlägt für ihn aber mit 42501 fehl. Der Fehler würde im JobContext
+  // stillschweigend geschluckt — also gar nicht erst versuchen.
+  // Fällt mit Phase 6/7, wenn die Schreibpfade nachziehen.
+  const canMarkCommentsRead =
+    !!job && (isAdmin || isPrimaryAssignee(job, profile?.id));
+
   // Beim Öffnen die Kommentare dieses Jobs als gesehen markieren
   // (entfernt den roten Punkt). Online-only, optimistisch im Context.
   useEffect(() => {
-    if (id) {
+    if (id && canMarkCommentsRead) {
       markJobCommentsAsRead(id);
     }
-  }, [id, markJobCommentsAsRead]);
+  }, [id, canMarkCommentsRead, markJobCommentsAsRead]);
 
   const loadOccurrences = useCallback(async () => {
     if (!jobId || !isAdmin || !isParentRule) return;
@@ -374,25 +391,34 @@ export default function JobDetailScreen() {
   const timeText = job.startTime ? `${job.startTime} Uhr` : "—";
   const scheduledStartText =
     formatDateTime(job.scheduledStart) ?? "Kein Termin geplant";
-  const employeeText = job.employeeName ?? "Nicht zugewiesen";
+  // ANZEIGE: vollständige Zuweisungsmenge (Phase 5). Gelöschte Konten
+  // erscheinen mit „(ehemalig)", damit der Nachweis lesbar bleibt.
+  const assignees = getAssignees(job);
+  const employeeText =
+    assignees.length > 0 ? formatAssigneesFull(job) : UNASSIGNED_LABEL;
+  const employeeLabel = assignees.length > 1 ? "Mitarbeitende" : "Mitarbeiter";
 
-  // Start/Abschluss laufen über die RPCs start_own_job/complete_own_job, die
-  // role='employee' UND assigned_to=auth.uid() verlangen. Daher nur dem
-  // zugewiesenen Mitarbeiter anbieten — sonst RPC-Fehler "Job not found or not
-  // allowed" (z. B. wenn ein Admin den Button drückt). Admins nutzen "Bearbeiten".
+  // BERECHTIGUNG (bewusst NICHT die Zuweisungsmenge): Start/Abschluss laufen
+  // über die RPCs start_own_job/complete_own_job, die role='employee' UND
+  // assigned_to=auth.uid() verlangen. Ein sekundär Zugewiesener sieht den
+  // Auftrag seit Phase 5 zwar, darf ihn aber serverseitig noch nicht starten —
+  // bekäme er hier einen Button, schlüge dieser mit "Job not found or not
+  // allowed" fehl. Wird in Phase 7 zusammen mit den RPCs umgestellt.
   const isAssignedEmployee =
-    role === "employee" && job.employeeId === profile?.id;
+    role === "employee" && isPrimaryAssignee(job, profile?.id);
   // Parent-Recurring-Regeln dürfen niemals gestartet/abgeschlossen werden —
   // nur konkrete Occurrences (job_type='single') sind ausführbare Termine.
   const canStart = !isParentRule && isAssignedEmployee && job.status === "open";
   const canComplete = !isParentRule && isAssignedEmployee && job.status === "in_progress";
   const isDone = job.status === "completed";
 
-  // Foto-Upload: Admin immer; Employee nur wenn diesem Job zugewiesen.
+  // Foto-Upload: Admin immer; Employee nur wenn PRIMÄR zugewiesen.
+  // Gleiche Begründung wie oben bei isAssignedEmployee: die Insert-Policies auf
+  // job_photos und storage.objects verlangen weiterhin assigned_to = auth.uid().
   // isOnline wird separat übergeben — JobPhotos zeigt den Offline-Hinweis selbst.
   const canUploadPhotos =
     role === "admin" ||
-    (role === "employee" && job.employeeId === profile?.id);
+    (role === "employee" && isPrimaryAssignee(job, profile?.id));
 
   return (
     <SafeAreaView style={styles.safe} edges={["top"]}>
@@ -544,9 +570,13 @@ export default function JobDetailScreen() {
           )}
 
           <InfoRow
-            label="Mitarbeiter"
+            label={employeeLabel}
             value={employeeText}
-            icon="person-outline"
+            icon={assignees.length > 1 ? "people-outline" : "person-outline"}
+            // Mehrfachzuweisungen dürfen nicht abgeschnitten werden — der
+            // Detail-Screen ist die Stelle, an der die Menge vollständig
+            // nachvollziehbar sein muss.
+            valueNumberOfLines={6}
           />
         </Card>
 
@@ -582,7 +612,13 @@ export default function JobDetailScreen() {
         />
 
         {/* ── Kommentare (append-only, online-only) ── */}
-        <JobComments jobId={job.id} onInputFocus={handleCommentFocus} />
+        {/* Schreibrecht = Legacy-Primär oder Admin (RLS-Insert-Policy).
+            Sekundär Zugewiesene lesen mit, sehen aber kein Eingabefeld. */}
+        <JobComments
+          jobId={job.id}
+          canComment={isAdmin || isPrimaryAssignee(job, profile?.id)}
+          onInputFocus={handleCommentFocus}
+        />
 
         {/* ── Aktionen ── */}
         <View style={styles.actions}>

--- a/features/jobs/JobsListScreen.tsx
+++ b/features/jobs/JobsListScreen.tsx
@@ -12,7 +12,7 @@ import { useJobs } from "@/context/JobContext";
 import { useAuth } from "@/context/AuthContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import {
-  formatAssigneesFull,
+  getAssigneeNames,
   isAssignedTo,
   isPrimaryAssignee,
 } from "@/utils/jobAssignees";
@@ -105,13 +105,20 @@ export default function JobsListScreen() {
         return false;
       }
 
-      // Suche über Kunde / Service / Ort / (Admin) alle Mitarbeitenden
+      // Suche über Kunde / Service / Ort / (Admin) alle Mitarbeitenden.
+      //
+      // BEWUSST getAssigneeNames statt formatAssigneesFull: der
+      // Anzeige-Formatter liefert für einen Auftrag ohne Zuweisung den
+      // Platzhalter „Nicht zugewiesen". Der landete im Suchindex, wodurch
+      // schon einzelne Buchstaben (z, g, e, i, s, n, …) sämtliche
+      // unzugewiesenen Aufträge trafen. Die Namensliste ist für einen
+      // leeren Auftrag korrekt leer.
       if (query) {
         const haystack = [
           job.customerName,
           job.service,
           job.location,
-          isAdmin ? formatAssigneesFull(job) : null,
+          isAdmin ? getAssigneeNames(job).join(" ") : null,
         ]
           .filter(Boolean)
           .join(" ")

--- a/features/jobs/JobsListScreen.tsx
+++ b/features/jobs/JobsListScreen.tsx
@@ -11,6 +11,11 @@ import JobCard from "@/components/JobCard";
 import { useJobs } from "@/context/JobContext";
 import { useAuth } from "@/context/AuthContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import {
+  formatAssigneesFull,
+  isAssignedTo,
+  isPrimaryAssignee,
+} from "@/utils/jobAssignees";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
@@ -60,7 +65,7 @@ export default function JobsListScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const { role } = useAuth();
+  const { role, profile } = useAuth();
   const { jobs, employees, startJob, completeJob, loading, refreshJobs, refreshEmployees } = useJobs();
 
   const [filter, setFilter] = useState<Filter>("all");
@@ -93,18 +98,20 @@ export default function JobsListScreen() {
       // Status-Filter
       if (filter !== "all" && job.status !== filter) return false;
 
-      // Mitarbeiter-Filter (nur Admin)
-      if (isAdmin && employeeId !== "all" && job.employeeId !== employeeId) {
+      // Mitarbeiter-Filter (nur Admin) — über die Zuweisungsmenge, damit
+      // ein Auftrag auch dann erscheint, wenn der gewählte Mitarbeiter nicht
+      // der Legacy-Primär ist.
+      if (isAdmin && employeeId !== "all" && !isAssignedTo(job, employeeId)) {
         return false;
       }
 
-      // Suche über Kunde / Service / Ort / (Admin) Mitarbeiter
+      // Suche über Kunde / Service / Ort / (Admin) alle Mitarbeitenden
       if (query) {
         const haystack = [
           job.customerName,
           job.service,
           job.location,
-          isAdmin ? job.employeeName : null,
+          isAdmin ? formatAssigneesFull(job) : null,
         ]
           .filter(Boolean)
           .join(" ")
@@ -307,8 +314,22 @@ export default function JobsListScreen() {
             // Admins dürfen den Status NICHT über diese RPCs ändern → bei ihnen
             // keine Quick-Action-Buttons zeigen, sonst RPC-Fehler "Job not found
             // or not allowed". (JobCard blendet die Buttons ohne diese Props aus.)
-            onStart={isAdmin ? undefined : () => startJob(item.id)}
-            onComplete={isAdmin ? undefined : () => completeJob(item.id)}
+            //
+            // Seit Phase 5 sieht ein Mitarbeiter auch Aufträge, denen er nur
+            // SEKUNDÄR zugewiesen ist. Die RPCs kennen die Zuweisungsmenge noch
+            // nicht — deshalb hier zusätzlich auf den Legacy-Primär prüfen,
+            // sonst bekäme er einen Button, der garantiert fehlschlägt.
+            // Entfällt mit Phase 7.
+            onStart={
+              isAdmin || !isPrimaryAssignee(item, profile?.id)
+                ? undefined
+                : () => startJob(item.id)
+            }
+            onComplete={
+              isAdmin || !isPrimaryAssignee(item, profile?.id)
+                ? undefined
+                : () => completeJob(item.id)
+            }
             onPress={() => router.push(`/jobs/${item.id}`)}
             showEmployeeName={isAdmin}
           />

--- a/features/jobs/components/JobComments.tsx
+++ b/features/jobs/components/JobComments.tsx
@@ -1,7 +1,15 @@
 // features/jobs/components/JobComments.tsx
 // Kommentar-Sektion für einen Job (append-only, MVP).
-// Liste (Autor, Zeit, Text) + Eingabe. Employee und Admin dürfen schreiben.
-// Online-only — nutzt useJobComments (kein JobContext, keine Offline-Queue).
+// Liste (Autor, Zeit, Text) + Eingabe. Online-only — nutzt useJobComments
+// (kein JobContext, keine Offline-Queue).
+//
+// SCHREIBRECHT ist NICHT dasselbe wie Leserecht: seit Phase 5 sieht auch ein
+// nur sekundär zugewiesener Mitarbeiter den Auftrag und seine Kommentare,
+// darf aber keinen schreiben — die RLS-Policy
+// "employee insert comments on own jobs" verlangt weiterhin
+// jobs.assigned_to = auth.uid(). Deshalb MUSS der Aufrufer `canComment`
+// setzen; ohne dieses Prop hätte der Nutzer ein aktives Senden-Feld, das
+// serverseitig mit einem RLS-Fehler endet.
 
 import { Button, Card, ErrorBanner, Input } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
@@ -34,12 +42,22 @@ function formatDateTime(iso?: string | null): string | null {
 
 type JobCommentsProps = {
   jobId: string;
+  /**
+   * Darf der aktuelle Nutzer hier kommentieren? Pflicht-Prop (kein Default
+   * `true`): ein vergessenes Prop soll die Eingabe ausblenden, nicht
+   * fälschlich freischalten.
+   */
+  canComment: boolean;
   // Wird gerufen, wenn das Kommentarfeld fokussiert wird — der Screen scrollt
   // dann so, dass Eingabe + Senden über der Tastatur sichtbar bleiben.
   onInputFocus?: () => void;
 };
 
-export function JobComments({ jobId, onInputFocus }: JobCommentsProps) {
+export function JobComments({
+  jobId,
+  canComment,
+  onInputFocus,
+}: JobCommentsProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
@@ -49,7 +67,7 @@ export function JobComments({ jobId, onInputFocus }: JobCommentsProps) {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
 
-  const canSend = draft.trim().length > 0 && !submitting;
+  const canSend = canComment && draft.trim().length > 0 && !submitting;
 
   const handleSend = async () => {
     setSubmitError("");
@@ -115,31 +133,40 @@ export function JobComments({ jobId, onInputFocus }: JobCommentsProps) {
         </View>
       )}
 
-      {/* ── Eingabe ── */}
-      <View style={styles.inputWrap}>
-        {submitError ? (
-          <ErrorBanner
-            message={submitError}
-            onDismiss={() => setSubmitError("")}
-          />
-        ) : null}
+      {/* ── Eingabe (nur mit Schreibrecht) ── */}
+      {canComment ? (
+        <View style={styles.inputWrap}>
+          {submitError ? (
+            <ErrorBanner
+              message={submitError}
+              onDismiss={() => setSubmitError("")}
+            />
+          ) : null}
 
-        <Input
-          placeholder="Kommentar schreiben…"
-          value={draft}
-          onChangeText={setDraft}
-          onFocus={onInputFocus}
-          multiline
-          editable={!submitting}
-        />
-        <Button
-          label="Senden"
-          icon="send"
-          loading={submitting}
-          disabled={!canSend}
-          onPress={handleSend}
-        />
-      </View>
+          <Input
+            placeholder="Kommentar schreiben…"
+            value={draft}
+            onChangeText={setDraft}
+            onFocus={onInputFocus}
+            multiline
+            editable={!submitting}
+          />
+          <Button
+            label="Senden"
+            icon="send"
+            loading={submitting}
+            disabled={!canSend}
+            onPress={handleSend}
+          />
+        </View>
+      ) : (
+        // Kein deaktivierter Button, sondern eine Erklärung: ein ausgegrautes
+        // Feld ohne Grund wirkt wie ein Fehler.
+        <Text style={styles.readOnlyHint}>
+          Du kannst hier mitlesen. Kommentare schreiben kann derzeit nur der
+          hauptverantwortliche Mitarbeiter des Auftrags.
+        </Text>
+      )}
     </Card>
   );
 }
@@ -160,6 +187,13 @@ function createStyles(theme: AppTheme) {
       fontWeight: theme.typography.weight.semibold,
       color: theme.colors.outline,
       letterSpacing: theme.typography.letterSpacing.wider,
+    },
+
+    readOnlyHint: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: 20,
     },
 
     loadingWrap: {

--- a/features/jobs/components/RuleOccurrences.tsx
+++ b/features/jobs/components/RuleOccurrences.tsx
@@ -24,6 +24,10 @@
 // maxHeight. Die unbegrenzt wachsende Historie bleibt seitenweise.
 
 import { StatusBadge } from "@/components/ui";
+import {
+  formatAssigneesShort,
+  isUnassigned,
+} from "@/utils/jobAssignees";
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { Job } from "@/types/job";
@@ -263,7 +267,9 @@ function OccurrenceRow({
         </View>
         <Text style={styles.rowMeta} numberOfLines={1}>
           {occurrence.startTime ? `${occurrence.startTime} Uhr` : "—"}
-          {occurrence.employeeName ? ` · ${occurrence.employeeName}` : ""}
+          {isUnassigned(occurrence)
+            ? ""
+            : ` · ${formatAssigneesShort(occurrence)}`}
         </Text>
       </View>
 

--- a/scripts/verify-job-assignees.mjs
+++ b/scripts/verify-job-assignees.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Verifikation der reinen Zuweisungs-Helfer aus utils/jobAssignees.ts.
+//
+// WARUM DIESES SKRIPT EXISTIERT
+//   Das Projekt hat (bewusst) keinen JS-Test-Runner. Die Fallback-Ableitung
+//   `buildLegacyAssignees()` ist aber sicherheitsrelevant fuer die Anzeige:
+//   sie entscheidet, was nach einem erfolgreichen Schreibvorgang mit
+//   fehlgeschlagenem Nachlesen in State UND AsyncStorage landet. Ein
+//   Review-Befund (H3/M-1) entstand genau dort. Deshalb wird die Funktion
+//   isoliert kompiliert und gegen die ECHTE Quelle geprueft — keine Kopie
+//   der Logik, kein Mock.
+//
+// AUSFUEHREN
+//   node scripts/verify-job-assignees.mjs
+//
+// Was NICHT hier geprueft wird (weil es Netzwerk/Supabase braucht):
+//   * dass die beiden Fehlerpfade in readBackJob() geloggt werden
+//   * dass ein erfolgreiches Nachlesen die vollstaendige Menge liefert
+//   Beides ist gegen PostgREST manuell verifiziert; die Vorgehensweise steht
+//   in docs/phase5-react-native-read-path.md.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import assert from "node:assert/strict";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const out = mkdtempSync(join(tmpdir(), "verify-assignees-"));
+
+try {
+  const cfg = join(out, "tsconfig.json");
+  writeFileSync(
+    cfg,
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: false,
+        outDir: join(out, "js"),
+        module: "es2020",
+        moduleResolution: "node",
+        target: "es2020",
+        skipLibCheck: true,
+        types: [],
+        baseUrl: root,
+        paths: { "@/*": ["./*"] },
+      },
+      include: [join(root, "utils/jobAssignees.ts")],
+    }),
+  );
+
+  execFileSync("npx", ["tsc", "-p", cfg], { cwd: root, stdio: "pipe" });
+
+  const mod = await import(
+    pathToFileURL(join(out, "js/utils/jobAssignees.js")).href
+  );
+  const { buildLegacyAssignees, formatAssigneesShort, formatAssigneesFull } = mod;
+
+  let n = 0;
+  const ok = (name, fn) => {
+    fn();
+    n += 1;
+    console.log(`  PASS  ${name}`);
+  };
+
+  console.log("buildLegacyAssignees — Fallback nach erfolgreichem Schreibvorgang");
+
+  // createJob-Fallback: Embed lieferte [], Legacy-Zeiger steht auf Erika.
+  ok("create-Fallback liefert einen Legacy-Zugewiesenen statt []", () => {
+    const r = buildLegacyAssignees({
+      id: "job-1",
+      employeeId: "emp-erika",
+      employeeName: "Erika",
+    });
+    assert.equal(r.length, 1);
+    assert.equal(r[0].employeeId, "emp-erika");
+    assert.equal(r[0].fullName, "Erika");
+    assert.equal(r[0].isDeleted, false);
+    assert.notDeepEqual(r, []);
+  });
+
+  // updateJob-Fallback: Embed trug noch den ALTEN, assigned_to den NEUEN.
+  ok("update-Fallback liefert den NEUEN, nicht den alten Zugewiesenen", () => {
+    const r = buildLegacyAssignees({
+      id: "job-1",
+      employeeId: "emp-zoe",
+      employeeName: "Zoe",
+    });
+    assert.equal(r.length, 1);
+    assert.equal(r[0].employeeId, "emp-zoe");
+    assert.ok(!r.some((a) => a.employeeId === "emp-erika"));
+  });
+
+  ok("erfindet nie mehr als einen Zugewiesenen", () => {
+    for (const id of ["a", "b", "c"]) {
+      assert.ok(
+        buildLegacyAssignees({ id: "j", employeeId: id, employeeName: "X" })
+          .length <= 1,
+      );
+    }
+  });
+
+  // Kontoloeschung setzt jobs.assigned_to auf NULL -> nichts abzuleiten.
+  ok("geloeschtes Konto (assigned_to NULL) -> leer, kein Platzhalter", () => {
+    assert.deepEqual(
+      buildLegacyAssignees({ id: "j", employeeId: null, employeeName: null }),
+      [],
+    );
+    assert.deepEqual(
+      buildLegacyAssignees({ id: "j", employeeId: undefined, employeeName: "W" }),
+      [],
+    );
+  });
+
+  ok("leerer Name faellt auf 'Unbekannt' zurueck", () => {
+    assert.equal(
+      buildLegacyAssignees({ id: "j", employeeId: "e", employeeName: "   " })[0]
+        .fullName,
+      "Unbekannt",
+    );
+    assert.equal(
+      buildLegacyAssignees({ id: "j", employeeId: "e", employeeName: null })[0]
+        .fullName,
+      "Unbekannt",
+    );
+  });
+
+  ok("assignmentId ist als abgeleitet erkennbar und stabil", () => {
+    const a = buildLegacyAssignees({ id: "j", employeeId: "e", employeeName: "N" });
+    const b = buildLegacyAssignees({ id: "j", employeeId: "e", employeeName: "N" });
+    assert.equal(a[0].assignmentId, b[0].assignmentId);
+    assert.ok(a[0].assignmentId.startsWith("legacy:"));
+  });
+
+  // L-1: keine erfundenen Abrechnungs-/Anwesenheitsdaten mehr.
+  ok("traegt keine Abrechnungs-/Anwesenheitsfelder", () => {
+    const r = buildLegacyAssignees({ id: "j", employeeId: "e", employeeName: "N" });
+    assert.deepEqual(Object.keys(r[0]).sort(), [
+      "assignmentId",
+      "employeeId",
+      "fullName",
+      "isDeleted",
+    ]);
+  });
+
+  ok("Fallback-Ergebnis rendert korrekt in den Anzeige-Helfern", () => {
+    const job = {
+      assignees: buildLegacyAssignees({
+        id: "j",
+        employeeId: "e",
+        employeeName: "Erika",
+      }),
+    };
+    assert.equal(formatAssigneesShort(job), "Erika");
+    assert.equal(formatAssigneesFull(job), "Erika");
+    assert.equal(formatAssigneesFull({ assignees: [] }), "Nicht zugewiesen");
+  });
+
+  console.log(`\n${n}/${n} Zusicherungen erfuellt.`);
+} finally {
+  rmSync(out, { recursive: true, force: true });
+}

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -1,6 +1,27 @@
 import { supabase } from "@/lib/supabase";
-import { CreateJobInput, EmployeeOption, Job, JobType } from "@/types/job";
+import {
+  CreateJobInput,
+  EmployeeOption,
+  Job,
+  JobAssignee,
+  JobType,
+} from "@/types/job";
 import { normalizeTime } from "@/utils/date";
+import { buildLegacyAssignees } from "@/utils/jobAssignees";
+
+// Eine Zeile aus job_assignments, wie sie eingebettet zurückkommt.
+// profiles ist der LEBENDE Mitarbeiter; bei gelöschtem Konto ist
+// employee_id NULL und profiles fehlt — dann trägt der Snapshot den Namen.
+type JobAssignmentRow = {
+  id: string;
+  employee_id: string | null;
+  employee_name_snapshot: string | null;
+  assigned_at: string | null;
+  profiles?:
+  | { id: string; full_name: string | null }
+  | { id: string; full_name: string | null }[]
+  | null;
+};
 
 // So sieht ein Job direkt aus der Datenbank aus
 type JobRow = {
@@ -33,6 +54,9 @@ type JobRow = {
     full_name: string;
   }[]
   | null;
+  // Zuweisungsmenge (Phase 5). Alias "assignments" im Select, damit sie sich
+  // nicht mit dem Legacy-Embed profiles:assigned_to überschneidet.
+  assignments?: JobAssignmentRow[] | null;
 };
 
 // Einfaches DB-Format für Mitarbeiter
@@ -150,9 +174,14 @@ function formatTimeRange(start: string | null, end: string | null): string {
   return `${formatDateTime(start!)} - ${formatDateTime(end!)}`;
 }
 
-// Zentrale Spaltenauswahl für Job-Abfragen (identisch zu den bestehenden
-// Inline-Selects). Wird von den neuen, gebündelten Zeitplan-/Regel-Queries
-// genutzt, damit das Mapping (mapJob) überall konsistent funktioniert.
+// EINZIGE Spaltenauswahl für Job-Abfragen. Vor Phase 5 lag dieselbe Liste
+// zusätzlich viermal inline (getJobs, createJob, updateJob, getJobOccurrences);
+// mit der neuen Zuweisungsmenge wären das vier Stellen, an denen ein
+// vergessener Embed stillschweigend eine leere Mitarbeiterliste erzeugt.
+// Deshalb konsolidiert — alle Abfragen nutzen ausschließlich diese Konstante.
+//
+// assigned_to + profiles:assigned_to bleiben bewusst enthalten: sie tragen das
+// Aktions-Gating und den Schreibpfad, bis Phase 7/11 sie ablösen.
 const JOB_SELECT = `
   id,
   customer_name,
@@ -176,8 +205,121 @@ const JOB_SELECT = `
   profiles:assigned_to (
     id,
     full_name
+  ),
+  assignments:job_assignments (
+    id,
+    employee_id,
+    employee_name_snapshot,
+    assigned_at,
+    profiles:employee_id (
+      id,
+      full_name
+    )
   )
 `;
+
+// PostgREST liefert eingebettete 1:1-Beziehungen mal als Objekt, mal als
+// Array (abhängig davon, ob die Beziehung als to-one erkannt wird).
+function firstProfileName(
+  profiles: JobAssignmentRow["profiles"] | JobRow["profiles"],
+): string | null {
+  if (!profiles) return null;
+  if (Array.isArray(profiles)) return profiles[0]?.full_name ?? null;
+  return profiles.full_name ?? null;
+}
+
+// Wandelt die eingebetteten Zuweisungszeilen in die App-Darstellung.
+//
+// NAMENSREGEL (entspricht der Vorgabe der Phase-1-Migration): der LEBENDE
+// Profilname gewinnt, solange das Profil existiert; erst wenn das Konto
+// gelöscht wurde (employee_id IS NULL), trägt der Schnappschuss den Namen.
+//
+// SORTIERUNG: nach assigned_at, dann Name, dann assignmentId. Ohne stabile
+// Reihenfolge würde die Mitarbeiterliste einer Karte bei jedem Neuladen
+// springen — PostgREST garantiert für eingebettete Mengen keine Ordnung.
+function mapAssignees(rows: JobAssignmentRow[] | null | undefined): JobAssignee[] {
+  if (!rows || rows.length === 0) return [];
+
+  return rows
+    .map((row) => {
+      const livingName = firstProfileName(row.profiles);
+      const snapshot = row.employee_name_snapshot?.trim() || null;
+
+      return {
+        assignedAt: row.assigned_at ?? "",
+        assignee: {
+          assignmentId: row.id,
+          employeeId: row.employee_id,
+          fullName: livingName?.trim() || snapshot || "Unbekannt",
+          isDeleted: row.employee_id === null,
+        } satisfies JobAssignee,
+      };
+    })
+    .sort((a, b) => {
+      const timeDiff = a.assignedAt.localeCompare(b.assignedAt);
+      if (timeDiff !== 0) return timeDiff;
+      const nameDiff = a.assignee.fullName.localeCompare(
+        b.assignee.fullName,
+        "de",
+      );
+      if (nameDiff !== 0) return nameDiff;
+      return a.assignee.assignmentId.localeCompare(b.assignee.assignmentId);
+    })
+    .map((entry) => entry.assignee);
+}
+
+// Liest einen gerade geschriebenen Job EINMAL frisch nach.
+//
+// Warum: die eingebettete Zuweisungsmenge im RETURNING eines INSERT/UPDATE
+// ist NICHT verlaesslich. Die Kompatibilitaets-Trigger aus Phase 2 schreiben
+// job_assignments in AFTER-Triggern; der Embed derselben Anweisung sieht
+// deren Ergebnis nicht mehr. Gegen PostgREST reproduziert:
+//
+//   INSERT (assigned_to=Erika) -> assignments: []        | frisch: [Erika]
+//   UPDATE (assigned_to=Zoe)   -> assignments: [Erika]   | frisch: [Zoe]
+//
+// Ohne Nachlesen zeigte ein neu angelegter Auftrag "Nicht zugewiesen" und ein
+// bearbeiteter den VORHERIGEN Mitarbeiter — und beides landete zusaetzlich
+// ueber saveCachedJobs im Offline-Cache.
+//
+// FALLBACK, wenn das Nachlesen scheitert (Netz, RLS, kein Datensatz):
+// Der Schreibvorgang war erfolgreich und darf NIE nachtraeglich als Fehler
+// erscheinen — es wird also immer ein Job zurueckgegeben, nie geworfen.
+//
+// Entscheidend ist, WAS dann in `assignees` steht. mapJob(row) allein waere
+// hier falsch: es traegt exakt die unzuverlaessige Embed-Menge und damit
+// wieder `[]` (nach dem Anlegen) bzw. die ALTE Menge (nach dem Bearbeiten) —
+// und der JobContext schreibt das Ergebnis in State UND AsyncStorage.
+// Stattdessen wird die Menge aus dem Legacy-Zeiger abgeleitet
+// (buildLegacyAssignees): genau ein Mitarbeiter, nie geraten, nie mehrere.
+//
+// Der Legacy-Zeiger ist an dieser Stelle verlaesslich: assigned_to ist eine
+// echte Spalte der gerade geschriebenen Zeile und kommt frisch aus dem
+// RETURNING — nur die eingebettete Beziehung hinkt hinterher.
+//
+// BEIDE Fehlerpfade werden geloggt (Ausnahme UND leeres Ergebnis), damit ein
+// stiller Fallback nicht unbemerkt bleibt.
+async function readBackJob(row: JobRow): Promise<Job> {
+  const base = mapJob(row);
+
+  try {
+    const fresh = await getJobById(row.id);
+    if (fresh) return fresh;
+
+    console.error(
+      "[jobs.service] Nachlesen nach Schreibvorgang lieferte keinen Datensatz " +
+      `(Job ${row.id}) — Zuweisungen werden aus dem Legacy-Zeiger abgeleitet.`,
+    );
+  } catch (err) {
+    console.error(
+      "[jobs.service] Nachlesen nach Schreibvorgang fehlgeschlagen " +
+      `(Job ${row.id}) — Zuweisungen werden aus dem Legacy-Zeiger abgeleitet.`,
+      err,
+    );
+  }
+
+  return { ...base, assignees: buildLegacyAssignees(base) };
+}
 
 // Wandelt einen DB-Job in unser App-Job-Objekt um
 function mapJob(row: JobRow): Job {
@@ -187,13 +329,13 @@ function mapJob(row: JobRow): Job {
     location: row.location_address,
     time: formatTimeRange(row.scheduled_start, row.scheduled_end),
     service: row.service_name,
-    employeeId: row.assigned_to,
 
-    // profiles kann entweder ein Objekt, ein Array oder null sein
-    // deshalb fangen wir hier alle Fälle ab
-    employeeName: Array.isArray(row.profiles)
-      ? row.profiles[0]?.full_name ?? null
-      : row.profiles?.full_name ?? null,
+    // Maßgeblich für jede Anzeige (Phase 5).
+    assignees: mapAssignees(row.assignments),
+
+    // @deprecated — nur noch Aktions-Gating und Schreibpfad, siehe types/job.ts
+    employeeId: row.assigned_to,
+    employeeName: firstProfileName(row.profiles),
 
     status: row.status,
     notes: row.notes,
@@ -222,33 +364,7 @@ function mapJob(row: JobRow): Job {
 export async function getJobs(): Promise<Job[]> {
   const { data, error } = await supabase
     .from("jobs")
-    .select(
-      `
-      id,
-      customer_name,
-      service_name,
-      location_address,
-      scheduled_start,
-      scheduled_end,
-      status,
-      started_at,
-      completed_at,
-      notes,
-      job_type,
-      date,
-      start_time,
-      recurring_days,
-      is_active,
-      parent_job_id,
-      recurrence_start_date,
-      recurrence_end_date,
-      assigned_to,
-      profiles:assigned_to (
-        id,
-        full_name
-      )
-      `
-    )
+    .select(JOB_SELECT)
     .order("created_at", { ascending: false });
 
   if (error) {
@@ -439,33 +555,7 @@ export async function createJob(input: CreateJobInput): Promise<CreateJobResult>
   const { data, error } = await supabase
     .from("jobs")
     .insert(payload)
-    .select(
-      `
-      id,
-      customer_name,
-      service_name,
-      location_address,
-      scheduled_start,
-      scheduled_end,
-      status,
-      started_at,
-      completed_at,
-      notes,
-      job_type,
-      date,
-      start_time,
-      recurring_days,
-      is_active,
-      parent_job_id,
-      recurrence_start_date,
-      recurrence_end_date,
-      assigned_to,
-      profiles:assigned_to (
-        id,
-        full_name
-      )
-      `
-    )
+    .select(JOB_SELECT)
     .single();
 
   // Hilfreich fürs Debugging (nur in Development)
@@ -545,8 +635,12 @@ export async function createJob(input: CreateJobInput): Promise<CreateJobResult>
     }
   }
 
-  // Rückgabe im App-Format
-  return { job: mapJob(data as JobRow), recurringOccurrencesFailed };
+  // Rückgabe im App-Format. Frisch nachlesen, damit `assignees` die vom
+  // Kompatibilitäts-Trigger erzeugte Zuweisung enthält (siehe readBackJob).
+  return {
+    job: await readBackJob(data as unknown as JobRow),
+    recurringOccurrencesFailed,
+  };
 }
 
 // Aktualisiert einen bestehenden Job
@@ -633,33 +727,7 @@ export async function updateJob(input: UpdateJobInput): Promise<Job> {
     .from("jobs")
     .update(payload)
     .eq("id", input.jobId)
-    .select(
-      `
-      id,
-      customer_name,
-      service_name,
-      location_address,
-      scheduled_start,
-      scheduled_end,
-      status,
-      started_at,
-      completed_at,
-      notes,
-      job_type,
-      date,
-      start_time,
-      recurring_days,
-      is_active,
-      parent_job_id,
-      recurrence_start_date,
-      recurrence_end_date,
-      assigned_to,
-      profiles:assigned_to (
-        id,
-        full_name
-      )
-      `
-    )
+    .select(JOB_SELECT)
     .single();
 
   if (error) {
@@ -679,7 +747,9 @@ export async function updateJob(input: UpdateJobInput): Promise<Job> {
     }
   }
 
-  return mapJob(data as JobRow);
+  // Frisch nachlesen: der RETURNING-Embed traegt hier noch die ALTE
+  // Zuweisungsmenge (siehe readBackJob).
+  return readBackJob(data as unknown as JobRow);
 }
 
 // Setzt einen Job auf "in_progress" und speichert Startzeit.
@@ -751,33 +821,7 @@ async function sendPushNotification(token: string, title: string, body: string) 
 export async function getJobOccurrences(parentJobId: string): Promise<Job[]> {
   const { data, error } = await supabase
     .from("jobs")
-    .select(
-      `
-      id,
-      customer_name,
-      service_name,
-      location_address,
-      scheduled_start,
-      scheduled_end,
-      status,
-      started_at,
-      completed_at,
-      notes,
-      job_type,
-      date,
-      start_time,
-      recurring_days,
-      is_active,
-      parent_job_id,
-      recurrence_start_date,
-      recurrence_end_date,
-      assigned_to,
-      profiles:assigned_to (
-        id,
-        full_name
-      )
-      `
-    )
+    .select(JOB_SELECT)
     .eq("parent_job_id", parentJobId)
     .order("date", { ascending: true })
     .order("start_time", { ascending: true });
@@ -853,17 +897,44 @@ export async function getJobById(jobId: string): Promise<Job | null> {
 }
 
 // Mitarbeiter-Filter für Zeitplan-Queries (serverseitig).
-//   - employeeId gesetzt          → assigned_to = employeeId
-//   - unassigned = true           → assigned_to IS NULL („Nicht zugewiesen")
+//   - employeeId gesetzt          → Mitarbeiter ist dem Auftrag zugewiesen
+//   - unassigned = true           → Auftrag hat GAR KEINE Zuweisung
 //   - beides leer                 → alle Mitarbeiter
 export type EmployeeFilter = { employeeId?: string; unassigned?: boolean };
 
+// Zusätzliche Embeds, die AUSSCHLIESSLICH als Filter-Prädikat dienen.
+//
+// WARUM EIN ZWEITER EMBED? Der Anzeige-Embed `assignments` muss IMMER die
+// vollständige Zuweisungsmenge liefern. Würde man ihn selbst filtern, zeigte
+// eine nach Mitarbeiter X gefilterte Liste an jedem Auftrag nur noch X —
+// die Kolleginnen und Kollegen verschwänden aus der Anzeige. Der zweite,
+// aliasierte Embed schränkt deshalb nur die ZEILENMENGE ein und wird nie
+// gelesen. PostgREST dupliziert dabei keine Zeilen (verifiziert).
+const ASSIGNEE_FILTER_EMBED = `,f:job_assignments!inner(employee_id)`;
+const UNASSIGNED_FILTER_EMBED = `,f:job_assignments!left(employee_id)`;
+
+// Liefert die Spaltenauswahl inklusive des passenden Filter-Embeds.
+// WICHTIG: Filter-Embed und Filter-Bedingung gehören zusammen — immer beide
+// über applySelect/applyEmployeeFilter mit DEMSELBEN filter aufrufen.
+function jobSelectFor(filter?: EmployeeFilter): string {
+  if (filter?.unassigned) return JOB_SELECT + UNASSIGNED_FILTER_EMBED;
+  if (filter?.employeeId) return JOB_SELECT + ASSIGNEE_FILTER_EMBED;
+  return JOB_SELECT;
+}
+
 // Wendet den Mitarbeiter-Filter auf einen Query-Builder an (serverseitig).
+//
+// „Nicht zugewiesen" läuft bewusst NICHT mehr über assigned_to IS NULL:
+// compat_primary_assignee() setzt den Legacy-Zeiger auch dann auf NULL, wenn
+// zwar Zuweisungen existieren, aber keine davon spurenfrei und aktiv ist
+// (z. B. bereits gestartet oder Mitarbeiter deaktiviert). Die Legacy-Spalte
+// ist damit KEIN verlässlicher Indikator für „hat niemanden" — die
+// Zuweisungsmenge selbst schon.
 function applyEmployeeFilter<T>(query: T, filter?: EmployeeFilter): T {
   if (!filter) return query;
   const q = query as any;
-  if (filter.unassigned) return q.is("assigned_to", null);
-  if (filter.employeeId) return q.eq("assigned_to", filter.employeeId);
+  if (filter.unassigned) return q.is("f", null);
+  if (filter.employeeId) return q.eq("f.employee_id", filter.employeeId);
   return query;
 }
 
@@ -883,7 +954,7 @@ export async function getScheduleOccurrences(
 ): Promise<Job[]> {
   let query = supabase
     .from("jobs")
-    .select(JOB_SELECT)
+    .select(jobSelectFor(params.employee))
     .eq("job_type", "single")
     .gte("date", params.from)
     .lte("date", params.to);
@@ -902,7 +973,7 @@ export async function getScheduleOccurrences(
   if (error) {
     throw error;
   }
-  return (data ?? []).map((row) => mapJob(row as JobRow));
+  return (data ?? []).map((row) => mapJob(row as unknown as JobRow));
 }
 
 // Überfällige executable Jobs: offen/in Arbeit mit Datum vor heute.
@@ -914,7 +985,7 @@ export async function getOverdueOccurrences(
 ): Promise<Job[]> {
   let query = supabase
     .from("jobs")
-    .select(JOB_SELECT)
+    .select(jobSelectFor(employee))
     .eq("job_type", "single")
     .in("status", ["open", "in_progress"])
     .lt("date", todayKey);
@@ -929,7 +1000,7 @@ export async function getOverdueOccurrences(
   if (error) {
     throw error;
   }
-  return (data ?? []).map((row) => mapJob(row as JobRow));
+  return (data ?? []).map((row) => mapJob(row as unknown as JobRow));
 }
 
 // Erledigte executable Jobs, nach Abschlusszeit absteigend, keyset-fähig
@@ -941,7 +1012,7 @@ export async function getCompletedOccurrences(
 ): Promise<Job[]> {
   let query = supabase
     .from("jobs")
-    .select(JOB_SELECT)
+    .select(jobSelectFor(employee))
     .eq("job_type", "single")
     .eq("status", "completed")
     .not("completed_at", "is", null);
@@ -959,7 +1030,7 @@ export async function getCompletedOccurrences(
   if (error) {
     throw error;
   }
-  return (data ?? []).map((row) => mapJob(row as JobRow));
+  return (data ?? []).map((row) => mapJob(row as unknown as JobRow));
 }
 
 // Nur die Parent-Regeln (Daueraufträge): recurring UND parent_job_id IS NULL.
@@ -977,7 +1048,7 @@ export async function getRecurringRules(): Promise<Job[]> {
   if (error) {
     throw error;
   }
-  return (data ?? []).map((row) => mapJob(row as JobRow));
+  return (data ?? []).map((row) => mapJob(row as unknown as JobRow));
 }
 
 // Zusammenfassung der Occurrences je Regel (nächster Termin + „hat Termine?")

--- a/services/offline/jobs.storage.ts
+++ b/services/offline/jobs.storage.ts
@@ -1,4 +1,5 @@
 import { Job } from "@/types/job";
+import { buildLegacyAssignees } from "@/utils/jobAssignees";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const JOBS_STORAGE_KEY = "offline_jobs_cache";
@@ -7,6 +8,28 @@ type StoredJobsPayload = {
   jobs: Job[];
   updatedAt: string;
 };
+
+/**
+ * Hebt einen Job aus einem ÄLTEREN Cache auf das Phase-5-Format an.
+ *
+ * Warum das nötig ist: der Cache überlebt das App-Update. Ein vor Phase 5
+ * geschriebener Eintrag kennt `assignees` nicht. Ohne diesen Shim zeigte der
+ * erste (offline) Kaltstart nach dem Update überall „Nicht zugewiesen" —
+ * eine sichtbare Regression genau in der Situation, für die der Cache da ist.
+ *
+ * Die Ableitung teilt sich die Logik mit dem Fallback in `readBackJob()`
+ * (services/jobs/jobs.service.ts) — beide stehen vor demselben Problem:
+ * nur der Legacy-Zeiger ist bekannt. Deshalb EIN gemeinsamer Helfer, damit
+ * die beiden Pfade nicht auseinanderlaufen (genau das war ein Review-Befund).
+ *
+ * Der Shim stellt den vorherigen Informationsstand her, nicht mehr: vor dem
+ * Update wurde ohnehin nur dieser eine Mitarbeiter angezeigt. Beim ersten
+ * erfolgreichen Online-Refresh kommt die echte Menge nach.
+ */
+function normalizeCachedJob(job: Job): Job {
+  if (Array.isArray(job.assignees)) return job;
+  return { ...job, assignees: buildLegacyAssignees(job) };
+}
 
 /**
  * Speichert die aktuelle Jobliste lokal im AsyncStorage.
@@ -43,7 +66,7 @@ export async function getCachedJobs(): Promise<Job[]> {
       return [];
     }
 
-    return parsed.jobs;
+    return parsed.jobs.map(normalizeCachedJob);
   } catch (error) {
     console.error("Failed to read cached jobs:", error);
     return [];
@@ -68,7 +91,7 @@ export async function getCachedJobsPayload(): Promise<StoredJobsPayload | null> 
       return null;
     }
 
-    return parsed;
+    return { ...parsed, jobs: parsed.jobs.map(normalizeCachedJob) };
   } catch (error) {
     console.error("Failed to read cached jobs payload:", error);
     return null;

--- a/types/job.ts
+++ b/types/job.ts
@@ -3,13 +3,53 @@ export type JobStatus = "open" | "in_progress" | "completed";
 // Einmaliger Auftrag (single) vs. dauerhafter/wiederkehrender Auftrag (recurring).
 export type JobType = "single" | "recurring";
 
+// Ein zugewiesener Mitarbeiter an einem Auftrag (eine Zeile aus job_assignments).
+//
+// BEWUSST MINIMAL: das Modell trägt nur, was der Lesepfad heute WIRKLICH
+// anzeigt. `attendance` und `counts_for_timesheet` existieren in der DB,
+// wurden hier aber entfernt — sie hatten keinen einzigen Konsumenten und
+// mussten in jedem Fallback-Pfad erfunden werden (aus job.status abgeleitet).
+// Insbesondere `counts_for_timesheet` ist die Quelle der Stundenzettel-
+// BERECHTIGUNG; ein erfundener Wert dafür im Client wäre eine Abrechnungs-
+// Falle. Beide kommen in Phase 7 zurück, wenn `attendance` serverseitig
+// gepflegt wird und es echte Konsumenten gibt.
+export type JobAssignee = {
+  /** PK der Zuweisung — stabiler React-Key, auch bei gelöschtem Konto. */
+  assignmentId: string;
+  /** NULL = das Mitarbeiterkonto wurde gelöscht (anonymisierter Nachweis). */
+  employeeId: string | null;
+  /** Lebender Profilname; Fallback auf den Schnappschuss bei gelöschtem Konto. */
+  fullName: string;
+  /** true, wenn das Konto gelöscht wurde (employeeId === null). */
+  isDeleted: boolean;
+};
+
 export type Job = {
   id: string;
   customerName: string;
   location: string;
   time: string;
   service: string;
+
+  /**
+   * Vollständige Zuweisungsmenge des Auftrags (Phase 5). Leeres Array =
+   * niemandem zugewiesen. Maßgeblich für JEDE Anzeige von Mitarbeitern.
+   */
+  assignees: JobAssignee[];
+
+  /**
+   * @deprecated Legacy-Primär aus jobs.assigned_to. NICHT mehr für die
+   * Anzeige verwenden — dafür ist `assignees` da.
+   *
+   * Bleibt in Phase 5 bewusst befüllt, weil er zwei Dinge trägt, die noch
+   * nicht umgestellt sind:
+   *  1. das Aktions-Gating (start_own_job/complete_own_job verlangen
+   *     serverseitig weiterhin assigned_to = auth.uid() — Phase 7),
+   *  2. den Schreibpfad beim Anlegen/Bearbeiten (Phase 6).
+   * Entfällt mit der Spalte in Phase 11.
+   */
   employeeId?: string | null;
+  /** @deprecated → `assignees`. Siehe Hinweis bei `employeeId`. */
   employeeName?: string | null;
   status: JobStatus;
   notes?: string | null;

--- a/utils/jobAssignees.ts
+++ b/utils/jobAssignees.ts
@@ -1,0 +1,174 @@
+import type { Job, JobAssignee } from "@/types/job";
+
+/**
+ * Zentrale Helfer für die Anzeige der Zuweisungsmenge eines Auftrags.
+ *
+ * Gleiche Begründung wie bei utils/jobSchedule.ts: die Frage „wer ist diesem
+ * Auftrag zugewiesen und wie schreibe ich das hin?" darf nicht in jedem Screen
+ * neu beantwortet werden. Job-Karte, Detail, Dashboard, Mitarbeiter-Detail,
+ * Suche und Filter nutzen ausschließlich diese Funktionen.
+ *
+ * WICHTIG — Anzeige vs. Berechtigung: diese Helfer beantworten NUR, wer
+ * angezeigt wird. Sie sind KEINE Grundlage für Aktions-Buttons. Start und
+ * Abschluss laufen über start_own_job/complete_own_job, die serverseitig
+ * weiterhin jobs.assigned_to = auth.uid() verlangen (Phase 7). Dafür gibt es
+ * bewusst `isPrimaryAssignee`.
+ */
+
+export const UNASSIGNED_LABEL = "Nicht zugewiesen";
+
+/** Kennzeichnung für Zuweisungen, deren Mitarbeiterkonto gelöscht wurde. */
+export const DELETED_SUFFIX = " (ehemalig)";
+
+/** Alle Zugewiesenen eines Jobs — nie undefined, auch bei Alt-Daten. */
+export function getAssignees(job: Pick<Job, "assignees">): JobAssignee[] {
+  return job.assignees ?? [];
+}
+
+/** Namen aller Zugewiesenen in stabiler Reihenfolge (Service sortiert bereits). */
+export function getAssigneeNames(job: Pick<Job, "assignees">): string[] {
+  return getAssignees(job).map((a) =>
+    a.isDeleted ? `${a.fullName}${DELETED_SUFFIX}` : a.fullName,
+  );
+}
+
+/** true, wenn dem Job niemand zugewiesen ist. */
+export function isUnassigned(job: Pick<Job, "assignees">): boolean {
+  return getAssignees(job).length === 0;
+}
+
+/**
+ * true, wenn der Mitarbeiter dem Auftrag zugewiesen ist (egal an welcher
+ * Stelle der Menge). Für ANZEIGE und FILTER — nicht für Aktions-Gating.
+ */
+export function isAssignedTo(
+  job: Pick<Job, "assignees">,
+  employeeId: string | null | undefined,
+): boolean {
+  if (!employeeId) return false;
+  return getAssignees(job).some((a) => a.employeeId === employeeId);
+}
+
+/**
+ * true, wenn der Mitarbeiter der LEGACY-PRIMÄR des Auftrags ist.
+ *
+ * Ausschließlich für das Aktions-Gating (Start/Abschluss/Foto-Upload/
+ * Kommentar) gedacht: die zugehörigen RPCs und Schreib-Policies verlangen
+ * serverseitig weiterhin jobs.assigned_to = auth.uid(). Würde die UI hier
+ * die volle Menge nutzen, bekäme ein sekundär Zugewiesener einen Button,
+ * der mit „Job not found or not allowed" fehlschlägt. Fällt mit Phase 7.
+ */
+export function isPrimaryAssignee(
+  job: Pick<Job, "employeeId">,
+  employeeId: string | null | undefined,
+): boolean {
+  if (!employeeId) return false;
+  return job.employeeId === employeeId;
+}
+
+/**
+ * Darf für DIESEN Nutzer an DIESEM Auftrag ein Start-/Fertig-Button
+ * erscheinen?
+ *
+ * Zentral, weil die Antwort an fünf Stellen gebraucht wird (Jobliste,
+ * Employee-Übersicht, Kalender, Home, Detail) und eine falsch-positive
+ * Antwort einen Button erzeugt, der serverseitig garantiert fehlschlägt.
+ *
+ * Drei Bedingungen:
+ *  1. Rolle 'employee' — Admins ändern den Status nie über diese RPCs.
+ *  2. job_type 'single' — Parent-Recurring-Regeln sind keine ausführbaren
+ *     Termine.
+ *  3. LEGACY-PRIMÄR (nicht die Zuweisungsmenge!) — start_own_job und
+ *     complete_own_job verlangen weiterhin assigned_to = auth.uid().
+ *     Seit Phase 5 sieht ein Mitarbeiter auch Aufträge, denen er nur
+ *     sekundär zugewiesen ist; ohne Bedingung 3 bekäme er dort einen
+ *     Button, der mit „Job not found or not allowed" endet.
+ *
+ * Bedingung 3 fällt mit Phase 7, wenn die RPCs die Zuweisungsmenge kennen.
+ */
+export function canRunJobActions(
+  job: Pick<Job, "employeeId" | "jobType">,
+  role: string | null | undefined,
+  employeeId: string | null | undefined,
+): boolean {
+  if (role !== "employee") return false;
+  if (job.jobType !== "single") return false;
+  return isPrimaryAssignee(job, employeeId);
+}
+
+/**
+ * Baut aus den LEGACY-Feldern (`employeeId`/`employeeName`) eine sichere
+ * Ein-Element-Zuweisungsliste.
+ *
+ * EINZIGE Notfall-Quelle für `assignees`, wenn die echte Zuweisungsmenge
+ * nicht verfügbar ist. Genau zwei Aufrufer:
+ *
+ *  1. `readBackJob()` in services/jobs/jobs.service.ts — wenn das frische
+ *     Nachlesen nach einem erfolgreichen INSERT/UPDATE scheitert. Ohne diese
+ *     Ableitung stünde dort `[]` (nach dem Anlegen, ununterscheidbar von
+ *     „niemandem zugewiesen") bzw. die ALTE Menge (nach dem Bearbeiten) —
+ *     und der JobContext schriebe genau das in State und AsyncStorage.
+ *  2. `normalizeCachedJob()` in services/offline/jobs.storage.ts — für
+ *     Cache-Einträge, die eine App-Version VOR Phase 5 geschrieben hat und
+ *     die `assignees` noch nicht kennen.
+ *
+ * Beide Fälle sind dasselbe Problem: nur der Legacy-Zeiger ist bekannt.
+ *
+ * BEWUSSTE EIGENSCHAFTEN:
+ *  - Erfindet NIE mehrere Zugewiesene. Der Legacy-Zeiger kann genau einen
+ *    Mitarbeiter ausdrücken; mehr zu behaupten wäre geraten.
+ *  - Erfindet KEINE Anwesenheits- oder Abrechnungsdaten (deshalb trägt
+ *    `JobAssignee` diese Felder nicht mehr, siehe types/job.ts).
+ *  - Gelöschte Konten: `jobs.assigned_to` wird bei der Kontolöschung auf NULL
+ *    gesetzt (ON DELETE SET NULL). Der Legacy-Zeiger trägt dann keinerlei
+ *    Information mehr — das Ergebnis ist korrekt `[]`, und es wird bewusst
+ *    KEIN anonymer Platzhalter erfunden. Die echte anonymisierte Zeile
+ *    (employeeId = null + Namens-Schnappschuss) entsteht ausschließlich auf
+ *    dem regulären Lesepfad in `mapAssignees()`.
+ *  - `assignmentId` ist synthetisch (Präfix `legacy:`): für diesen Eintrag
+ *    existiert keine echte job_assignments-ID. Wird nur als React-Key genutzt
+ *    und ist am Präfix als abgeleitet erkennbar.
+ */
+export function buildLegacyAssignees(
+  job: Pick<Job, "id" | "employeeId" | "employeeName">,
+): JobAssignee[] {
+  if (!job.employeeId) return [];
+
+  return [
+    {
+      assignmentId: `legacy:${job.id}:${job.employeeId}`,
+      employeeId: job.employeeId,
+      fullName: job.employeeName?.trim() || "Unbekannt",
+      isDeleted: false,
+    },
+  ];
+}
+
+/**
+ * Kompakte Anzeige für enge Stellen (Job-Karte, Listenzeilen):
+ * bis `maxNames` Namen, der Rest als „+N".
+ *
+ * Beispiele (maxNames = 2):
+ *   []                       -> "Nicht zugewiesen"
+ *   [Anna]                   -> "Anna"
+ *   [Anna, Bert]             -> "Anna, Bert"
+ *   [Anna, Bert, Cora, Dora] -> "Anna, Bert +2"
+ */
+export function formatAssigneesShort(
+  job: Pick<Job, "assignees">,
+  maxNames: number = 2,
+): string {
+  const names = getAssigneeNames(job);
+  if (names.length === 0) return UNASSIGNED_LABEL;
+  if (names.length <= maxNames) return names.join(", ");
+  return `${names.slice(0, maxNames).join(", ")} +${names.length - maxNames}`;
+}
+
+/**
+ * Vollständige Aufzählung — für Detailansichten, Screenreader-Label und den
+ * Suchindex, wo Kürzen falsch wäre.
+ */
+export function formatAssigneesFull(job: Pick<Job, "assignees">): string {
+  const names = getAssigneeNames(job);
+  return names.length === 0 ? UNASSIGNED_LABEL : names.join(", ");
+}

--- a/utils/recurringRule.ts
+++ b/utils/recurringRule.ts
@@ -13,6 +13,7 @@
 //      / Zeitraum abgelaufen), damit defekte Regeln nicht still verborgen sind.
 
 import type { Job } from "@/types/job";
+import { isUnassigned } from "@/utils/jobAssignees";
 import { getWeekdayKey } from "@/utils/recurrence";
 import { normalizeTime } from "@/utils/date";
 
@@ -113,7 +114,7 @@ export type RuleOccurrenceSummary = {
  *   6. healthy           – alles in Ordnung
  */
 export function deriveRuleHealth(
-  rule: Pick<Job, "status" | "isActive" | "recurrenceEndDate" | "employeeId">,
+  rule: Pick<Job, "status" | "isActive" | "recurrenceEndDate" | "assignees">,
   summary: RuleOccurrenceSummary,
   assigneeIsActive: boolean | null,
   today: string,
@@ -149,12 +150,16 @@ export function deriveRuleHealth(
     };
   }
 
-  if (rule.employeeId && assigneeIsActive === false) {
+  // assigneeIsActive ist seit Phase 5 die ZUSAMMENFASSUNG über alle
+  // Zugewiesenen: false, sobald MINDESTENS EINER deaktiviert ist (der
+  // Aufrufer bildet das). Eine Regel mit einem deaktivierten Mitglied ist
+  // erklärungsbedürftig, auch wenn andere Mitglieder aktiv sind.
+  if (!isUnassigned(rule) && assigneeIsActive === false) {
     return {
       state: "inactive_employee",
       severity: "warning",
       label: "Mitarbeiter inaktiv",
-      hint: "Der zugewiesene Mitarbeiter ist deaktiviert.",
+      hint: "Mindestens ein zugewiesener Mitarbeiter ist deaktiviert.",
     };
   }
 

--- a/utils/recurringRuleFilter.ts
+++ b/utils/recurringRuleFilter.ts
@@ -16,6 +16,7 @@
 // in ruleFilterSummaryParts() — keine bestehende Logik muss sich ändern.
 
 import type { Job } from "@/types/job";
+import { isAssignedTo, isUnassigned } from "@/utils/jobAssignees";
 import type { WeekdayKey } from "@/utils/recurrence";
 import { WEEKDAYS } from "@/utils/recurrence";
 
@@ -72,17 +73,20 @@ export function matchesRuleSearch(
  * Jede Bedingung ist unabhängig prüfbar — siehe Architektur-Hinweis oben.
  */
 export function matchesRuleFilters(
-  rule: Pick<Job, "isActive" | "employeeId" | "recurringDays">,
+  rule: Pick<Job, "isActive" | "assignees" | "recurringDays">,
   filters: RuleFilters,
 ): boolean {
   if (filters.status === "active" && rule.isActive === false) return false;
   if (filters.status === "inactive" && rule.isActive !== false) return false;
 
-  if (filters.employee === "unassigned" && rule.employeeId) return false;
+  // Zuweisungsmenge statt Legacy-Primär: „Nicht zugewiesen" heißt jetzt
+  // wirklich „keine einzige Zuweisung" (der Legacy-Zeiger kann auch dann
+  // NULL sein, wenn Zuweisungen existieren — siehe compat_primary_assignee).
+  if (filters.employee === "unassigned" && !isUnassigned(rule)) return false;
   if (
     filters.employee !== "all" &&
     filters.employee !== "unassigned" &&
-    rule.employeeId !== filters.employee
+    !isAssignedTo(rule, filters.employee)
   ) {
     return false;
   }
@@ -100,7 +104,7 @@ export function matchesRuleFilters(
 export function matchesRuleSearchAndFilters(
   rule: Pick<
     Job,
-    "customerName" | "service" | "location" | "isActive" | "employeeId" | "recurringDays"
+    "customerName" | "service" | "location" | "isActive" | "assignees" | "recurringDays"
   >,
   query: string,
   filters: RuleFilters,

--- a/utils/scheduleView.ts
+++ b/utils/scheduleView.ts
@@ -4,6 +4,7 @@
 // KEINE React-/Supabase-Imports.
 
 import type { Job } from "@/types/job";
+import { formatAssigneesFull } from "@/utils/jobAssignees";
 import { getJobDisplayTime } from "@/utils/jobSchedule";
 
 // Die vier Zeitplan-Filter (executable Jobs: single + Occurrences, nie Parents).
@@ -29,12 +30,15 @@ export const SCHEDULE_FILTERS: { key: ScheduleFilter; label: string }[] = [
  * supabase/tests/recurring_jobs_display.test.sql abgesichert.
  */
 export function matchesSearch(
-  job: Pick<Job, "customerName" | "service" | "location" | "employeeName">,
+  job: Pick<Job, "customerName" | "service" | "location" | "assignees">,
   query: string,
 ): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
-  return [job.customerName, job.service, job.location, job.employeeName]
+  // Seit Phase 5 über ALLE Zugewiesenen — sonst fände die Suche einen
+  // Auftrag nicht mehr, sobald der gesuchte Mitarbeiter nicht der
+  // Legacy-Primär ist.
+  return [job.customerName, job.service, job.location, formatAssigneesFull(job)]
     .filter(Boolean)
     .join(" ")
     .toLowerCase()

--- a/utils/scheduleView.ts
+++ b/utils/scheduleView.ts
@@ -4,7 +4,7 @@
 // KEINE React-/Supabase-Imports.
 
 import type { Job } from "@/types/job";
-import { formatAssigneesFull } from "@/utils/jobAssignees";
+import { getAssigneeNames } from "@/utils/jobAssignees";
 import { getJobDisplayTime } from "@/utils/jobSchedule";
 
 // Die vier Zeitplan-Filter (executable Jobs: single + Occurrences, nie Parents).
@@ -38,7 +38,13 @@ export function matchesSearch(
   // Seit Phase 5 über ALLE Zugewiesenen — sonst fände die Suche einen
   // Auftrag nicht mehr, sobald der gesuchte Mitarbeiter nicht der
   // Legacy-Primär ist.
-  return [job.customerName, job.service, job.location, formatAssigneesFull(job)]
+  //
+  // BEWUSST getAssigneeNames statt formatAssigneesFull: der Anzeige-Formatter
+  // liefert für einen Auftrag ohne Zuweisung den Platzhalter
+  // „Nicht zugewiesen". Der landete im Suchindex, wodurch schon einzelne
+  // Buchstaben (z, g, e, i, s, n, …) sämtliche unzugewiesenen Aufträge
+  // trafen. Die Namensliste ist für einen leeren Auftrag korrekt leer.
+  return [job.customerName, job.service, job.location, getAssigneeNames(job).join(" ")]
     .filter(Boolean)
     .join(" ")
     .toLowerCase()


### PR DESCRIPTION
Phase 5, part 2 of 2. **READ ONLY** — nothing here writes assignments (that is Phase 6).

## ⚠️ Depends on #55

This PR targets `feat/phase5-db-read-access`, not `main`. **Merge #55 first**, then this. Without the migration in #55, admins already see the complete assignee set, but employees only see jobs where they are the legacy primary — the feature is half-effective.

The diff here contains **no migration and no SQL policy change**; all schema work lives in #55.

## Job.assignees[]

`Job.assignees[]` replaces `jobs.assigned_to` as the source for every display of who is on a job: job card, job detail, dashboard, employee detail, jobs list, recurring rules, rule occurrences, search and filters.

Service layer:
- `JOB_SELECT` embeds `job_assignments` with the living profile name, falling back to the stored name snapshot for deleted accounts (rendered as "(ehemalig)"). It is now the single source for every job query — the four previously duplicated inline selects are consolidated, so a forgotten embed cannot silently produce an empty assignee list.
- Assignees are sorted deterministically (`assigned_at`, then name, then id); PostgREST does not guarantee embedded ordering, so without this the list would reshuffle on every reload.

## Aliased PostgREST embeds and unassigned filtering

Filtering by one employee while still showing **all** assignees needs two embeds of the same relation:

```
assignments:job_assignments(...)          -- display, unfiltered
f:job_assignments!inner(employee_id)      -- predicate only
&f.employee_id=eq.<id>
```

Verified against live PostgREST: the display embed stays complete (a job with two assignees still shows both when filtering by one), no duplicate parent rows, `count=exact` correct, `limit`/`offset` correct.

"Unassigned" moved to `f:job_assignments!left(employee_id)` + `f=is.null`. It can no longer use `assigned_to IS NULL`, because `compat_primary_assignee()` also returns NULL when assignments exist but none is trace-free and active — the legacy column is not a reliable "has nobody" indicator.

## Display vs. action gating — deliberately separate

Display uses `assignees[]`. **Action gating stays on the legacy primary** via `canRunJobActions()` / `isPrimaryAssignee()`, because `start_own_job`, `complete_own_job` and the comment/photo insert policies still require `jobs.assigned_to = auth.uid()`.

A secondary assignee therefore sees the job but gets **no** Start/Complete button (all five call sites: jobs list, employee overview, calendar, home, detail), **no** photo upload, and **no** comment input. `JobComments` gained a required `canComment` prop — no default `true`, so a forgotten prop hides the input rather than falsely enabling it — and renders an explanation instead of a greyed-out button. `markJobCommentsAsRead` is likewise not called for users who cannot write `job_comment_reads`, so no silent 42501 is emitted.

**Client gating is UX only. RLS remains the enforcing boundary** — server-side write attempts by a secondary assignee are rejected regardless of the UI.

## create/update read-back

The embed in an INSERT/UPDATE `RETURNING` does not see rows written by the Phase 2 AFTER triggers. Verified against live PostgREST:

```
INSERT RETURNING : assigned_to=Erika | embed=[]        → read-back: [Erika]
PATCH  RETURNING : assigned_to=Zoe   | embed=[Erika]   → read-back: [Zoe]
```

Without a re-read a newly created job rendered "Nicht zugewiesen" and an edited job showed the *previous* assignee — and `JobContext` persisted that into state **and** AsyncStorage. `createJob`/`updateJob` now re-read once via `readBackJob()`.

### Fallback behaviour

A successful write must never become an error, so `readBackJob` always returns a job. What it puts in `assignees` matters:

- **Both** failure paths are logged — the thrown error *and* the null result (previously the null path was entirely silent).
- The fallback derives the set from the legacy pointer via `buildLegacyAssignees()`: exactly one assignee, never several, never guessed. `assigned_to` is reliable here — it is a real column of the row just written and comes back fresh; only the embedded relation lags.
- Deleted accounts: `ON DELETE SET NULL` clears `assigned_to`, so the fallback correctly yields `[]` rather than inventing an anonymous placeholder. Real anonymised rows only ever come from the regular read path.

The same helper backs the offline-cache normalization, so the two paths that face the identical problem cannot drift — they were previously two separate implementations.

## Removal of non-authoritative attendance and countsForTimesheet

Both are removed from `JobAssignee`, `JOB_SELECT`, the row type and the mapping. Neither had a single consumer, and both had to be **fabricated from `job.status`** in fallback paths. A made-up value for `countsForTimesheet` — the source of timesheet *eligibility* — is a billing hazard. Both return in Phase 7 when `attendance` is server-maintained and there are real consumers.

**The timesheet itself is untouched** and still filters on `assigned_to`. Moving it to `counts_for_timesheet` was reverted after review: nothing maintains `attendance` until Phase 7, so every job completed after the Phase 1 backfill would have silently vanished from the timesheet.

## Offline compatibility

Caches written by a pre-Phase-5 app version have no `assignees`. They are normalized on read, deriving the single legacy assignee — otherwise the first offline cold start after the update would show "Nicht zugewiesen" everywhere, exactly when the cache matters most. New-format caches (including a genuine empty set) pass through untouched.

## Verification

- `node scripts/verify-job-assignees.mjs` — **8/8**. The repo has no JS test runner, so the fallback was extracted as a pure function and is compiled standalone and asserted against the **real source**, not a copy: create-fallback yields one assignee not `[]`; update-fallback yields the new not the old; never more than one; deleted account → empty without placeholder; blank name → "Unbekannt"; stable `legacy:`-prefixed id; no billing/attendance fields; renders correctly through the display helpers.
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- Manual PostgREST verification (needs a live backend, so not scriptable): the insert/update/read-back sequence above, plus anonymised assignee mapping and the filter/pagination/count behaviour. Procedure documented in `docs/phase5-react-native-read-path.md`.
- SQL regression for the schema side: 260/260 in #55.

## Out of scope

No assignment writing (Phase 6). Secondary assignees still cannot start/complete, comment or upload (Phase 7). `jobs.assigned_to` and `Job.employeeId` remain (Phase 11). The `employee update own assigned jobs` policy and the production storage drift are tracked as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)