### PR TITLE
fix: credit all assignees in timesheets; scope offline job data per user

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,5 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import { registerForPushNotifications } from "@/services/notificationService";
+import { clearPendingJobActions } from "@/services/offline/jobs.queue";
+import { clearCachedJobs } from "@/services/offline/jobs.storage";
 import {
   clearCachedProfile,
   getCachedProfile,
@@ -172,6 +174,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Lokalen Profil-Cache leeren, damit ein deaktivierter Nutzer nicht beim
     // nächsten Offline-Start über den Cache wieder „aktiv" erscheint.
     await clearCachedProfile();
+
+    // DEAKTIVIERUNG (nicht: normaler Logout) räumt auch die lokalen Job-Daten
+    // weg. Bewusste Abweichung von signOut():
+    //  • Der Zugriff wurde ENTZOGEN — Firmendaten (Kunden, Adressen, Notizen)
+    //    dürfen auf dem Gerät nicht zurückbleiben, auch nicht verschlüsselt
+    //    hinter der User-Bindung.
+    //  • Offene Warteschlangen-Aktionen dieses Nutzers können ohnehin nie mehr
+    //    erfolgreich synchronisieren: start_own_job/complete_own_job laufen
+    //    über current_user_role()/RLS, die für inaktive Profile NULL liefern.
+    //    Sie zu behalten erzeugte nur einen dauerhaft klemmenden Pending-Zähler.
+    // Best effort — ein Fehler hier darf die Abmeldung nie blockieren.
+    try {
+      await Promise.all([clearCachedJobs(), clearPendingJobActions()]);
+    } catch (err) {
+      if (__DEV__) {
+        console.warn("Failed to clear local job data on deactivation:", err);
+      }
+    }
 
     try {
       await supabase.auth.signOut();
@@ -578,6 +598,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Profil-Cache leeren, damit auf einem geteilten Gerät kein Profil des
     // vorherigen Nutzers offline wiederhergestellt werden kann.
     await clearCachedProfile();
+
+    // BEWUSST NICHT geleert: Job-Cache und Offline-Warteschlange.
+    //
+    // Beide sind seit v2 an die User-ID gebunden (siehe jobs.storage.ts /
+    // jobs.queue.ts) — ein anderer Nutzer bekommt sie nach dem Anmelden
+    // strukturell nicht mehr zu sehen bzw. ausgeführt. Das Leeren wäre daher
+    // für die Absicherung nicht nötig, hätte aber zwei echte Nachteile:
+    //  • Es würde NOCH NICHT ÜBERTRAGENE Arbeitszeit vernichten. Meldet sich
+    //    ein Mitarbeiter nach einem offline gestarteten Auftrag ab, ginge
+    //    genau dieser Start-/Abschlusszeitpunkt verloren.
+    //  • Es würde den Offline-Kaltstart nach einer erneuten Anmeldung
+    //    unmöglich machen (kein Cache → Fehlerbildschirm statt Aufträge).
+    //
+    // Ein bewusstes Löschen gibt es deshalb nur dort, wo der Zugriff wirklich
+    // entzogen wird: forceSignOutDueToDeactivation() und die Kontolöschung
+    // (features/profile/DeleteAccountScreen.tsx).
 
     const { error } = await supabase.auth.signOut();
 

--- a/context/JobContext.tsx
+++ b/context/JobContext.tsx
@@ -160,6 +160,13 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
   const { session, role } = useAuth();
   const isAdmin = role === "admin";
 
+  // Besitzer aller lokalen Job-Daten (Cache + Warteschlange). Kommt aus der
+  // SESSION, nicht aus dem Profil: die Session steht beim Kaltstart sofort zur
+  // Verfügung, das Profil ggf. erst nach einem Netzwerk-Roundtrip. Würde hier
+  // profile.id verwendet, liefe der Offline-Kaltstart wieder in den früher
+  // behobenen Dauer-Spinner (siehe loadAll unten).
+  const userId = session?.user?.id ?? null;
+
   const [jobs, setJobs] = useState<Job[]>([]);
   // Ungelesene Kommentar-Job-IDs (gebündelt aus der RPC). Speist den Tab-Badge
   // unabhängig vom (für Admins begrenzten) Ladefenster.
@@ -182,13 +189,18 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
   const refreshJobsInProgressRef = useRef(false);
 
   const refreshPendingState = useCallback(async () => {
-    const actions = await getPendingJobActions();
+    if (!userId) {
+      setPendingActions([]);
+      setPendingCount(0);
+      return;
+    }
+    const actions = await getPendingJobActions(userId);
     setPendingActions(actions);
     setPendingCount(actions.length);
-  }, []);
+  }, [userId]);
 
   const runPendingSyncSafely = useCallback(async () => {
-    if (syncInProgressRef.current) {
+    if (syncInProgressRef.current || !userId) {
       return;
     }
 
@@ -199,7 +211,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
     }
 
     try {
-      const result = await syncPendingJobActions();
+      const result = await syncPendingJobActions(userId);
       setSyncFailed(result.failed > 0);
     } finally {
       syncInProgressRef.current = false;
@@ -209,10 +221,10 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         console.log("[Jobs] Queue-Sync beendet");
       }
     }
-  }, [refreshPendingState]);
+  }, [refreshPendingState, userId]);
 
   const refreshJobs = useCallback(async () => {
-    if (refreshJobsInProgressRef.current) {
+    if (refreshJobsInProgressRef.current || !userId) {
       return;
     }
 
@@ -228,9 +240,9 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
           console.log("[Jobs] Quelle: remote");
         }
         const serverJobs = await loadJobsForRole(isAdmin);
-        await saveCachedJobs(serverJobs);
+        await saveCachedJobs(userId, serverJobs);
 
-        const pendingActions = await getPendingJobActions();
+        const pendingActions = await getPendingJobActions(userId);
         const mergedJobs = applyPendingActionsToJobs(
           serverJobs,
           pendingActions,
@@ -256,8 +268,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       if (__DEV__) {
         console.log("[Jobs] Quelle: cache (offline)");
       }
-      const cachedJobs = await getCachedJobs();
-      const pendingActions = await getPendingJobActions();
+      const cachedJobs = await getCachedJobs(userId);
+      const pendingActions = await getPendingJobActions(userId);
       const mergedJobs = applyPendingActionsToJobs(cachedJobs, pendingActions);
 
       setJobs(mergedJobs);
@@ -273,8 +285,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       }
 
       try {
-        const cachedJobs = await getCachedJobs();
-        const pendingActions = await getPendingJobActions();
+        const cachedJobs = await getCachedJobs(userId);
+        const pendingActions = await getPendingJobActions(userId);
         const mergedJobs = applyPendingActionsToJobs(
           cachedJobs,
           pendingActions,
@@ -294,7 +306,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       refreshJobsInProgressRef.current = false;
       await refreshPendingState();
     }
-  }, [refreshPendingState, isAdmin]);
+  }, [refreshPendingState, isAdmin, userId]);
 
   const retrySync = useCallback(async () => {
     await runPendingSyncSafely();
@@ -354,6 +366,12 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    // Ohne User-ID darf NICHTS aus dem lokalen Cache gelesen werden — sonst
+    // landeten die Daten des zuletzt angemeldeten Nutzers in der Oberfläche.
+    if (!userId) {
+      return;
+    }
+
     if (didInitialLoadRef.current) {
       return;
     }
@@ -370,8 +388,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       setError(null);
       try {
         const [cachedJobs, pending] = await Promise.all([
-          getCachedJobs(),
-          getPendingJobActions(),
+          getCachedJobs(userId),
+          getPendingJobActions(userId),
         ]);
         setJobs(applyPendingActionsToJobs(cachedJobs, pending));
         setPendingActions(pending);
@@ -405,7 +423,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
     };
 
     loadAll();
-  }, [session, refreshJobs, refreshEmployees, runPendingSyncSafely]);
+  }, [session, userId, refreshJobs, refreshEmployees, runPendingSyncSafely]);
 
   useEffect(() => {
     if (!session) {
@@ -492,7 +510,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         const exists = prevJobs.some((job) => job.id === createdJob.id);
         const nextJobs: Job[] = exists ? prevJobs : [createdJob, ...prevJobs];
 
-        saveCachedJobs(nextJobs).catch((err) =>
+        saveCachedJobs(userId, nextJobs).catch((err) =>
           console.error("Failed to cache jobs after create:", err),
         );
 
@@ -508,7 +526,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       console.error("Failed to create job:", err);
       throw err;
     }
-  }, []);
+  }, [userId]);
 
   const updateJob = useCallback(
     async (input: {
@@ -534,7 +552,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
             (job): Job => (job.id === updatedJob.id ? updatedJob : job),
           );
 
-          saveCachedJobs(nextJobs).catch((err) =>
+          saveCachedJobs(userId, nextJobs).catch((err) =>
             console.error("Failed to cache jobs after update:", err),
           );
 
@@ -555,7 +573,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
               job.id === partiallyUpdatedJob.id ? partiallyUpdatedJob : job,
             );
 
-            saveCachedJobs(nextJobs).catch((cacheErr) =>
+            saveCachedJobs(userId, nextJobs).catch((cacheErr) =>
               console.error(
                 "Failed to cache jobs after partial update:",
                 cacheErr,
@@ -570,7 +588,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         throw err;
       }
     },
-    [],
+    [userId],
   );
 
   const deleteJob = useCallback(async (jobId: string) => {
@@ -580,7 +598,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       setJobs((prevJobs) => {
         const nextJobs: Job[] = prevJobs.filter((job) => job.id !== jobId);
 
-        saveCachedJobs(nextJobs).catch((err) =>
+        saveCachedJobs(userId, nextJobs).catch((err) =>
           console.error("Failed to cache jobs after delete:", err),
         );
 
@@ -590,7 +608,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       console.error("Failed to delete job:", err);
       throw err;
     }
-  }, []);
+  }, [userId]);
 
   const startJob = useCallback(async (jobId: string) => {
     try {
@@ -605,7 +623,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
             startedAt,
           });
 
-          saveCachedJobs(nextJobs).catch((err) =>
+          saveCachedJobs(userId, nextJobs).catch((err) =>
             console.error("Failed to cache jobs after start:", err),
           );
 
@@ -621,7 +639,17 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
 
       const timestamp = new Date().toISOString();
 
+      // Ohne bekannten Besitzer darf keine Aktion in die Warteschlange —
+      // sie liesse sich spaeter keinem Nutzer zuordnen und wuerde beim
+      // naechsten Lesen ohnehin verworfen (fail closed).
+      if (!userId) {
+        throw new Error(
+          "Aktion kann offline nicht gespeichert werden: keine aktive Sitzung.",
+        );
+      }
+
       const nextActions = await addPendingJobAction({
+        userId,
         type: "start_job",
         jobId,
         timestamp,
@@ -635,7 +663,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
           startedAt: timestamp,
         });
 
-        saveCachedJobs(nextJobs).catch((err) =>
+        saveCachedJobs(userId, nextJobs).catch((err) =>
           console.error("Failed to cache jobs after offline start:", err),
         );
 
@@ -645,7 +673,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       console.error("Failed to start job:", err);
       throw err;
     }
-  }, []);
+  }, [userId]);
 
   const completeJob = useCallback(async (jobId: string) => {
     try {
@@ -660,7 +688,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
             completedAt,
           });
 
-          saveCachedJobs(nextJobs).catch((err) =>
+          saveCachedJobs(userId, nextJobs).catch((err) =>
             console.error("Failed to cache jobs after complete:", err),
           );
 
@@ -676,7 +704,17 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
 
       const timestamp = new Date().toISOString();
 
+      // Ohne bekannten Besitzer darf keine Aktion in die Warteschlange —
+      // sie liesse sich spaeter keinem Nutzer zuordnen und wuerde beim
+      // naechsten Lesen ohnehin verworfen (fail closed).
+      if (!userId) {
+        throw new Error(
+          "Aktion kann offline nicht gespeichert werden: keine aktive Sitzung.",
+        );
+      }
+
       const nextActions = await addPendingJobAction({
+        userId,
         type: "complete_job",
         jobId,
         timestamp,
@@ -690,7 +728,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
           completedAt: timestamp,
         });
 
-        saveCachedJobs(nextJobs).catch((err) =>
+        saveCachedJobs(userId, nextJobs).catch((err) =>
           console.error("Failed to cache jobs after offline complete:", err),
         );
 
@@ -700,7 +738,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       console.error("Failed to complete job:", err);
       throw err;
     }
-  }, []);
+  }, [userId]);
 
   const markJobCommentsAsRead = useCallback(async (jobId: string) => {
     // Optimistisch sofort den Punkt entfernen (gute UX, kein Warten auf DB).

--- a/services/offline/jobs.queue.ts
+++ b/services/offline/jobs.queue.ts
@@ -5,12 +5,15 @@ export type PendingJobActionType = "start_job" | "complete_job";
 export type PendingJobAction =
   | {
       id: string;
+      /** Besitzer der Aktion — nur DIESER Nutzer darf sie ausführen. */
+      userId: string;
       type: "start_job";
       jobId: string;
       timestamp: string;
     }
   | {
       id: string;
+      userId: string;
       type: "complete_job";
       jobId: string;
       timestamp: string;
@@ -18,79 +21,167 @@ export type PendingJobAction =
 
 const JOBS_QUEUE_STORAGE_KEY = "offline_jobs_queue";
 
+// v2: Warteschlange trägt Version + Besitzer je Aktion (vorher: nacktes Array
+// ohne jede Zuordnung).
+//
+// SICHERHEIT — geteilte Geräte: Ohne Besitzer konnte die Sync-Routine die
+// offline erfassten Aktionen von Nutzer A unter der Sitzung von Nutzer B
+// ausführen. Serverseitig scheitern die meisten davon (start_own_job/
+// complete_own_job verlangen assigned_to = auth.uid()), ABER im Sonderfall
+// „B ist demselben Auftrag zugewiesen" wäre A's Aktion mit A's Zeitstempel
+// unter B's Sitzung tatsächlich durchgelaufen — eine falsche Zuschreibung
+// von Arbeitszeit.
+export const JOBS_QUEUE_VERSION = 2;
+
+type StoredQueuePayload = {
+  version: number;
+  actions: PendingJobAction[];
+};
+
 function generateActionId() {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export async function getPendingJobActions(): Promise<PendingJobAction[]> {
+function isValidAction(value: unknown): value is PendingJobAction {
+  if (!value || typeof value !== "object") return false;
+  const a = value as Partial<PendingJobAction>;
+  return (
+    typeof a.id === "string" &&
+    typeof a.userId === "string" &&
+    !!a.userId &&
+    (a.type === "start_job" || a.type === "complete_job") &&
+    typeof a.jobId === "string" &&
+    typeof a.timestamp === "string"
+  );
+}
+
+/**
+ * Liest ALLE Aktionen aller Nutzer — ausschließlich für Schreibvorgänge
+ * (Anhängen/Entfernen), damit fremde Aktionen beim Speichern erhalten bleiben.
+ *
+ * MIGRATION v1 → v2 (fail closed): Eine alte Nutzlast ist ein nacktes Array
+ * ohne `userId`. Solche Aktionen lassen sich KEINEM Nutzer zuordnen. Sie
+ * werden deshalb verworfen statt dem gerade angemeldeten Nutzer zugeschrieben
+ * — Zuschreiben wäre genau der Fehler, den dieser Fix behebt (fremde Aktion
+ * unter fremder Sitzung). Betroffen ist nur ein sehr schmales Fenster:
+ * Aktionen, die vor dem Update offline erfasst und bis zum Update nicht
+ * synchronisiert wurden.
+ */
+async function readAllActions(): Promise<PendingJobAction[]> {
+  const raw = await AsyncStorage.getItem(JOBS_QUEUE_STORAGE_KEY);
+  if (!raw) return [];
+
+  const parsed = JSON.parse(raw) as unknown;
+
+  // v1: nacktes Array ohne Version/Besitzer → nicht zuordenbar, verwerfen.
+  if (Array.isArray(parsed)) {
+    if (__DEV__) {
+      console.warn(
+        `[jobs.queue] Alte, nicht zuordenbare Warteschlange verworfen (${parsed.length} Aktion(en)).`,
+      );
+    }
+    await AsyncStorage.removeItem(JOBS_QUEUE_STORAGE_KEY);
+    return [];
+  }
+
+  const payload = parsed as Partial<StoredQueuePayload> | null;
+  if (
+    !payload ||
+    payload.version !== JOBS_QUEUE_VERSION ||
+    !Array.isArray(payload.actions)
+  ) {
+    await AsyncStorage.removeItem(JOBS_QUEUE_STORAGE_KEY);
+    return [];
+  }
+
+  // Einzelne kaputte Einträge aussortieren, den Rest behalten.
+  return payload.actions.filter(isValidAction);
+}
+
+/**
+ * Alle Aktionen (aller Nutzer). Nur für Sync-/Speicherlogik, NICHT für die UI.
+ */
+export async function getAllPendingJobActions(): Promise<PendingJobAction[]> {
   try {
-    const raw = await AsyncStorage.getItem(JOBS_QUEUE_STORAGE_KEY);
-
-    if (!raw) {
-      return [];
-    }
-
-    const parsed = JSON.parse(raw);
-
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    return parsed as PendingJobAction[];
+    return await readAllActions();
   } catch (error) {
     console.error("Failed to read offline jobs queue:", error);
     return [];
   }
 }
 
+/**
+ * Aktionen DIESES Nutzers — Grundlage für Anzeige (Badge/Banner) und Sync.
+ * Fremde Aktionen bleiben gespeichert, sind hier aber unsichtbar.
+ */
+export async function getPendingJobActions(
+  userId: string | null,
+): Promise<PendingJobAction[]> {
+  // Kein angemeldeter Nutzer → keine Aktionen (fail closed).
+  if (!userId) return [];
+
+  const actions = await getAllPendingJobActions();
+  return actions.filter((action) => action.userId === userId);
+}
+
 export async function savePendingJobActions(
   actions: PendingJobAction[],
 ): Promise<void> {
   try {
-    await AsyncStorage.setItem(JOBS_QUEUE_STORAGE_KEY, JSON.stringify(actions));
+    const payload: StoredQueuePayload = {
+      version: JOBS_QUEUE_VERSION,
+      actions,
+    };
+    await AsyncStorage.setItem(JOBS_QUEUE_STORAGE_KEY, JSON.stringify(payload));
   } catch (error) {
     console.error("Failed to save offline jobs queue:", error);
     throw error;
   }
 }
 
+/**
+ * Hängt eine Aktion für DIESEN Nutzer an. Gibt die Aktionen des Nutzers
+ * zurück (nicht die fremden) — passend für pendingCount/pendingActions.
+ */
 export async function addPendingJobAction(input: {
+  userId: string;
   type: PendingJobActionType;
   jobId: string;
   timestamp?: string;
 }): Promise<PendingJobAction[]> {
-  const actions = await getPendingJobActions();
+  const allActions = await getAllPendingJobActions();
+
+  const base = {
+    id: generateActionId(),
+    userId: input.userId,
+    jobId: input.jobId,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+  };
 
   const nextAction: PendingJobAction =
     input.type === "start_job"
-      ? {
-          id: generateActionId(),
-          type: "start_job",
-          jobId: input.jobId,
-          timestamp: input.timestamp ?? new Date().toISOString(),
-        }
-      : {
-          id: generateActionId(),
-          type: "complete_job",
-          jobId: input.jobId,
-          timestamp: input.timestamp ?? new Date().toISOString(),
-        };
+      ? { ...base, type: "start_job" }
+      : { ...base, type: "complete_job" };
 
-  const nextActions = [...actions, nextAction];
-  await savePendingJobActions(nextActions);
+  const nextAll = [...allActions, nextAction];
+  await savePendingJobActions(nextAll);
 
-  return nextActions;
+  return nextAll.filter((action) => action.userId === input.userId);
 }
 
+/**
+ * Entfernt eine erfolgreich synchronisierte Aktion. Fremde Aktionen bleiben
+ * dabei unangetastet erhalten.
+ */
 export async function removePendingJobAction(
   actionId: string,
 ): Promise<PendingJobAction[]> {
-  const actions = await getPendingJobActions();
-  const nextActions = actions.filter((action) => action.id !== actionId);
+  const allActions = await getAllPendingJobActions();
+  const nextAll = allActions.filter((action) => action.id !== actionId);
 
-  await savePendingJobActions(nextActions);
+  await savePendingJobActions(nextAll);
 
-  return nextActions;
+  return nextAll;
 }
 
 export async function clearPendingJobActions(): Promise<void> {
@@ -104,11 +195,12 @@ export async function clearPendingJobActions(): Promise<void> {
 
 /**
  * Optional hilfreich:
- * Gibt alle Actions für einen bestimmten Job zurück.
+ * Gibt alle Actions DIESES Nutzers für einen bestimmten Job zurück.
  */
 export async function getPendingActionsForJob(
+  userId: string,
   jobId: string,
 ): Promise<PendingJobAction[]> {
-  const actions = await getPendingJobActions();
+  const actions = await getPendingJobActions(userId);
   return actions.filter((action) => action.jobId === jobId);
 }

--- a/services/offline/jobs.storage.ts
+++ b/services/offline/jobs.storage.ts
@@ -4,7 +4,24 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const JOBS_STORAGE_KEY = "offline_jobs_cache";
 
+// v2: Cache ist an die User-ID gebunden (vorher: eine einzige globale Liste).
+//
+// SICHERHEIT — geteilte Geräte: Vor v2 trug der Cache weder Version noch
+// Besitzer. Meldete sich Nutzer A ab und Nutzer B an, las JobContext beim
+// Start unmittelbar diesen Cache und rendert A's Aufträge (Kunden, Adressen,
+// Notizen, Kolleginnen) in B's Oberfläche — online bis zum ersten Refresh,
+// OFFLINE dauerhaft. Genau dieselbe Absicherung existiert seit v2 bereits für
+// den Profil-Cache (services/offline/profile.storage.ts) und wird hier
+// bewusst 1:1 gespiegelt.
+//
+// Der Version-Bump invalidiert automatisch jeden älteren (unscoped) Cache:
+// eine Nutzlast ohne `version`/`userId` lässt sich keinem Nutzer zuordnen und
+// wird deshalb FAIL-CLOSED verworfen statt geraten.
+export const JOBS_CACHE_VERSION = 2;
+
 type StoredJobsPayload = {
+  version: number;
+  userId: string;
   jobs: Job[];
   updatedAt: string;
 };
@@ -32,11 +49,53 @@ function normalizeCachedJob(job: Job): Job {
 }
 
 /**
- * Speichert die aktuelle Jobliste lokal im AsyncStorage.
+ * Liest die Nutzlast und gibt sie NUR zurück, wenn Version UND Besitzer
+ * stimmen. Jede Abweichung (alte Version, fremder/fehlender Nutzer, kaputte
+ * Daten) gilt als „kein Cache" — fail closed, nie geraten.
  */
-export async function saveCachedJobs(jobs: Job[]): Promise<void> {
+async function readOwnedPayload(
+  userId: string,
+): Promise<StoredJobsPayload | null> {
+  const raw = await AsyncStorage.getItem(JOBS_STORAGE_KEY);
+  if (!raw) return null;
+
+  const parsed = JSON.parse(raw) as Partial<StoredJobsPayload> | null;
+  if (!parsed) return null;
+
+  // Alte Cache-Version / fremder User / kaputte Daten → nicht verwenden.
+  if (parsed.version !== JOBS_CACHE_VERSION) return null;
+  if (!parsed.userId || parsed.userId !== userId) return null;
+  if (!Array.isArray(parsed.jobs)) return null;
+
+  return {
+    version: parsed.version,
+    userId: parsed.userId,
+    jobs: parsed.jobs.map(normalizeCachedJob),
+    updatedAt: parsed.updatedAt ?? "",
+  };
+}
+
+/**
+ * Speichert die aktuelle Jobliste lokal im AsyncStorage — gebunden an den
+ * Nutzer, dem die Daten gehören.
+ *
+ * Es gibt bewusst weiterhin nur EINEN Schlüssel: der Cache des zuletzt aktiven
+ * Nutzers überschreibt den vorherigen. Mehrere Nutzer-Caches parallel zu halten
+ * würde auf einem geteilten Gerät fremde Firmendaten unbegrenzt aufbewahren —
+ * genau das soll dieser Fix verhindern.
+ */
+export async function saveCachedJobs(
+  userId: string | null,
+  jobs: Job[],
+): Promise<void> {
+  // Ohne bekannten Besitzer wird NICHT geschrieben — ein Cache ohne Zuordnung
+  // wäre beim nächsten Lesen ohnehin ungültig (fail closed).
+  if (!userId) return;
+
   try {
     const payload: StoredJobsPayload = {
+      version: JOBS_CACHE_VERSION,
+      userId,
       jobs,
       updatedAt: new Date().toISOString(),
     };
@@ -49,24 +108,16 @@ export async function saveCachedJobs(jobs: Job[]): Promise<void> {
 }
 
 /**
- * Lädt die lokal gespeicherten Jobs.
- * Wenn nichts vorhanden ist oder Daten kaputt sind, kommt [] zurück.
+ * Lädt die lokal gespeicherten Jobs DIESES Nutzers.
+ * Fremder/alter/kaputter Cache → [] (nie die Daten eines anderen Nutzers).
  */
-export async function getCachedJobs(): Promise<Job[]> {
+export async function getCachedJobs(userId: string | null): Promise<Job[]> {
+  // Kein angemeldeter Nutzer → kein Cache-Zugriff (fail closed).
+  if (!userId) return [];
+
   try {
-    const raw = await AsyncStorage.getItem(JOBS_STORAGE_KEY);
-
-    if (!raw) {
-      return [];
-    }
-
-    const parsed = JSON.parse(raw) as StoredJobsPayload | null;
-
-    if (!parsed || !Array.isArray(parsed.jobs)) {
-      return [];
-    }
-
-    return parsed.jobs.map(normalizeCachedJob);
+    const payload = await readOwnedPayload(userId);
+    return payload?.jobs ?? [];
   } catch (error) {
     console.error("Failed to read cached jobs:", error);
     return [];
@@ -74,24 +125,16 @@ export async function getCachedJobs(): Promise<Job[]> {
 }
 
 /**
- * Liefert zusätzliche Cache-Infos zurück,
- * z.B. wann der Cache zuletzt aktualisiert wurde.
+ * Liefert zusätzliche Cache-Infos zurück (z.B. wann zuletzt aktualisiert) —
+ * ebenfalls nur für den Besitzer des Caches.
  */
-export async function getCachedJobsPayload(): Promise<StoredJobsPayload | null> {
+export async function getCachedJobsPayload(
+  userId: string | null,
+): Promise<StoredJobsPayload | null> {
+  if (!userId) return null;
+
   try {
-    const raw = await AsyncStorage.getItem(JOBS_STORAGE_KEY);
-
-    if (!raw) {
-      return null;
-    }
-
-    const parsed = JSON.parse(raw) as StoredJobsPayload | null;
-
-    if (!parsed || !Array.isArray(parsed.jobs)) {
-      return null;
-    }
-
-    return { ...parsed, jobs: parsed.jobs.map(normalizeCachedJob) };
+    return await readOwnedPayload(userId);
   } catch (error) {
     console.error("Failed to read cached jobs payload:", error);
     return null;

--- a/services/offline/jobs.sync.ts
+++ b/services/offline/jobs.sync.ts
@@ -41,11 +41,19 @@ async function executeAction(action: PendingJobAction): Promise<void> {
 
 /**
  * Hauptfunktion:
- * - verarbeitet die Queue
- * - führt alle Actions nacheinander aus
+ * - verarbeitet die Queue DES ÜBERGEBENEN NUTZERS
+ * - führt dessen Actions nacheinander aus
  * - entfernt erfolgreiche Actions aus der Queue
+ *
+ * NUTZER-BINDUNG (geteilte Geräte): Es werden ausschließlich Aktionen
+ * ausgeführt, deren `userId` mit der aktiven Sitzung übereinstimmt. Aktionen
+ * eines ANDEREN Nutzers werden übersprungen und bleiben unangetastet
+ * gespeichert — sie gehören ihm und synchronisieren, sobald er sich wieder
+ * anmeldet. Sie werden ausdrücklich NICHT gelöscht (kein Verlust echter,
+ * noch nicht übertragener Arbeitszeit) und NICHT unter fremder Sitzung
+ * ausgeführt (keine Falschzuschreibung).
  */
-export async function syncPendingJobActions(): Promise<{
+export async function syncPendingJobActions(userId: string): Promise<{
   success: number;
   failed: number;
 }> {
@@ -58,7 +66,8 @@ export async function syncPendingJobActions(): Promise<{
     return { success: 0, failed: 0 };
   }
 
-  const actions = await getPendingJobActions();
+  // Nur die eigenen Aktionen — fremde bleiben liegen (siehe oben).
+  const actions = await getPendingJobActions(userId);
 
   if (!actions.length) {
     if (__DEV__) {

--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -28,6 +28,20 @@ type TimesheetJobRow = {
   completed_at: string;
 };
 
+// Zusätzlicher Embed, der AUSSCHLIESSLICH als Filter-Prädikat dient:
+// „nur Aufträge, denen dieser Mitarbeiter zugewiesen ist".
+//
+// Identisches Muster wie ASSIGNEE_FILTER_EMBED in services/jobs/jobs.service.ts
+// (dort als duplikatfrei verifiziert). Der Alias `f` verhindert eine Kollision
+// mit anderen Embeds und macht sichtbar, dass die Menge nie GELESEN wird.
+//
+// KEINE DUPLIKATE: Der Filter unten bindet `f.employee_id` auf GENAU EINEN
+// Mitarbeiter, und job_assignments trägt die Bedingung
+// `unique (job_id, employee_id)` (Migration 20260725000000). Pro Auftrag kann
+// also höchstens EINE Zuweisungszeile matchen — ein Auftrag erscheint damit
+// niemals doppelt im Stundenzettel, auch nicht bei mehreren Zugewiesenen.
+const ASSIGNEE_FILTER_EMBED = `,f:job_assignments!inner(employee_id)`;
+
 // Baut die Bemerkung aus Service + Ort: "Fensterreinigung · Hauptstr. 1".
 function buildRemark(service: string | null, location: string | null): string {
   const parts = [service?.trim(), location?.trim()].filter(
@@ -59,12 +73,37 @@ function mapEntry(row: TimesheetJobRow): TimesheetEntry {
  * daraus den vollständigen Stundenzettel.
  *
  * Filter:
- *  - assigned_to = employeeId
+ *  - Mitarbeiter ist dem Auftrag ZUGEWIESEN (job_assignments.employee_id),
+ *    NICHT mehr der Legacy-Zeiger jobs.assigned_to — siehe Begründung unten
  *  - status = 'completed'
  *  - started_at / completed_at vorhanden
  *  - job_type = 'single' (schließt Recurring-Parent-Regeln aus; konkrete
  *    Occurrences sind selbst 'single')
  *  - Arbeitstag (started_at, lokal) im gewählten Monat
+ *
+ * WARUM NICHT MEHR jobs.assigned_to:
+ * Seit der Mehrfachzuweisung (Phase 6A) kann ein Auftrag mehreren Mitarbeitern
+ * gehören. jobs.assigned_to kann aber nur EINEN tragen; welcher das ist,
+ * bestimmt compat_primary_assignee() und ist bei gleichzeitig angelegten
+ * Zuweisungen ARBITRÄR (gleicher assigned_at → Tiebreak über die zufällige
+ * UUID `id`, siehe Migration 20260726000000). Der alte Filter schloss damit
+ * alle übrigen Zugewiesenen aus dem Stundenzettel aus — sie wurden für
+ * geleistete Arbeit nicht erfasst.
+ *
+ * WARUM (NOCH) NICHT counts_for_timesheet:
+ * Die Spalte ist als künftige Berechtigungsquelle vorgesehen, wird aber
+ * derzeit von NICHTS gepflegt: set_job_assignments legt Zeilen mit dem
+ * Default attendance='assigned' an, und start_own_job/complete_own_job fassen
+ * job_assignments überhaupt nicht an (Phase 7 offen). counts_for_timesheet ist
+ * für neu angelegte Zuweisungen deshalb dauerhaft false — ein Filter darauf
+ * lieferte heute LEERE Stundenzettel. Der Umstieg gehört zu Phase 7/9, wenn
+ * attendance serverseitig gesetzt wird.
+ *
+ * Bewusst NICHT gefiltert wird zusätzlich nach:
+ *  - attendance / review  → siehe oben, werden aktuell nicht gepflegt
+ *  - profiles.is_active   → historische Stundenzettel müssen auch für
+ *                           inzwischen deaktivierte Mitarbeiter abrufbar
+ *                           bleiben (Abrechnung/Nachweis)
  *
  * @param year   z.B. 2026
  * @param month  1–12
@@ -93,9 +132,9 @@ export async function getTimesheet(params: {
       location_address,
       started_at,
       completed_at
-      `,
+      ` + ASSIGNEE_FILTER_EMBED,
     )
-    .eq("assigned_to", employeeId)
+    .eq("f.employee_id", employeeId)
     .eq("status", "completed")
     .eq("job_type", "single")
     .not("started_at", "is", null)
@@ -108,7 +147,11 @@ export async function getTimesheet(params: {
     throw error;
   }
 
-  const entries = (data ?? []).map((row) => mapEntry(row as TimesheetJobRow));
+  // Der Filter-Embed `f` ist Teil der Zeile, wird aber nie gelesen — gleiche
+  // Cast-Konvention wie bei den gebundenen Abfragen in jobs.service.ts.
+  const entries = (data ?? []).map((row) =>
+    mapEntry(row as unknown as TimesheetJobRow),
+  );
   const totalMinutes = entries.reduce((sum, e) => sum + e.durationMinutes, 0);
 
   const monthLabel = monthStart.toLocaleDateString("de-DE", {


### PR DESCRIPTION
Implements the two verified beta blockers from the focused audit. **No schema change, no migration, no RPC change, `counts_for_timesheet` not used.**

---

## FIX A — Timesheet multi-assignment

### Bug
`getTimesheet` filtered by the legacy single-assignee column:

```
.eq("assigned_to", employeeId)
```

Since multi-assignment shipped (#57), `jobs.assigned_to` holds only **one** of N assignees. Which one is decided by `compat_primary_assignee`, and because `set_job_assignments` inserts every row in a single transaction they all share an identical `assigned_at` — so the tiebreak falls through to `order by ja.assigned_at, ja.id` (migration `20260726000000:237`), i.e. a **random UUID**. Every other assignee was silently missing from their timesheet and PDF export, and *which* employee got credited was arbitrary per job.

### Fix
Filter through `job_assignments.employee_id` using the inner-embed pattern already verified duplicate-free in `jobs.service.ts:1061`:

```
const ASSIGNEE_FILTER_EMBED = `,f:job_assignments!inner(employee_id)`;
…
.eq("f.employee_id", employeeId)
```

**No duplicates possible here:** the filter binds `f.employee_id` to exactly one employee, and `job_assignments` carries `unique (job_id, employee_id)` (`20260725000000:145`), so at most one assignment row can match per job.

### Deliberately not used: `counts_for_timesheet`
Nothing maintains it yet, so filtering on it today would return **empty timesheets**:
- `set_job_assignments` inserts only `(job_id, employee_id, employee_name_snapshot, assigned_by)` → `attendance` takes its default `'assigned'` (`20260728000000:625-635`)
- `start_own_job` / `complete_own_job` never touch `job_assignments` (`lib/schema.sql:641-785`) — Phase 7 is open
- ⟹ `counts_for_timesheet` is permanently `false` for every new assignment

Also not filtered by `attendance`, `review`, or `is_active` — historical timesheets must remain available for deactivated employees. Duration maths, totals, date windowing and PDF generation are untouched; single-assignee behaviour is unchanged.

---

## FIX B — Offline cache/queue user scoping

### Bug
`offline_jobs_cache` and `offline_jobs_queue` had no owner and were never cleared on sign-out (`signOut()` cleared only the profile cache). On a shared device, user B's first render showed **user A's cached jobs** — customers, addresses, notes, colleague names — briefly when online, **indefinitely when offline**. A's queued actions were also handed to `syncPendingJobActions` under B's session.

### Fix
Both stores are now **versioned and user-bound**, mirroring the existing `profile.storage.ts` pattern (which already defended against exactly this for profiles):

| Store | Before | After |
|---|---|---|
| `offline_jobs_cache` | `{ jobs, updatedAt }` | `{ version: 2, userId, jobs, updatedAt }` |
| `offline_jobs_queue` | bare `PendingJobAction[]` | `{ version: 2, actions: [...] }`, each action carries `userId` |

- `getCachedJobs(userId)` / `getPendingJobActions(userId)` return empty on version **or** owner mismatch.
- `syncPendingJobActions(userId)` processes only the current user's actions.
- All helpers accept `string | null` and fail closed when there is no session.
- `userId` comes from `session.user.id`, not `profile.id` — the session is available immediately at cold start, so the previously-fixed offline spinner (`JobContext` `loadAll`) does not regress.

### Legacy AsyncStorage migration (fail closed)
A v1 payload has no owner and cannot be attributed to anyone. It is **discarded, not adopted** — adopting it would reintroduce precisely the bug being fixed (one user's action running under another's session). Impact is limited to actions queued offline and left unsynced across the update.

### Queue-retention policy
- Foreign actions are **skipped, never executed, and never deleted**. They stay in storage and sync when their owner signs back in — no loss of real unsynced work, no misattribution.
- Ordinary `signOut()` **deliberately does not clear** local job data. Scoping already makes it unreadable by anyone else, while clearing would (a) destroy not-yet-transmitted start/complete timestamps and (b) break offline cold start after re-login. Documented inline.
- Clearing happens only where access is genuinely revoked: `forceSignOutDueToDeactivation()` (added here — a deactivated user's queued actions can never succeed anyway, since RLS helpers return NULL for inactive profiles) and account deletion (already existed).

---

## Validation

| Check | Result |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | **exit 0, clean** |
| `npm run lint` (CI gate) | **exit 0** |
| `npx eslint` on all touched files | **0 errors, 6 warnings** |
| Baseline on `main`, same files | **0 errors, 6 warnings** — identical, no new findings |

The 6 warnings are pre-existing `setProfileSafe` `exhaustive-deps` notices in `AuthContext.tsx`, untouched by this PR. No JS test runner exists in the repo, so manual scenarios are listed below.

> Note: `npm run lint` runs `expo lint`, which only scans `app/` and `components/` (`DEFAULT_INPUTS` in `@expo/cli/build/src/lint/lintAsync.js`) — ~18% of source. The full-scope `eslint` run above is the meaningful check for these files. Widening the gate is tracked separately and is out of scope here.

---

## Manual regression scenarios

**Fix A — timesheet**
1. Create a single job, assign **two** employees, save.
2. Have it started and completed.
3. Admin → Stundenzettel → employee 1 → job present, minutes correct.
4. Same month, employee 2 → **job present** (was missing before).
5. Single-assignee job in the same month → totals byte-identical to before.
6. Export PDF for both → each shows the shift exactly once.
7. Deactivate one employee → their past timesheet still loads.

**Fix B — cache/queue scoping**
1. Log in as user A, load jobs, background the app.
2. Log out.
3. Enable airplane mode.
4. Log in as user B → **no jobs from A appear** (empty/offline state instead).
5. Offline as A: start a job → pending badge = 1. Log out, log in as B → **B's badge is 0**, A's action is not executed.
6. Go online as B → A's action still not executed; B's own actions sync normally.
7. Log back in as A, go online → **A's queued action syncs and applies.**
8. Upgrade path: with a pre-update (v1) cache/queue present, first launch shows an empty cache and discards the unattributable queue — no foreign data, no stuck badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)