### PR TITLE
feat(jobs): Shared Job Time — jeder Zugewiesene darf starten und abschließen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
   `jobs` hat zusätzlich Terminierungs-Spalten: `job_type` (enum `single`|`recurring`), `date`,
   `start_time`, `recurring_days text[]`, `is_active`. Wiederkehrende Aufträge werden als **eine Regel**
   gespeichert (keine vorausberechneten Einzel-Jobs).
+  `jobs` trägt außerdem `started_at`/`started_by` und `completed_at`/`completed_by` — die `*_by`-Spalten
+  halten nur den **Akteur** des jeweiligen Übergangs fest (siehe „Geteilte Job-Uhr" unten).
   RPCs u. a.: `start_own_job`/`complete_own_job` (Employee-Aktionen trotz RLS), `setup_company_for_admin`,
   `update_my_push_token`, `get_unread_comment_job_ids` (ungelesene Kommentar-Job-IDs).
   **Wichtig:** `lib/schema.sql` ist nur Referenz — Schema-Änderungen müssen **manuell im Supabase
@@ -84,7 +86,8 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
   `JobAssignee` (**maßgeblich für jede Mitarbeiter-Anzeige**, `Job.assignees[]`),
   `CreateJobInput`, `EmployeeOption`. Terminierung am `Job`: `jobType`, `date` (`YYYY-MM-DD`, nur single),
   `startTime` (`HH:mm`), `recurringDays` (Kurzcodes `mon`…`sun`, nur recurring), `isActive`.
-  Job trägt zusätzlich `hasUnreadComments` (gemerged im JobContext, nicht in `mapJob`).
+  Job trägt zusätzlich `hasUnreadComments` (gemerged im JobContext, nicht in `mapJob`) sowie
+  `startedBy`/`completedBy` (Akteure der Übergänge — nur IDs, Namen werden über `assignees` aufgelöst).
 - `types/comment.ts` — `JobComment`, `CreateCommentInput` (Job-Kommentare).
 
 ### Theming (`constants/`, `hooks/`)
@@ -135,15 +138,30 @@ Die Route-Dateien sind dünn — die eigentliche UI liegt in `features/` (z. B. 
   **Einmalig** (Datum + Uhrzeit) oder **Wiederkehrend** (Wochentage + Uhrzeit + Aktiv/Inaktiv). Validierung:
   single braucht Datum **und** Uhrzeit; recurring braucht mind. **einen** Wochentag **und** Uhrzeit. Kunde,
   Ort/Location, Service bleiben Pflicht; Mitarbeiter-Zuweisung und Notizen optional.
-- **Mehrere Mitarbeiter pro Auftrag (ab Phase 5, READ-ONLY):** Maßgeblich für jede ANZEIGE ist
-  `Job.assignees[]` (aus `job_assignments`, gemappt in `jobs.service.ts`). `Job.employeeId`/`employeeName`
-  sind `@deprecated` und tragen nur noch (a) den Schreibpfad (Phase 6) und (b) das **Aktions-Gating**.
-  Letzteres ist kein Versehen: `start_own_job`/`complete_own_job` und die Insert-Policies auf
-  `job_comments`/`job_photos`/`storage.objects` verlangen serverseitig weiterhin
-  `jobs.assigned_to = auth.uid()`. Start-/Fertig-/Upload-Buttons deshalb **immer** über
-  `canRunJobActions()` bzw. `isPrimaryAssignee()` gaten, **nie** über `isAssignedTo()` — sonst
-  erscheint für sekundär Zugewiesene ein Button, der mit „Job not found or not allowed" fehlschlägt.
-  Wird in Phase 7 aufgelöst. Zuweisungs-Anzeige nicht selbst formatieren: `utils/jobAssignees.ts` nutzen.
+- **Mehrere Mitarbeiter pro Auftrag:** Maßgeblich für jede ANZEIGE ist `Job.assignees[]` (aus
+  `job_assignments`, gemappt in `jobs.service.ts`). `Job.employeeId`/`employeeName` sind `@deprecated`
+  und tragen nur noch den Schreibpfad sowie den Bestands-/Kompatibilitätszweig. Zuweisungs-Anzeige nicht
+  selbst formatieren: `utils/jobAssignees.ts` nutzen.
+- **Aktions-Gating — zwei Gates, nie selbst gebaut:** jeder Button muss dem SERVER-Prädikat entsprechen,
+  das ihn ausführt. Es gibt genau zwei:
+  - `canRunJobActions(job, role, employeeId)` → **Start/Abschluss**. Seit Phase 7 („Shared Job Time",
+    Migration `20260731000000`) erlauben `start_own_job`/`complete_own_job` die **volle Zuweisungsmenge**
+    (ODER den Legacy-Zeiger für Bestandszeilen ohne `job_assignments`-Zeile). Prüft zusätzlich
+    `role='employee'` und `jobType='single'` — beides steht serverseitig ebenfalls außerhalb der
+    ODER-Klammer, weil Recurring-Parent-Regeln selbst Zuweisungen tragen.
+  - `isPrimaryAssignee(job, employeeId)` → **Kommentar schreiben, Foto-Upload, Ungelesen-Status**. Deren
+    INSERT-Policies auf `job_comments`/`job_photos`/`job_comment_reads`/`storage.objects` verlangen
+    weiterhin `jobs.assigned_to = auth.uid()`. Diese Asymmetrie ist gewollt und dokumentiert; sie fällt
+    in einem eigenen PR. Hier `isAssignedTo()` zu verwenden erzeugt einen Button, der mit 42501 bzw.
+    „Job not found or not allowed" fehlschlägt.
+- **Geteilte Job-Uhr (Shared Job Time):** ein Auftrag hat **genau eine** offizielle Dauer
+  (`completed_at - started_at`). Wer Start/Abschluss gedrückt hat, ist dafür unerheblich — **alle**
+  Zugewiesenen erhalten diese Zeit im Stundenzettel, auch wer Start nie gedrückt hat. Der erste
+  erfolgreiche Übergang gewinnt (Statusbedingung im UPDATE), jeder weitere ist ein idempotenter No-Op.
+  `jobs.started_by`/`completed_by` halten nur den **Akteur** fest (Nachvollziehbarkeit, **nie**
+  Abrechnungs- oder Berechtigungsgrundlage). Es gibt bewusst **keine** Pro-Mitarbeiter-Timer und
+  **keine** Anwesenheitserfassung: `job_assignments.attendance`/`counts_for_timesheet` werden von
+  nichts gepflegt — nicht darauf filtern (sonst leere Stundenzettel).
 - **Heute-Logik nicht duplizieren:** Die „heute fällig?"-Entscheidung liegt zentral in `utils/jobSchedule.ts`
   (`isJobToday`/`getJobDisplayTime`/`getRecurringDaysLabel`) und wird von `EmployeeOverviewScreen`,
   `AdminDashboardScreen` und `JobCard` genutzt. Neue Screens diesen Helper verwenden, keine eigene

--- a/context/JobContext.tsx
+++ b/context/JobContext.tsx
@@ -621,6 +621,17 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
           const nextJobs = updateJobInList(prevJobs, jobId, {
             status: "in_progress",
             startedAt,
+            // Akteur optimistisch auf den eigenen Nutzer.
+            //
+            // Hat ein Kollege das Rennen gewonnen, gibt die RPC dessen
+            // Startzeit zurück und der Akteur ist hier kurzzeitig falsch. Das
+            // ist bewusst harmlos gehalten: die Anzeige nennt den Akteur NUR,
+            // wenn es ein ANDERER war (siehe WorkedTimeCard). Der Fehler
+            // äußert sich also als fehlender Hinweis, nie als falscher Name,
+            // und der nächste Realtime-Event/Refresh korrigiert ihn.
+            startedBy: userId,
+            // Rückwärts-Übergang: die RPC nullt completed_at/completed_by.
+            completedBy: null,
           });
 
           saveCachedJobs(userId, nextJobs).catch((err) =>
@@ -661,6 +672,11 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         const nextJobs = updateJobInList(prevJobs, jobId, {
           status: "in_progress",
           startedAt: timestamp,
+          // Offline ist der Akteur eindeutig der lokale Nutzer (die Aktion
+          // liegt auf seinen Namen in der Warteschlange). Der Server setzt
+          // beim Sync denselben Wert.
+          startedBy: userId,
+          completedBy: null,
         });
 
         saveCachedJobs(userId, nextJobs).catch((err) =>
@@ -686,6 +702,9 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
           const nextJobs = updateJobInList(prevJobs, jobId, {
             status: "completed",
             completedAt,
+            // Siehe Begründung bei startJob: Akteur optimistisch, Anzeige
+            // nennt ihn nur, wenn es ein anderer war.
+            completedBy: userId,
           });
 
           saveCachedJobs(userId, nextJobs).catch((err) =>
@@ -726,6 +745,8 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         const nextJobs = updateJobInList(prevJobs, jobId, {
           status: "completed",
           completedAt: timestamp,
+          // Offline eindeutig der lokale Nutzer (siehe startJob).
+          completedBy: userId,
         });
 
         saveCachedJobs(userId, nextJobs).catch((err) =>

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -125,9 +125,10 @@ export default function EmployeeOverviewScreen() {
   ).length;
 
   // ── Aktiver Job (erster in_progress über alle eigenen Jobs)
-  // Nur der eigene laufende Auftrag: seit Phase 5 sieht ein Mitarbeiter auch
-  // Aufträge, die eine Kollegin gestartet hat und bei denen er nur sekundär
-  // zugewiesen ist. Die Abschluss-Karte gehört ihm dann nicht.
+  // Seit Phase 7 („Shared Job Time") gehört die Abschluss-Karte JEDEM
+  // Zugewiesenen: hat eine Kollegin den Auftrag gestartet, darf ihn auch der
+  // Mitarbeiter abschließen, der Start nie gedrückt hat — beide erhalten
+  // dieselbe geteilte Arbeitszeit. canRunJobActions kapselt genau das.
   const activeJob = useMemo(
     () =>
       jobs.find(

--- a/features/home/HomeScreen.tsx
+++ b/features/home/HomeScreen.tsx
@@ -181,9 +181,9 @@ function AnimatedJobCard({
 }: {
   item: any;
   index: number;
-  // Optional: ohne Handler blendet JobCard die Quick-Action aus. Seit Phase 5
-  // ist das der Normalfall für Aufträge, bei denen der Nutzer nicht der
-  // Legacy-Primär ist (siehe canRunJobActions).
+  // Optional: ohne Handler blendet JobCard die Quick-Action aus — für Admins
+  // und für Aufträge, denen der Nutzer nicht zugewiesen ist (siehe
+  // canRunJobActions).
   onStart?: () => void;
   onComplete?: () => void;
   onPress?: () => void;

--- a/features/jobs/EmployeeJobsCalendarScreen.tsx
+++ b/features/jobs/EmployeeJobsCalendarScreen.tsx
@@ -290,7 +290,7 @@ export default function EmployeeJobsCalendarScreen() {
             job={item}
             // Start/Fertig sind Employee-Aktionen (RPCs start_own_job/
             // complete_own_job). JobCard zeigt je Status genau eine Action.
-            // Seit Phase 5 nur für den Legacy-Primär — siehe canRunJobActions.
+            // Seit Phase 7 für JEDEN Zugewiesenen — siehe canRunJobActions.
             onStart={
               canRunJobActions(item, role, profile?.id)
                 ? () => handleStart(item.id)

--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -31,6 +31,7 @@ import {
 import { WorkedTimeCard } from "@/features/jobs/components/WorkedTimeCard";
 import { formatRecurringDays } from "@/utils/recurrence";
 import {
+  canRunJobActions,
   formatAssigneesFull,
   getAssignees,
   isPrimaryAssignee,
@@ -176,12 +177,13 @@ export default function JobDetailScreen() {
 
   // Darf der Nutzer den Ungelesen-Status dieses Jobs schreiben?
   //
-  // job_comment_reads hat eigene INSERT/UPDATE-Policies, die — wie alle
-  // Schreibpfade — weiterhin den LEGACY-PRIMÄR verlangen. Ein sekundär
-  // Zugewiesener darf die Kommentare zwar lesen (Phase 5), das Markieren
-  // schlägt für ihn aber mit 42501 fehl. Der Fehler würde im JobContext
-  // stillschweigend geschluckt — also gar nicht erst versuchen.
-  // Fällt mit Phase 6/7, wenn die Schreibpfade nachziehen.
+  // job_comment_reads hat eigene INSERT/UPDATE-Policies, die weiterhin den
+  // LEGACY-PRIMÄR verlangen. Ein sekundär Zugewiesener darf die Kommentare
+  // zwar lesen (Phase 5), das Markieren schlägt für ihn aber mit 42501 fehl.
+  // Der Fehler würde im JobContext stillschweigend geschluckt — also gar
+  // nicht erst versuchen.
+  // Phase 7 hat NUR start_own_job/complete_own_job erweitert; die
+  // Kommentar-/Foto-Schreibpfade folgen in einem eigenen PR.
   const canMarkCommentsRead =
     !!job && (isAdmin || isPrimaryAssignee(job, profile?.id));
 
@@ -398,23 +400,23 @@ export default function JobDetailScreen() {
     assignees.length > 0 ? formatAssigneesFull(job) : UNASSIGNED_LABEL;
   const employeeLabel = assignees.length > 1 ? "Mitarbeitende" : "Mitarbeiter";
 
-  // BERECHTIGUNG (bewusst NICHT die Zuweisungsmenge): Start/Abschluss laufen
-  // über die RPCs start_own_job/complete_own_job, die role='employee' UND
-  // assigned_to=auth.uid() verlangen. Ein sekundär Zugewiesener sieht den
-  // Auftrag seit Phase 5 zwar, darf ihn aber serverseitig noch nicht starten —
-  // bekäme er hier einen Button, schlüge dieser mit "Job not found or not
-  // allowed" fehl. Wird in Phase 7 zusammen mit den RPCs umgestellt.
-  const isAssignedEmployee =
-    role === "employee" && isPrimaryAssignee(job, profile?.id);
-  // Parent-Recurring-Regeln dürfen niemals gestartet/abgeschlossen werden —
-  // nur konkrete Occurrences (job_type='single') sind ausführbare Termine.
-  const canStart = !isParentRule && isAssignedEmployee && job.status === "open";
-  const canComplete = !isParentRule && isAssignedEmployee && job.status === "in_progress";
+  // BERECHTIGUNG Start/Abschluss (Phase 7, „Shared Job Time"): JEDER
+  // Zugewiesene darf, nicht nur der Legacy-Primär — canRunJobActions spiegelt
+  // exakt das Prädikat von start_own_job/complete_own_job (Rolle, job_type,
+  // Zuweisungsmenge ODER Legacy-Zeiger). Der isParentRule-Zusatz ist
+  // redundant, bleibt aber als lokale, sichtbare Absicherung stehen: eine
+  // Parent-Regel ist kein ausführbarer Termin.
+  const canRunActions = canRunJobActions(job, role, profile?.id);
+  const canStart = !isParentRule && canRunActions && job.status === "open";
+  const canComplete =
+    !isParentRule && canRunActions && job.status === "in_progress";
   const isDone = job.status === "completed";
 
   // Foto-Upload: Admin immer; Employee nur wenn PRIMÄR zugewiesen.
-  // Gleiche Begründung wie oben bei isAssignedEmployee: die Insert-Policies auf
-  // job_photos und storage.objects verlangen weiterhin assigned_to = auth.uid().
+  // BEWUSSTE ASYMMETRIE zu canStart/canComplete oben: die Insert-Policies auf
+  // job_photos und storage.objects hängen weiterhin an assigned_to = auth.uid().
+  // Phase 7 hat NUR die beiden Status-RPCs erweitert — Fotos und Kommentare
+  // gehören nicht zur Job-Uhr und folgen in einem eigenen PR.
   // isOnline wird separat übergeben — JobPhotos zeigt den Offline-Hinweis selbst.
   const canUploadPhotos =
     role === "admin" ||

--- a/features/jobs/JobsListScreen.tsx
+++ b/features/jobs/JobsListScreen.tsx
@@ -12,9 +12,9 @@ import { useJobs } from "@/context/JobContext";
 import { useAuth } from "@/context/AuthContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import {
+  canRunJobActions,
   getAssigneeNames,
   isAssignedTo,
-  isPrimaryAssignee,
 } from "@/utils/jobAssignees";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -317,25 +317,23 @@ export default function JobsListScreen() {
           <JobCard
             job={item}
             // Start/Fertig sind Employee-Aktionen (RPCs start_own_job/
-            // complete_own_job verlangen role='employee' UND assigned_to=auth.uid()).
-            // Admins dürfen den Status NICHT über diese RPCs ändern → bei ihnen
-            // keine Quick-Action-Buttons zeigen, sonst RPC-Fehler "Job not found
-            // or not allowed". (JobCard blendet die Buttons ohne diese Props aus.)
+            // complete_own_job verlangen role='employee'). Admins dürfen den
+            // Status NICHT über diese RPCs ändern → bei ihnen keine
+            // Quick-Action-Buttons zeigen, sonst RPC-Fehler "Job not found or
+            // not allowed". (JobCard blendet die Buttons ohne diese Props aus.)
             //
-            // Seit Phase 5 sieht ein Mitarbeiter auch Aufträge, denen er nur
-            // SEKUNDÄR zugewiesen ist. Die RPCs kennen die Zuweisungsmenge noch
-            // nicht — deshalb hier zusätzlich auf den Legacy-Primär prüfen,
-            // sonst bekäme er einen Button, der garantiert fehlschlägt.
-            // Entfällt mit Phase 7.
+            // Rolle, Auftragstyp und Zuweisung entscheidet ausschließlich
+            // canRunJobActions — dieselbe Funktion wie in Home, Übersicht,
+            // Kalender und Detail, damit das Gating nicht auseinanderläuft.
             onStart={
-              isAdmin || !isPrimaryAssignee(item, profile?.id)
-                ? undefined
-                : () => startJob(item.id)
+              canRunJobActions(item, role, profile?.id)
+                ? () => startJob(item.id)
+                : undefined
             }
             onComplete={
-              isAdmin || !isPrimaryAssignee(item, profile?.id)
-                ? undefined
-                : () => completeJob(item.id)
+              canRunJobActions(item, role, profile?.id)
+                ? () => completeJob(item.id)
+                : undefined
             }
             onPress={() => router.push(`/jobs/${item.id}`)}
             showEmployeeName={isAdmin}

--- a/features/jobs/components/WorkedTimeCard.tsx
+++ b/features/jobs/components/WorkedTimeCard.tsx
@@ -8,6 +8,7 @@
 // hier wird nichts dupliziert.
 
 import { Card, StatusBadge } from "@/components/ui";
+import { useAuth } from "@/context/AuthContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useJobWorkedTime } from "@/hooks/useJobWorkedTime";
 import type { Job } from "@/types/job";
@@ -18,8 +19,41 @@ import { Animated, StyleSheet, Text, View } from "react-native";
 import type { AppTheme } from "@/constants/theme";
 
 type Props = {
-  job: Pick<Job, "status" | "startedAt" | "completedAt">;
+  job: Pick<
+    Job,
+    | "status"
+    | "startedAt"
+    | "completedAt"
+    | "startedBy"
+    | "completedBy"
+    | "assignees"
+  >;
 };
+
+/**
+ * Name des Akteurs eines Übergangs — oder null, wenn kein Hinweis nötig ist.
+ *
+ * Zeigt bewusst NUR fremde Akteure: „von Ahmed" erklärt einem Mitarbeiter,
+ * warum er Arbeitszeit erhält, die er selbst nicht gestartet hat (geteilte
+ * Job-Uhr, Phase 7). „von mir" wäre reines Rauschen.
+ *
+ * Kein Hinweis in drei Fällen — alle bewusst still:
+ *  - kein Akteur gespeichert (Alt-Daten vor Phase 7, oder Konto gelöscht:
+ *    ON DELETE SET NULL),
+ *  - der Akteur ist der aktuelle Nutzer,
+ *  - der Akteur ist in `assignees` nicht auflösbar (z. B. inzwischen aus dem
+ *    Auftrag entfernt). Ein erfundener Platzhaltername wäre schlechter als
+ *    kein Hinweis.
+ */
+function actorName(
+  actorId: string | null | undefined,
+  assignees: Job["assignees"] | undefined,
+  currentUserId: string | null | undefined,
+): string | null {
+  if (!actorId || actorId === currentUserId) return null;
+  const match = (assignees ?? []).find((a) => a.employeeId === actorId);
+  return match?.fullName ?? null;
+}
 
 // Datum als "18.07.2026" (ohne Uhrzeit) — für die Start-/Ende-Blöcke.
 function formatBlockDate(iso: string | null | undefined): string | null {
@@ -36,6 +70,7 @@ function formatBlockDate(iso: string | null | undefined): string | null {
 export function WorkedTimeCard({ job }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const { profile } = useAuth();
   const { minutes, label, isRunning } = useJobWorkedTime(job);
 
   // Sanfte Puls-Animation, wenn sich das Label ändert (jede Minute während
@@ -73,6 +108,17 @@ export function WorkedTimeCard({ job }: Props) {
     ? formatTimeHHmm(new Date(job.completedAt))
     : null;
 
+  // Mehrfachzuweisung = geteilte Job-Uhr. Nur dann ist der Zusatzhinweis
+  // unten relevant; bei einem einzigen Mitarbeiter wäre er Ballast.
+  const isShared = (job.assignees ?? []).length > 1;
+
+  const startedByName = actorName(job.startedBy, job.assignees, profile?.id);
+  const completedByName = actorName(
+    job.completedBy,
+    job.assignees,
+    profile?.id,
+  );
+
   const accentColor = isRunning
     ? theme.colors.statusInProgress
     : theme.colors.statusCompleted;
@@ -107,6 +153,11 @@ export function WorkedTimeCard({ job }: Props) {
           <Text style={styles.timeBlockLabel}>GESTARTET</Text>
           <Text style={styles.timeBlockDate}>{startedDate ?? "—"}</Text>
           <Text style={styles.timeBlockValue}>{startedTime ?? "—:—"}</Text>
+          {startedByName ? (
+            <Text style={styles.timeBlockActor} numberOfLines={2}>
+              von {startedByName}
+            </Text>
+          ) : null}
         </View>
 
         <View style={styles.timeBlockDivider} />
@@ -121,6 +172,11 @@ export function WorkedTimeCard({ job }: Props) {
             <>
               <Text style={styles.timeBlockDate}>{completedDate ?? "—"}</Text>
               <Text style={styles.timeBlockValue}>{completedTime ?? "—:—"}</Text>
+              {completedByName ? (
+                <Text style={styles.timeBlockActor} numberOfLines={2}>
+                  von {completedByName}
+                </Text>
+              ) : null}
             </>
           )}
         </View>
@@ -153,6 +209,11 @@ export function WorkedTimeCard({ job }: Props) {
         />
         <Text style={styles.infoText}>
           Die Arbeitszeit wird automatisch aus Start- und Endzeit berechnet.
+          {isShared
+            ? // Geteilte Job-Uhr (Phase 7): erklärt, warum jemand Zeit
+              // erhält, die ein Kollege gestartet hat.
+              " Sie gilt für alle zugewiesenen Mitarbeitenden — unabhängig davon, wer Start und Abschluss gedrückt hat."
+            : ""}
         </Text>
       </View>
     </Card>
@@ -237,6 +298,15 @@ function createStyles(theme: AppTheme) {
       fontWeight: theme.typography.weight.bold,
       color: theme.colors.onSurface,
       letterSpacing: theme.typography.letterSpacing.tight,
+    },
+    // „von <Name>" unter der Uhrzeit — nur bei fremdem Akteur (siehe
+    // actorName). Bewusst dezent: der Akteur ist ein Hinweis, keine
+    // Kennzahl.
+    timeBlockActor: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
     },
     timeBlockRunning: {
       fontSize: theme.typography.size.xl,

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -89,6 +89,13 @@ create table if not exists public.jobs (
   scheduled_end timestamptz,
   started_at timestamptz,
   completed_at timestamptz,
+  -- ── Akteure der beiden Statusübergänge (Phase 7, „Shared Job Time") ──
+  -- WER gedrückt hat, nicht wem die Zeit gehört: die offizielle Dauer
+  -- (completed_at - started_at) gilt für ALLE Zugewiesenen, unabhängig davon,
+  -- wer Start/Abschluss ausgelöst hat. Nullable + ON DELETE SET NULL, damit
+  -- eine Kontolöschung nicht blockiert wird.
+  started_by uuid references public.profiles(id) on delete set null,
+  completed_by uuid references public.profiles(id) on delete set null,
   -- ── Terminierung: einmalig (single) vs. wiederkehrend (recurring) ──
   -- single:    date + start_time gesetzt, recurring_days null
   -- recurring: recurring_days (Wochentage) + start_time gesetzt, date null
@@ -638,6 +645,13 @@ grant execute on function public.accept_own_invite() to authenticated;
 -- = idempotenter No-Op (kein Fehler, kein zweites Event) — wichtig, damit ein
 -- Offline-Retry/Doppel-Tap nicht scheitert oder doppelt benachrichtigt.
 -- Siehe supabase/migrations/20260717000000_admin_status_notifications.sql.
+--
+-- BERECHTIGT ist JEDER über job_assignments Zugewiesene (Phase 7, „Shared Job
+-- Time") — plus, für Bestandszeilen ohne Zuweisungszeile, der Legacy-Primär
+-- jobs.assigned_to. job_type='single' bleibt eigenständige Bedingung AUSSERHALB
+-- der ODER-Klammer, weil Recurring-Parent-Regeln selbst Zuweisungen tragen und
+-- is_assigned_to_job() job_type nicht kennt. Vollständige Begründung in
+-- supabase/migrations/20260731000000_shared_job_time_multi_assignment.sql.
 create or replace function public.start_own_job(
   job_id_input uuid,
   started_at_input timestamptz default now()
@@ -660,13 +674,18 @@ begin
   set
     status = 'in_progress',
     started_at = started_at_input,
-    completed_at = null
+    started_by = auth.uid(),
+    completed_at = null,
+    completed_by = null
   where id = job_id_input
-    and assigned_to = auth.uid()
     and company_id = public.current_user_company_id()
     and public.current_user_role() = 'employee'
     and job_type = 'single'   -- Parent-Recurring-Regeln dürfen nicht gestartet werden
     and status = 'open'       -- NUR der echte Übergang open -> in_progress
+    and (
+      assigned_to = auth.uid()                    -- Legacy-Primär (Bestand)
+      or public.is_assigned_to_job(job_id_input)  -- Zuweisungsmenge (Phase 7)
+    )
   returning * into updated_row;
 
   if found then
@@ -685,17 +704,22 @@ begin
     return started_at_input;
   end if;
 
-  -- Kein Übergang: idempotenter No-Op (eigener Job, aber nicht mehr 'open')
-  -- vs. nicht erlaubt (fremder/nicht gefundener Job) unterscheiden.
+  -- Kein Übergang: idempotenter No-Op (zugewiesener Job, aber nicht mehr
+  -- 'open') vs. nicht erlaubt (fremder/nicht gefundener Job) unterscheiden.
   select * into existing_row
   from public.jobs
   where id = job_id_input
-    and assigned_to = auth.uid()
     and company_id = public.current_user_company_id()
     and public.current_user_role() = 'employee'
-    and job_type = 'single';
+    and job_type = 'single'
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    );
 
   if found then
+    -- Der Kollege war schneller (oder Doppel-Tap/Retry): die bereits
+    -- gesetzte, GETEILTE Startzeit zurückgeben — nie die eigene.
     return coalesce(existing_row.started_at, started_at_input);
   end if;
 
@@ -713,6 +737,7 @@ grant execute on function public.start_own_job(uuid, timestamptz) to authenticat
 -- completed eine notification_outbox-Zeile; bereits abgeschlossen = No-Op.
 -- Abschluss eines nicht gestarteten (open) Jobs wirft bewusst (kein falscher
 -- Erfolg) — die UI erlaubt „Abschließen" ohnehin nur bei in_progress.
+-- Berechtigung wie bei start_own_job: jeder Zugewiesene, plus Legacy-Primär.
 create or replace function public.complete_own_job(
   job_id_input uuid,
   completed_at_input timestamptz default now()
@@ -734,13 +759,17 @@ begin
   update public.jobs
   set
     status = 'completed',
-    completed_at = completed_at_input
+    completed_at = completed_at_input,
+    completed_by = auth.uid()
   where id = job_id_input
-    and assigned_to = auth.uid()
     and company_id = public.current_user_company_id()
     and public.current_user_role() = 'employee'
     and job_type = 'single'          -- Parent-Recurring-Regeln nicht abschließbar
     and status = 'in_progress'       -- NUR der echte Übergang in_progress -> completed
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    )
   returning * into updated_row;
 
   if found then
@@ -762,22 +791,27 @@ begin
   select * into existing_row
   from public.jobs
   where id = job_id_input
-    and assigned_to = auth.uid()
     and company_id = public.current_user_company_id()
     and public.current_user_role() = 'employee'
-    and job_type = 'single';
+    and job_type = 'single'
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    );
 
   if not found then
     raise exception 'Job not found or not allowed';
   end if;
 
   -- Bereits abgeschlossen -> idempotenter No-Op (retry-sicher), kein Event.
+  -- Deckt auch den Wettlauf zweier Zugewiesener ab: der Zweite erhält die
+  -- GETEILTE Endzeit des Ersten.
   if existing_row.status = 'completed' then
     return coalesce(existing_row.completed_at, completed_at_input);
   end if;
 
-  -- Eigener Job, aber (noch) nicht in_progress (z. B. 'open') -> nicht als
-  -- Erfolg vortäuschen, sichtbar scheitern.
+  -- Zugewiesener Job, aber (noch) nicht in_progress (z. B. 'open') -> nicht
+  -- als Erfolg vortäuschen, sichtbar scheitern.
   raise exception 'Job not in progress (cannot complete)';
 end;
 $$;
@@ -1864,10 +1898,10 @@ comment on function public.clear_my_push_token() is
 'Clears only the current user expo push token. Always succeeds for any authenticated caller (active or not) — used on logout so a shared device never keeps a stale token bound to the previous user.';
 
 comment on function public.start_own_job(uuid, timestamptz) is
-'Employee can start only own assigned job inside own company.';
+'Setzt einen Auftrag der eigenen Firma auf in_progress. Berechtigt ist JEDER über job_assignments Zugewiesene sowie (Bestand) der Legacy-Primär jobs.assigned_to; nur role=employee, nur job_type=single. Schreibt started_at/started_by und ein job_started-Outbox-Event genau beim echten Übergang open -> in_progress; bereits gestartet/abgeschlossen ist ein idempotenter No-Op und gibt die GETEILTE Startzeit zurück. Fasst job_assignments nicht an (keine Anwesenheitserfassung).';
 
 comment on function public.complete_own_job(uuid, timestamptz) is
-'Employee can complete only own assigned job inside own company.';
+'Setzt einen laufenden Auftrag der eigenen Firma auf completed. Berechtigt ist JEDER über job_assignments Zugewiesene sowie (Bestand) der Legacy-Primär; nur role=employee, nur job_type=single. Schreibt completed_at/completed_by und ein job_completed-Outbox-Event genau beim echten Übergang in_progress -> completed; bereits abgeschlossen ist ein idempotenter No-Op. Ein noch nicht gestarteter Auftrag wird abgelehnt (ohne Start gibt es keine Dauer). Fasst job_assignments nicht an (keine Anwesenheitserfassung).';
 
 comment on function public.enforce_active_assignee() is
 'BEFORE INSERT/UPDATE Guard auf jobs: Zuweisung nur an ein aktives Profil mit role=employee derselben company_id. Prüft bei INSERT und bei UPDATE mit geändertem assigned_to oder company_id. Unabhängig vom schreibenden Pfad (RLS oder SECURITY DEFINER RPC).';

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -53,6 +53,8 @@ type JobRow = {
   status: "open" | "in_progress" | "completed";
   started_at: string | null;
   completed_at: string | null;
+  started_by: string | null;
+  completed_by: string | null;
   notes: string | null;
   assigned_to: string | null;
   job_type: JobType | null;
@@ -231,8 +233,10 @@ function formatTimeRange(start: string | null, end: string | null): string {
 // vergessener Embed stillschweigend eine leere Mitarbeiterliste erzeugt.
 // Deshalb konsolidiert — alle Abfragen nutzen ausschließlich diese Konstante.
 //
-// assigned_to + profiles:assigned_to bleiben bewusst enthalten: sie tragen das
-// Aktions-Gating und den Schreibpfad, bis Phase 7/11 sie ablösen.
+// assigned_to + profiles:assigned_to bleiben bewusst enthalten: das
+// Aktions-Gating läuft seit Phase 7 über die Zuweisungsmenge, der Legacy-Zeiger
+// deckt aber weiterhin (a) Bestandszeilen ohne Zuweisungszeile, (b) die
+// Kommentar-/Foto-Schreibpfade und (c) den Schreibpfad — bis Phase 11.
 const JOB_SELECT = `
   id,
   customer_name,
@@ -243,6 +247,8 @@ const JOB_SELECT = `
   status,
   started_at,
   completed_at,
+  started_by,
+  completed_by,
   notes,
   job_type,
   date,
@@ -394,6 +400,11 @@ function mapJob(row: JobRow): Job {
     scheduledEnd: row.scheduled_end,
     startedAt: row.started_at,
     completedAt: row.completed_at,
+
+    // Akteure der Übergänge (Phase 7) — Nachvollziehbarkeit, KEINE
+    // Abrechnungs- oder Berechtigungsgrundlage (siehe types/job.ts).
+    startedBy: row.started_by,
+    completedBy: row.completed_by,
 
     // Terminierung — bestehende Zeilen ohne Typ gelten als "single"/aktiv.
     jobType: row.job_type ?? "single",

--- a/services/offline/jobs.merge.ts
+++ b/services/offline/jobs.merge.ts
@@ -6,11 +6,18 @@ import { PendingJobAction } from "./jobs.queue";
  */
 function applyPendingActionToJob(job: Job, action: PendingJobAction): Job {
   switch (action.type) {
+    // Der Akteur ist eindeutig der Besitzer der Aktion: die Warteschlange
+    // liefert ausschließlich Aktionen des angemeldeten Nutzers (siehe
+    // getPendingJobActions), und beim Sync setzt der Server genau denselben
+    // Wert (auth.uid()). Ohne diese Spiegelung zeigte ein offline gestarteter
+    // Job aus dem Cache "läuft, ohne Akteur".
     case "start_job":
       return {
         ...job,
         status: "in_progress" as const,
         startedAt: action.timestamp,
+        startedBy: action.userId,
+        completedBy: null,
       };
 
     case "complete_job":
@@ -18,6 +25,7 @@ function applyPendingActionToJob(job: Job, action: PendingJobAction): Job {
         ...job,
         status: "completed" as const,
         completedAt: action.timestamp,
+        completedBy: action.userId,
       };
 
     default:

--- a/services/offline/jobs.queue.ts
+++ b/services/offline/jobs.queue.ts
@@ -26,11 +26,15 @@ const JOBS_QUEUE_STORAGE_KEY = "offline_jobs_queue";
 //
 // SICHERHEIT — geteilte Geräte: Ohne Besitzer konnte die Sync-Routine die
 // offline erfassten Aktionen von Nutzer A unter der Sitzung von Nutzer B
-// ausführen. Serverseitig scheitern die meisten davon (start_own_job/
-// complete_own_job verlangen assigned_to = auth.uid()), ABER im Sonderfall
-// „B ist demselben Auftrag zugewiesen" wäre A's Aktion mit A's Zeitstempel
-// unter B's Sitzung tatsächlich durchgelaufen — eine falsche Zuschreibung
-// von Arbeitszeit.
+// ausführen. Ist B demselben Auftrag zugewiesen, läuft A's Aktion mit A's
+// Zeitstempel unter B's Sitzung tatsächlich durch — eine falsche Zuschreibung
+// von Arbeitszeit UND ein falscher started_by/completed_by.
+//
+// Seit Phase 7 („Shared Job Time", Migration 20260731000000) darf JEDER
+// Zugewiesene starten und abschließen. Der Sonderfall „B ist demselben
+// Auftrag zugewiesen" ist damit kein Randfall mehr, sondern bei
+// mehrfach zugewiesenen Aufträgen der Normalfall — die Besitzer-Bindung
+// dieser Warteschlange ist dadurch WICHTIGER geworden, nicht weniger wichtig.
 export const JOBS_QUEUE_VERSION = 2;
 
 type StoredQueuePayload = {

--- a/supabase/migrations/20260731000000_shared_job_time_multi_assignment.sql
+++ b/supabase/migrations/20260731000000_shared_job_time_multi_assignment.sql
@@ -1,0 +1,469 @@
+-- =========================================================
+-- MIGRATION: Shared Job Time — Start/Abschluss fuer JEDEN Zugewiesenen
+-- Datum: 2026-07-31   (Phase 7 von 11 — Aktionspfad)
+-- =========================================================
+-- ZWECK
+--   Seit Phase 5/6 kann ein Auftrag mehrere Mitarbeiter tragen
+--   (job_assignments) und alle sehen ihn. Starten und Abschliessen darf
+--   aber weiterhin AUSSCHLIESSLICH der Legacy-Primaer jobs.assigned_to —
+--   welcher Mitarbeiter das ist, entscheidet compat_primary_assignee() und
+--   ist bei gleichzeitig angelegten Zuweisungen ARBITRAER (Tiebreak ueber
+--   die Zufalls-UUID, siehe 20260726000000). Praktisch heisst das: von zwei
+--   gleichzeitig zugewiesenen Mitarbeitern kann einer den Auftrag nicht
+--   starten. Genau das ist im Beta-Test aufgefallen.
+--
+--   Diese Migration stellt beide RPCs auf die ZUWEISUNGSMENGE um und
+--   ergaenzt die Auftragszeile um die AKTEURE der beiden Uebergaenge.
+--
+-- FACHMODELL: EINE GETEILTE ZEITSCHIENE (bewusst, erste Fassung)
+--   Der Auftrag hat GENAU EINE offizielle Dauer:
+--       jobs.completed_at - jobs.started_at
+--   Wer Start gedrueckt hat, ist fuer die Dauer UNERHEBLICH. Startet Ahmed
+--   um 08:00 und schliesst Mohammed um 10:00 ab, erhalten BEIDE
+--   08:00–10:00 im Stundenzettel — auch der, der Start nie gedrueckt hat.
+--   Die Uhr gehoert dem AUFTRAG, nicht dem Mitarbeiter.
+--
+--   Es entstehen deshalb ausdruecklich KEINE Pro-Mitarbeiter-Timer, KEINE
+--   Arbeitssitzungen und KEINE Anwesenheitserfassung. Das folgt in einer
+--   spaeteren Phase.
+--
+-- =========================================================
+-- WARUM DIESE MIGRATION UEBERHAUPT NOETIG IST
+-- =========================================================
+-- Es gibt keinen rein clientseitigen Weg. Die beiden Statuswechsel laufen
+-- zwingend ueber start_own_job/complete_own_job, weil Mitarbeiter per RLS
+-- KEIN UPDATE auf public.jobs haben (bewusst so, siehe lib/schema.sql).
+-- Beide Funktionen tragen den Vergleich
+--     assigned_to = auth.uid()
+-- HART IM FUNKTIONSKOERPER. Ein sekundaer Zugewiesener bekommt dort
+-- garantiert "Job not found or not allowed" — unabhaengig davon, was die
+-- App anzeigt oder sendet.
+--
+-- GEPRUEFTE ALTERNATIVEN UND WARUM SIE NICHT AUSREICHEN
+--
+--   (1) Nur die App aendern (Buttons fuer alle Zugewiesenen zeigen).
+--       Ergebnis: der Button erscheint und scheitert serverseitig. Genau
+--       davor warnen die bestehenden Kommentare in utils/jobAssignees.ts.
+--       Loest nichts.
+--
+--   (2) Mitarbeitern eine UPDATE-Policy auf public.jobs geben.
+--       Deutlich groesserer Eingriff und fachlich falsch: eine
+--       Spalten-Einschraenkung laesst sich in einer Policy nicht
+--       ausdruecken — der Mitarbeiter koennte damit Kunde, Adresse,
+--       Terminierung oder started_at ruecksetzen. Die RPC-Loesung haelt
+--       genau zwei Uebergaenge erlaubt. Verworfen.
+--
+--   (3) jobs.assigned_to beim Start auf den Handelnden umbiegen
+--       ("wer startet, wird Primaer").
+--       Kein Schema-Zuwachs, aber es zerstoert Daten: ein Legacy-Schreiben
+--       auf assigned_to bedeutet seit 20260729000000 MENGE ERSETZEN — der
+--       Start eines Mitarbeiters wuerde alle uebrigen Zuweisungen des
+--       Auftrags entfernen und damit genau die Stundenzettel-Grundlage aus
+--       PR #58 loeschen. Verworfen.
+--
+--   (4) attendance / employee_started_at in job_assignments pflegen
+--       (der Weg, den die Roadmap fuer die Anwesenheitsphase vorsieht).
+--       Waere ohne neue Spalten moeglich, ist hier aber ausdruecklich NICHT
+--       gewollt: das ist Anwesenheitserfassung und damit ausser Scope.
+--       Zusaetzlich haette es zwei echte Nebenwirkungen — es veraendert
+--       counts_for_timesheet (generierte Spalte) und es entzieht die Zeile
+--       der Primaer-Auswahl in compat_primary_assignee() (Bedingung
+--       attendance = 'assigned'). Bewusst verworfen; job_assignments wird
+--       von dieser Migration NICHT angefasst.
+--
+-- WARUM ZWEI NEUE SPALTEN (started_by/completed_by)
+--   Bisher war der Akteur implizit: es KONNTE nur assigned_to sein. Genau
+--   diese Implikation faellt mit dieser Migration weg — ohne die Spalten
+--   waere nach dem Start nicht mehr feststellbar, WER gestartet hat. Das
+--   ist keine Kuer: die geteilte Zeitschiene schreibt einem Mitarbeiter
+--   Arbeitszeit zu, die ein Kollege gestartet hat. Wer die Uhr gestellt
+--   hat, muss nachvollziehbar bleiben.
+--   notification_outbox traegt den Akteur zwar auch, ist aber eine
+--   Versand-Warteschlange (wird abgearbeitet und aufgeraeumt) und damit
+--   kein Nachweis.
+--   Beide Spalten sind rein additiv, NULLABLE und ON DELETE SET NULL —
+--   kein Bestandsleser und keine Konto-Loeschung wird davon beruehrt
+--   (siehe Begruendung in Abschnitt 1).
+--
+-- =========================================================
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+-- =========================================================
+--   * public.job_assignments — keine Spalte, kein Trigger, KEIN Schreiben.
+--     attendance, employee_started_at, employee_completed_at, review und
+--     counts_for_timesheet bleiben unangetastet.
+--   * Der Stundenzettel (services/timesheets/timesheet.service.ts, PR #58)
+--     bleibt unveraendert. Er filtert bereits ueber job_assignments und
+--     credited damit ALLE Zugewiesenen mit der offiziellen Job-Dauer —
+--     also exakt das hier gewuenschte Verhalten. Es gibt nichts anzupassen.
+--     Insbesondere wird NICHT auf counts_for_timesheet umgestellt (waere
+--     dauerhaft false, siehe (4) oben und PR #58).
+--   * Die INSERT-Policies auf job_comments, job_photos, job_comment_reads
+--     und storage.objects bleiben an assigned_to gebunden. Kommentieren und
+--     Fotos gehoeren nicht zur Job-Uhr; sie zu erweitern waere eine zweite,
+--     eigenstaendige Rechteausweitung. Die App gated diese Buttons
+--     weiterhin am Legacy-Primaer — die Asymmetrie bleibt damit
+--     konsistent zwischen Client und Server.
+--   * get_unread_comment_job_ids() bleibt unveraendert (haengt am
+--     Schreibpfad job_comment_reads, siehe Abschnitt 5 von 20260730000000).
+--   * Keine Aenderung an Benachrichtigungen: beide RPCs schreiben ihre
+--     notification_outbox-Zeile wie bisher, mit dem HANDELNDEN als
+--     employee_id/employee_name. Vorher war das zwangslaeufig der Primaer,
+--     jetzt ist es der tatsaechliche Akteur — der Admin-Push wird dadurch
+--     genauer, nicht anders geartet.
+--   * Keine Aenderung an Admin-Policies, an generate_job_occurrences/
+--     update_job_occurrences oder an den compat_*-Triggern.
+--
+-- IDEMPOTENZ
+--   Vollstaendig wiederholbar: Spalten via ADD COLUMN IF NOT EXISTS,
+--   Indizes via CREATE INDEX IF NOT EXISTS, Funktionen via
+--   CREATE OR REPLACE (Signatur unveraendert, Grants bleiben erhalten).
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgefuehrt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Akteure der beiden Uebergaenge
+-- ---------------------------------------------------------
+-- FK-VERHALTEN — nicht verhandelbar, gelernter Fehler:
+--   NULLABLE + ON DELETE SET NULL. In genau diesem Repository hat eine
+--   Spalte mit NOT NULL + ON DELETE RESTRICT (job_photos.uploaded_by) in
+--   PRODUKTION die Konto-Loeschung blockiert; behoben in
+--   20260722000000 / 20260722000001. Derselbe Fehler wird hier nicht
+--   wiederholt. Konsistent mit jobs.assigned_to und jobs.created_by, die
+--   aus demselben Grund anonymisieren statt zu blockieren.
+--
+-- KEIN NAMENS-SCHNAPPSCHUSS: nach einer Konto-Loeschung ist der Akteur
+-- anonym (NULL) und die Anzeige zeigt nur noch den Zeitpunkt. Der
+-- belastbare Abrechnungsnachweis liegt nicht hier, sondern in
+-- job_assignments.employee_name_snapshot (Phase 1). Eine zweite
+-- Namenskopie waere Redundanz ohne Zugewinn.
+--
+-- KEINE CHECK-CONSTRAINT gegen started_at (etwa "beide gesetzt oder beide
+-- NULL"): CHECKs werden bei JEDEM UPDATE geprueft, auch bei dem UPDATE,
+-- das ON DELETE SET NULL selbst ausloest — genau so blockiert man wieder
+-- Konto-Loeschungen. Die Kopplung wird stattdessen zum SCHREIBZEITPUNKT in
+-- den beiden RPCs erzwungen (dieselbe Begruendung wie bei
+-- job_assignments.reviewed_by, Phase 1).
+alter table public.jobs
+  add column if not exists started_by uuid references public.profiles(id) on delete set null;
+
+alter table public.jobs
+  add column if not exists completed_by uuid references public.profiles(id) on delete set null;
+
+comment on column public.jobs.started_by is
+'Mitarbeiter, der den Uebergang open -> in_progress ausgeloest hat (Akteur, '
+'nicht Eigentuemer). NULL = nie gestartet ODER Konto geloescht. Traegt KEINE '
+'Abrechnungsbedeutung: die offizielle Dauer ist completed_at - started_at und '
+'gilt fuer ALLE Zugewiesenen, unabhaengig davon, wer gedrueckt hat.';
+
+comment on column public.jobs.completed_by is
+'Mitarbeiter, der den Uebergang in_progress -> completed ausgeloest hat. '
+'Gleiche Semantik wie started_by — Akteur, keine Abrechnungsbedeutung.';
+
+-- FK-Rueckwaertsindizes, damit eine Konto-Loeschung (ON DELETE SET NULL)
+-- nicht ueber einen Seq Scan auf jobs laeuft. Partiell, weil die Spalten
+-- fuer die grosse Mehrheit der Zeilen NULL sind (dieselbe Bauform wie
+-- idx_job_assignments_assigned_by aus Phase 1).
+create index if not exists idx_jobs_started_by
+  on public.jobs (started_by) where started_by is not null;
+
+create index if not exists idx_jobs_completed_by
+  on public.jobs (completed_by) where completed_by is not null;
+
+
+-- ---------------------------------------------------------
+-- 2. RPC: START OWN JOB — jeder Zugewiesene darf starten
+-- ---------------------------------------------------------
+-- GEAENDERT wird GENAU DREIERLEI:
+--   a) Berechtigung: "assigned_to = auth.uid()"
+--      ->  "assigned_to = auth.uid() OR public.is_assigned_to_job(...)"
+--   b) started_by wird beim echten Uebergang gesetzt
+--   c) completed_by wird zusammen mit completed_at zurueckgesetzt
+-- Alles andere (Rolle, Firma, job_type, Statusbedingung, Idempotenz,
+-- Outbox-Event, Rueckgabewert, Signatur) bleibt Zeichen fuer Zeichen wie
+-- gehabt.
+--
+-- (a) IST EINE ECHTE OBERMENGE — niemand verliert ein Recht. Der
+--     Legacy-Zweig bleibt bewusst stehen: es gibt Bestandszeilen mit
+--     assigned_to OHNE passende job_assignments-Zeile (der Phase-1-Backfill
+--     hat 6 nicht-konforme Zeilen ausdruecklich erhalten). Ein Ersetzen
+--     statt Erweitern haette genau diesen Mitarbeitern den Start entzogen.
+--     Der Zweig faellt erst mit der Spalte selbst (Phase 11).
+--
+-- is_assigned_to_job(uuid) ist der GLEICHE Helfer, den die Lesepolicies aus
+-- 20260730000000 nutzen — Lese- und Aktionsrecht koennen damit nicht
+-- auseinanderlaufen. Er ist SECURITY DEFINER (keine RLS-Rekursion), STABLE,
+-- prueft die Firma selbst und ist fuer authenticated ausfuehrbar (Phase 3);
+-- diese Migration vergibt KEIN neues Recht.
+--
+-- job_type = 'single' BLEIBT EIGENSTAENDIGE BEDINGUNG, ausserhalb der
+-- ODER-Klammer. Recurring-PARENT-Regeln tragen seit Phase 4 selbst
+-- Zuweisungen (sie sind die Vorlage) und is_assigned_to_job() kennt
+-- job_type nicht — liefert dort also true. Innerhalb der Klammer waere eine
+-- Parent-Regel damit startbar. Identische Falle wie in Abschnitt (B) von
+-- 20260730000000.
+--
+-- "NIEMAND KANN ZWEIMAL STARTEN" — WIE DAS GARANTIERT IST:
+--   Die Bedingung status = 'open' steht im UPDATE selbst. Zwei
+--   gleichzeitige Starts konkurrieren um dieselbe Zeilensperre; der
+--   Zweite wertet nach dem Commit des Ersten seine WHERE-Klausel gegen die
+--   NEUE Zeilenversion erneut aus (EvalPlanQual), findet status =
+--   'in_progress' und trifft nichts. Er laeuft dann in den No-Op-Zweig und
+--   erhaelt den bereits gesetzten started_at zurueck. started_at,
+--   started_by und das Outbox-Event koennen also NIE ueberschrieben oder
+--   verdoppelt werden — der Erste gewinnt, ohne dass der Zweite einen
+--   Fehler sieht (wichtig fuer Doppel-Tap und Offline-Retry).
+create or replace function public.start_own_job(
+  job_id_input uuid,
+  started_at_input timestamptz default now()
+)
+returns timestamptz
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_row  public.jobs%rowtype;
+  existing_row public.jobs%rowtype;
+  emp_name     text;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  update public.jobs
+  set
+    status       = 'in_progress',
+    started_at   = started_at_input,
+    started_by   = auth.uid(),
+    -- Rueckwaerts-Uebergang: completed_at wurde hier immer schon genullt.
+    -- completed_by muss zwingend mitgenullt werden, sonst behauptet die
+    -- Zeile einen Abschluss-Akteur ohne Abschlusszeitpunkt.
+    completed_at = null,
+    completed_by = null
+  where id = job_id_input
+    and company_id = public.current_user_company_id()
+    and public.current_user_role() = 'employee'
+    and job_type = 'single'   -- Parent-Recurring-Regeln duerfen nicht gestartet werden
+    and status = 'open'       -- NUR der echte Uebergang open -> in_progress
+    and (
+      assigned_to = auth.uid()                    -- Legacy-Primaer (Bestand)
+      or public.is_assigned_to_job(job_id_input)  -- Zuweisungsmenge (Phase 7)
+    )
+  returning * into updated_row;
+
+  if found then
+    select full_name into emp_name from public.profiles where id = auth.uid();
+
+    insert into public.notification_outbox (
+      company_id, job_id, event_type, job_status,
+      employee_id, employee_name, customer_name, service_name
+    )
+    values (
+      updated_row.company_id, updated_row.id, 'job_started', 'in_progress',
+      auth.uid(), emp_name, updated_row.customer_name, updated_row.service_name
+    )
+    on conflict (job_id, event_type) do nothing;
+
+    return started_at_input;
+  end if;
+
+  -- Kein Uebergang: zugewiesener Job, aber nicht mehr 'open' (idempotenter
+  -- No-Op) vs. nicht erlaubt (fremder/nicht gefundener Job) unterscheiden.
+  select * into existing_row
+  from public.jobs
+  where id = job_id_input
+    and company_id = public.current_user_company_id()
+    and public.current_user_role() = 'employee'
+    and job_type = 'single'
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    );
+
+  if found then
+    -- Der Kollege war schneller (oder Doppel-Tap/Retry): die bereits
+    -- gesetzte, GETEILTE Startzeit zurueckgeben — nie die eigene.
+    return coalesce(existing_row.started_at, started_at_input);
+  end if;
+
+  raise exception 'Job not found or not allowed';
+end;
+$$;
+
+comment on function public.start_own_job(uuid, timestamptz) is
+'Setzt einen Auftrag der eigenen Firma auf in_progress. Berechtigt ist JEDER '
+'ueber job_assignments Zugewiesene sowie (Bestand) der Legacy-Primaer '
+'jobs.assigned_to; nur role=employee, nur job_type=single. Schreibt '
+'started_at/started_by und ein job_started-Outbox-Event genau beim echten '
+'Uebergang open -> in_progress; bereits gestartet/abgeschlossen ist ein '
+'idempotenter No-Op und gibt die GETEILTE Startzeit zurueck. Fasst '
+'job_assignments nicht an (keine Anwesenheitserfassung).';
+
+-- Grants bleiben durch CREATE OR REPLACE erhalten; hier nur, damit die
+-- Migration auch auf einer frisch gebauten Datenbank vollstaendig ist.
+grant execute on function public.start_own_job(uuid, timestamptz) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 3. RPC: COMPLETE OWN JOB — jeder Zugewiesene darf abschliessen
+-- ---------------------------------------------------------
+-- Gleiche Erweiterung wie oben, plus completed_by.
+--
+-- BEWUSST UNVERAENDERT: das Abschliessen eines noch NICHT gestarteten
+-- Auftrags (status = 'open') scheitert weiterhin sichtbar. Fachlich ist das
+-- hier sogar wichtiger als vorher — bei einer geteilten Zeitschiene gibt es
+-- ohne Start keine Startzeit, und ein stillschweigender Erfolg wuerde einen
+-- Auftrag ohne Dauer als abgeschlossen fuehren. Der Mitarbeiter, der Start
+-- vergessen hat, drueckt in diesem Fall zuerst Start (die App zeigt genau
+-- diesen Button, weil der Auftrag fuer alle noch 'open' ist).
+create or replace function public.complete_own_job(
+  job_id_input uuid,
+  completed_at_input timestamptz default now()
+)
+returns timestamptz
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_row  public.jobs%rowtype;
+  existing_row public.jobs%rowtype;
+  emp_name     text;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  update public.jobs
+  set
+    status       = 'completed',
+    completed_at = completed_at_input,
+    completed_by = auth.uid()
+  where id = job_id_input
+    and company_id = public.current_user_company_id()
+    and public.current_user_role() = 'employee'
+    and job_type = 'single'      -- Parent-Recurring-Regeln nicht abschliessbar
+    and status = 'in_progress'   -- NUR der echte Uebergang in_progress -> completed
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    )
+  returning * into updated_row;
+
+  if found then
+    select full_name into emp_name from public.profiles where id = auth.uid();
+
+    insert into public.notification_outbox (
+      company_id, job_id, event_type, job_status,
+      employee_id, employee_name, customer_name, service_name
+    )
+    values (
+      updated_row.company_id, updated_row.id, 'job_completed', 'completed',
+      auth.uid(), emp_name, updated_row.customer_name, updated_row.service_name
+    )
+    on conflict (job_id, event_type) do nothing;
+
+    return completed_at_input;
+  end if;
+
+  select * into existing_row
+  from public.jobs
+  where id = job_id_input
+    and company_id = public.current_user_company_id()
+    and public.current_user_role() = 'employee'
+    and job_type = 'single'
+    and (
+      assigned_to = auth.uid()
+      or public.is_assigned_to_job(job_id_input)
+    );
+
+  if not found then
+    raise exception 'Job not found or not allowed';
+  end if;
+
+  -- Bereits abgeschlossen -> idempotenter No-Op (retry-sicher), kein Event.
+  -- Deckt auch den Wettlauf zweier Zugewiesener ab: der Zweite erhaelt die
+  -- GETEILTE Endzeit des Ersten.
+  if existing_row.status = 'completed' then
+    return coalesce(existing_row.completed_at, completed_at_input);
+  end if;
+
+  -- Zugewiesener Job, aber (noch) nicht in_progress -> nicht als Erfolg
+  -- vortaeuschen, sichtbar scheitern.
+  raise exception 'Job not in progress (cannot complete)';
+end;
+$$;
+
+comment on function public.complete_own_job(uuid, timestamptz) is
+'Setzt einen laufenden Auftrag der eigenen Firma auf completed. Berechtigt ist '
+'JEDER ueber job_assignments Zugewiesene sowie (Bestand) der Legacy-Primaer; '
+'nur role=employee, nur job_type=single. Schreibt completed_at/completed_by und '
+'ein job_completed-Outbox-Event genau beim echten Uebergang in_progress -> '
+'completed; bereits abgeschlossen ist ein idempotenter No-Op. Ein noch nicht '
+'gestarteter Auftrag wird abgelehnt (ohne Start gibt es keine Dauer). Fasst '
+'job_assignments nicht an (keine Anwesenheitserfassung).';
+
+grant execute on function public.complete_own_job(uuid, timestamptz) to authenticated;
+
+
+-- =========================================================
+-- SICHERHEITSBILANZ
+-- =========================================================
+-- HINZUGEKOMMEN ist genau ein Recht: ein Mitarbeiter, der ueber
+-- job_assignments einem Auftrag SEINER EIGENEN FIRMA zugewiesen ist, darf
+-- diesen Auftrag starten und abschliessen. Nicht mehr.
+--
+-- UNVERAENDERT fail-closed bleiben:
+--   * role = 'employee' — Admins aendern den Status nie ueber diese RPCs.
+--   * Firmengrenze — doppelt: current_user_company_id() in der RPC UND
+--     die Firmenpruefung innerhalb von is_assigned_to_job().
+--   * Deaktivierte Konten — current_user_role() und
+--     current_user_company_id() liefern fuer is_active = false NULL
+--     (20260714000000); die WHERE-Klausel trifft dann nichts, und auch
+--     is_assigned_to_job() liefert false. Ein deaktivierter Mitarbeiter
+--     kann also nichts starten oder abschliessen, selbst wenn seine
+--     Zuweisungszeile noch existiert.
+--   * job_type = 'single' — Parent-Recurring-Regeln bleiben nicht
+--     ausfuehrbar (eigenstaendiges AND, siehe Abschnitt 2).
+--   * Nicht zugewiesene Mitarbeiter derselben Firma: beide Zweige der
+--     ODER-Klammer sind falsch -> "Job not found or not allowed". Der
+--     Auftrag ist fuer sie ohnehin per RLS unsichtbar.
+--   * KEINE neue Policy, KEIN neuer Grant, KEINE neue Funktion, KEIN
+--     zusaetzliches UPDATE-Recht auf public.jobs. Der Statuswechsel bleibt
+--     ausschliesslich ueber diese zwei Uebergaenge moeglich.
+--
+-- NEBENWIRKUNG DER NEUEN SPALTEN: Admins haben eine UPDATE-Policy auf
+-- public.jobs und koennten started_by/completed_by grundsaetzlich direkt
+-- schreiben — genau wie heute schon started_at/completed_at. Die App tut
+-- das nicht (updateJob sendet beide Spalten nicht). Admin-seitige
+-- Zeitkorrekturen sind ein eigenes Thema einer spaeteren Phase und werden
+-- hier nicht eroeffnet.
+
+
+-- =========================================================
+-- ROLLBACK
+-- =========================================================
+-- 1. Beide Funktionen in ihrer Fassung aus lib/schema.sql (Stand VOR dieser
+--    Migration) neu anlegen: den ODER-Zweig entfernen, wieder
+--    "and assigned_to = auth.uid()" verwenden und die Zuweisungen von
+--    started_by/completed_by aus dem UPDATE loeschen.
+-- 2. Optional die Spalten entfernen:
+--       drop index if exists public.idx_jobs_completed_by;
+--       drop index if exists public.idx_jobs_started_by;
+--       alter table public.jobs drop column if exists completed_by;
+--       alter table public.jobs drop column if exists started_by;
+--    REIHENFOLGE IST PFLICHT: erst Schritt 1, dann Schritt 2 — die
+--    zurueckgerollten Funktionen referenzieren die Spalten nicht mehr.
+--    Umgekehrt schlaegt jeder Start/Abschluss mit "column does not exist"
+--    fehl, weil PL/pgSQL-Koerper nicht abhaengigkeitsverfolgt sind
+--    (derselbe Rollback-Fallstrick wie in Phase 2 und 4 dokumentiert).
+--
+-- Datenverlust: nur die beiden Akteur-Spalten. started_at/completed_at,
+-- job_assignments und der Stundenzettel bleiben unberuehrt — nach dem
+-- Rollback darf lediglich wieder ausschliesslich der Legacy-Primaer
+-- starten und abschliessen.

--- a/supabase/tests/shared_job_time_multi_assignment.test.sql
+++ b/supabase/tests/shared_job_time_multi_assignment.test.sql
@@ -1,0 +1,772 @@
+-- =========================================================
+-- TEST: Shared Job Time — Start/Abschluss fuer JEDEN Zugewiesenen
+-- (Migration 20260731000000_shared_job_time_multi_assignment)
+-- =========================================================
+-- Prueft die drei Aussagen, auf denen die Phase steht:
+--
+--   1. JEDER ueber job_assignments Zugewiesene darf starten und
+--      abschliessen — auch der, der den jeweils anderen Uebergang nicht
+--      ausgeloest hat (geteilte Job-Uhr).
+--   2. Die Uhr gehoert dem AUFTRAG: startet Ahmed und schliesst Mohammed
+--      ab, ist die offizielle Dauer 08:00–10:00 und BEIDE erscheinen mit
+--      genau dieser Zeit im Stundenzettel-Praedikat.
+--   3. Es geht dabei KEINE Grenze auf: nicht Zugewiesene, fremde Firmen,
+--      deaktivierte Konten, Admins und Recurring-Parent-Regeln bleiben
+--      abgewiesen; ein zweiter Start/Abschluss aendert nichts.
+--
+-- Alle Zugriffe laufen als echte Rollen (SET ROLE + request.jwt.claims),
+-- also ueber denselben Pfad wie die App ueber PostgREST.
+--
+-- HINWEIS ZU „VERWEIGERT"-PFADEN: wie in job_assignments_rls.test.sql
+-- begruendet, stuerzt der lokale Supabase-Container bei einem
+-- permission-denied-Fehler ab. Dieser Test loest keine solchen Fehler aus —
+-- alle Ablehnungen kommen aus dem FUNKTIONSKOERPER der beiden RPCs
+-- (RAISE EXCEPTION) bzw. aus RLS, nicht aus fehlenden Privilegien.
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende, keine
+-- Produktionsdaten. Ausfuehren lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/shared_job_time_multi_assignment.test.sql
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = f1…1 | Firma B = f1…2
+-- Admin A   = f2…1
+-- AHMED     = f2…2  (Legacy-Primaer von J1)
+-- MOHAMMED  = f2…3  (nur ueber job_assignments an J1)
+-- FREMD A   = f2…4  (Firma A, J1 NICHT zugewiesen)
+-- Admin B   = f2…5 | Employee B = f2…6 (andere Firma)
+-- INAKTIV   = f2…7  (Firma A, zugewiesen, aber is_active = false)
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000001','authenticated','authenticated','s-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000002','authenticated','authenticated','s-ahmed@example.test','{"full_name":"Ahmed Start"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000003','authenticated','authenticated','s-mohammed@example.test','{"full_name":"Mohammed Ende"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000004','authenticated','authenticated','s-fremd@example.test','{"full_name":"Frida Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000005','authenticated','authenticated','s-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000006','authenticated','authenticated','s-b1@example.test','{"full_name":"Bea Fremdfirma"}'),
+    ('00000000-0000-0000-0000-000000000000','f2000000-0000-0000-0000-000000000007','authenticated','authenticated','s-inaktiv@example.test','{"full_name":"Ines Inaktiv"}');
+end $$;
+
+-- Der auth-Trigger handle_new_user ist in der lokalen Baseline nicht
+-- enthalten — Profile werden deshalb explizit angelegt.
+insert into public.profiles (id, full_name) values
+  ('f2000000-0000-0000-0000-000000000001','Admin A'),
+  ('f2000000-0000-0000-0000-000000000002','Ahmed Start'),
+  ('f2000000-0000-0000-0000-000000000003','Mohammed Ende'),
+  ('f2000000-0000-0000-0000-000000000004','Frida Fremd'),
+  ('f2000000-0000-0000-0000-000000000005','Admin B'),
+  ('f2000000-0000-0000-0000-000000000006','Bea Fremdfirma'),
+  ('f2000000-0000-0000-0000-000000000007','Ines Inaktiv')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('f1000000-0000-0000-0000-000000000001','Shared Firma A','shared-firma-a-test'),
+  ('f1000000-0000-0000-0000-000000000002','Shared Firma B','shared-firma-b-test');
+
+update public.profiles set company_id='f1000000-0000-0000-0000-000000000001', role='admin',    is_active=true where id='f2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='f1000000-0000-0000-0000-000000000001', role='employee', is_active=true where id in
+  ('f2000000-0000-0000-0000-000000000002','f2000000-0000-0000-0000-000000000003','f2000000-0000-0000-0000-000000000004','f2000000-0000-0000-0000-000000000007');
+update public.profiles set company_id='f1000000-0000-0000-0000-000000000002', role='admin',    is_active=true where id='f2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='f1000000-0000-0000-0000-000000000002', role='employee', is_active=true where id='f2000000-0000-0000-0000-000000000006';
+
+-- Auftraege (alle Firma A, ausser J5):
+--   J1 = single, {AHMED, MOHAMMED}      -> Hauptszenario (A startet, B schliesst ab)
+--   J2 = single, {MOHAMMED, AHMED}      -> Gegenrichtung (Szenario 2)
+--   J3 = RECURRING-PARENT, {MOHAMMED}   -> darf NIE startbar sein
+--   J4 = single, NUR Legacy-Zeiger      -> Bestandsfall ohne Zuweisungszeile
+--   J5 = single, Firma B, {Employee B}  -> Firmengrenze
+--   J6 = single, {INAKTIV}              -> deaktiviertes Konto
+insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                         location_address, status, job_type, date, start_time, recurring_days,
+                         is_active, created_at, updated_at, parent_job_id) values
+  ('f4000000-0000-0000-0000-000000000001','f1000000-0000-0000-0000-000000000001',null,'f2000000-0000-0000-0000-000000000001','K1','S1','O1','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('f4000000-0000-0000-0000-000000000002','f1000000-0000-0000-0000-000000000001',null,'f2000000-0000-0000-0000-000000000001','K2','S2','O2','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('f4000000-0000-0000-0000-000000000003','f1000000-0000-0000-0000-000000000001',null,'f2000000-0000-0000-0000-000000000001','K3','S3','O3','open','recurring',null,'08:00',array['mon'],true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('f4000000-0000-0000-0000-000000000004','f1000000-0000-0000-0000-000000000001',null,'f2000000-0000-0000-0000-000000000001','K4','S4','O4','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('f4000000-0000-0000-0000-000000000005','f1000000-0000-0000-0000-000000000002',null,'f2000000-0000-0000-0000-000000000005','K5','S5','O5','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('f4000000-0000-0000-0000-000000000006','f1000000-0000-0000-0000-000000000001',null,'f2000000-0000-0000-0000-000000000001','K6','S6','O6','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null);
+
+create temporary table _r (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+
+-- =========================================================
+-- Ausgangslage herstellen
+-- =========================================================
+-- Der Legacy-Zeiger muss DETERMINISTISCH stehen, sonst ist "sekundaer"
+-- nicht nachweisbar. Phase 2 behaelt einen gedeckten Zeiger bei (Regel 1
+-- von compat_primary_assignee) — also erst den gewuenschten Primaer allein
+-- setzen, dann den Zweiten ergaenzen.
+--   J1: Primaer AHMED,    dann MOHAMMED  -> MOHAMMED ist der sekundaere
+--   J2: Primaer MOHAMMED, dann AHMED     -> AHMED    ist der sekundaere
+do $$
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000001',
+    array['f2000000-0000-0000-0000-000000000002']::uuid[]);
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000001',
+    array['f2000000-0000-0000-0000-000000000002','f2000000-0000-0000-0000-000000000003']::uuid[]);
+
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000002',
+    array['f2000000-0000-0000-0000-000000000003']::uuid[]);
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000002',
+    array['f2000000-0000-0000-0000-000000000003','f2000000-0000-0000-0000-000000000002']::uuid[]);
+
+  -- Recurring-PARENT traegt eine Zuweisung als Vorlage (Phase 4).
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000003',
+    array['f2000000-0000-0000-0000-000000000003']::uuid[]);
+
+  -- Noch AKTIVES Konto zuweisen — der Guard enforce_active_assignment
+  -- laesst keine Zuweisung an ein inaktives Profil zu. Deaktiviert wird
+  -- erst danach (unten), was fachlich exakt dem Realfall entspricht.
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000006',
+    array['f2000000-0000-0000-0000-000000000007']::uuid[]);
+
+  execute 'reset role';
+end $$;
+
+-- Fremdfirmen-Auftrag J5 direkt verdrahten (ein zweiter Rollenwechsel als
+-- Admin B braechte keinen Erkenntnisgewinn).
+insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+values ('f4000000-0000-0000-0000-000000000005','f2000000-0000-0000-0000-000000000006','Bea Fremdfirma');
+
+-- J4: BESTANDSFALL "nur Legacy-Zeiger, keine Zuweisungszeile".
+-- Genau diese Konstellation existiert in Produktion (der Phase-1-Backfill
+-- hat nicht-konforme Zeilen bewusst erhalten) und ist der Grund, warum der
+-- ODER-Zweig "assigned_to = auth.uid()" in beiden RPCs stehen bleibt.
+--
+-- Sie laesst sich NICHT durch ein normales UPDATE herstellen: die
+-- Kompatibilitaets-Trigger aus Phase 2/4.1 spiegeln jeden Legacy-Schreib-
+-- vorgang sofort in job_assignments (Richtung A) und leiten umgekehrt den
+-- Zeiger aus der Menge ab (Richtung B). Fuer die Dauer des Fixtures werden
+-- beide Richtungen deshalb stillgelegt und danach wieder aktiviert.
+alter table public.jobs            disable trigger compat_sync_assignments_from_legacy_upd;
+alter table public.job_assignments disable trigger compat_sync_legacy_from_assignments_trg;
+
+update public.jobs set assigned_to='f2000000-0000-0000-0000-000000000002'
+where id='f4000000-0000-0000-0000-000000000004';
+
+alter table public.jobs            enable trigger compat_sync_assignments_from_legacy_upd;
+alter table public.job_assignments enable trigger compat_sync_legacy_from_assignments_trg;
+
+-- INAKTIV wird jetzt deaktiviert — Zuweisung bleibt bestehen.
+update public.profiles set is_active=false where id='f2000000-0000-0000-0000-000000000007';
+
+
+-- CASE 0: Ausgangslage — Zeiger und Mengen sitzen wie beabsichtigt
+do $$
+declare v text;
+begin
+  select 'j1_legacy='||coalesce((select assigned_to::text from public.jobs where id='f4000000-0000-0000-0000-000000000001'),'NULL')
+       ||'/j1_anzahl='||(select count(*)::text from public.job_assignments where job_id='f4000000-0000-0000-0000-000000000001')
+       ||'/j4_legacy='||coalesce((select assigned_to::text from public.jobs where id='f4000000-0000-0000-0000-000000000004'),'NULL')
+       ||'/j4_anzahl='||(select count(*)::text from public.job_assignments where job_id='f4000000-0000-0000-0000-000000000004')
+    into v;
+  insert into _r values (0,'Ausgangslage: J1 Primaer=AHMED mit 2 Zuweisungen, J4 nur Legacy-Zeiger ohne Zuweisung',
+    'j1_legacy=f2000000-0000-0000-0000-000000000002/j1_anzahl=2/j4_legacy=f2000000-0000-0000-0000-000000000002/j4_anzahl=0', v);
+  raise notice 'CASE 0 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- A. SZENARIO 1 — Ahmed startet 08:00, Mohammed schliesst 10:00 ab
+-- =========================================================
+
+-- CASE 1: AHMED (Legacy-Primaer) startet. Setzt started_at UND started_by.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000001',
+                                 timestamptz '2026-07-31 08:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status
+       ||'/start='||coalesce(to_char(j.started_at at time zone 'UTC','HH24:MI'),'NULL')
+       ||'/start_by='||coalesce(j.started_by::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000001';
+
+  insert into _r values (1,'AHMED startet J1 -> in_progress, started_at + started_by gesetzt',
+    'OK/status=in_progress/start=08:00/start_by=f2000000-0000-0000-0000-000000000002', v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: MOHAMMED sieht den laufenden Auftrag und dieselbe Startzeit.
+-- (Die Anforderung "jeder Zugewiesene sieht sofort: Job in Arbeit".)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'status='||status||'/start='||to_char(started_at at time zone 'UTC','HH24:MI') into v
+  from public.jobs where id='f4000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (2,'MOHAMMED sieht J1 als laufend mit AHMEDs Startzeit',
+    'status=in_progress/start=08:00', v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: KERN DER PHASE — MOHAMMED (sekundaer, hat NICHT gestartet)
+-- schliesst ab. Vor der Migration: "Job not found or not allowed".
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000001',
+                                    timestamptz '2026-07-31 10:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status
+       ||'/ende='||coalesce(to_char(j.completed_at at time zone 'UTC','HH24:MI'),'NULL')
+       ||'/ende_by='||coalesce(j.completed_by::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000001';
+
+  insert into _r values (3,'MOHAMMED (sekundaer) schliesst J1 ab -> completed_at + completed_by gesetzt',
+    'OK/status=completed/ende=10:00/ende_by=f2000000-0000-0000-0000-000000000003', v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- CASE 4: DIE GETEILTE UHR — genau EINE Dauer, und beide Akteure stehen
+-- unterschiedlich in der Zeile. Kein Pro-Mitarbeiter-Timer entstanden.
+do $$
+declare v text;
+begin
+  select 'dauer_min='||(extract(epoch from (j.completed_at - j.started_at))/60)::int::text
+       ||'/verschiedene_akteure='||(j.started_by is distinct from j.completed_by)::text
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000001';
+  insert into _r values (4,'J1 hat GENAU EINE offizielle Dauer (120 Min) mit zwei verschiedenen Akteuren',
+    'dauer_min=120/verschiedene_akteure=true', v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- CASE 5: STUNDENZETTEL-PRAEDIKAT — beide Mitarbeiter erhalten 08:00–10:00.
+-- Exakt die Abfrage aus services/timesheets/timesheet.service.ts
+-- (job_assignments-Inner-Join, status=completed, job_type=single).
+-- Nachweis, dass PR #58 unveraendert weiterarbeitet: der Mitarbeiter, der
+-- Start NIE gedrueckt hat, bekommt dieselbe Zeit wie der Starter.
+do $$
+declare v text;
+begin
+  select string_agg(x.eintrag, ' | ' order by x.eintrag) into v
+  from (
+    select p.full_name||'='
+           ||to_char(j.started_at   at time zone 'UTC','HH24:MI')||'-'
+           ||to_char(j.completed_at at time zone 'UTC','HH24:MI') as eintrag
+    from public.jobs j
+    join public.job_assignments ja on ja.job_id = j.id
+    join public.profiles p         on p.id      = ja.employee_id
+    where j.id = 'f4000000-0000-0000-0000-000000000001'
+      and j.status   = 'completed'
+      and j.job_type = 'single'
+      and j.started_at   is not null
+      and j.completed_at is not null
+  ) x;
+  insert into _r values (5,'Stundenzettel: BEIDE Zugewiesenen erhalten die geteilte Zeit 08:00-10:00',
+    'Ahmed Start=08:00-10:00 | Mohammed Ende=08:00-10:00', v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- CASE 6: NIEMAND KANN ZWEIMAL ABSCHLIESSEN. AHMED versucht es nach
+-- MOHAMMED: idempotenter No-Op, MOHAMMEDs Endzeit und Akteur bleiben.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000001',
+                                    timestamptz '2026-07-31 23:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/ende='||to_char(j.completed_at at time zone 'UTC','HH24:MI')
+       ||'/ende_by='||coalesce(j.completed_by::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000001';
+
+  insert into _r values (6,'Zweiter Abschluss ist No-Op: Endzeit und Akteur bleiben bei MOHAMMED/10:00',
+    'OK/ende=10:00/ende_by=f2000000-0000-0000-0000-000000000003', v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: Genau EIN job_completed-Outbox-Event (keine Doppel-
+-- Benachrichtigung durch den zweiten Versuch).
+do $$
+declare v text;
+begin
+  select 'gestartet='||count(*) filter (where event_type='job_started')::text
+       ||'/abgeschlossen='||count(*) filter (where event_type='job_completed')::text
+       -- ORDER BY explizit: DISTINCT sortiert in der Praxis, garantiert ist
+       -- das aber nicht — ein Test darf nicht von Implementierungsdetails
+       -- der Aggregation abhaengen.
+       ||'/akteure='||coalesce(string_agg(distinct employee_name, ',' order by employee_name),'-')
+    into v
+  from public.notification_outbox
+  where job_id='f4000000-0000-0000-0000-000000000001';
+  insert into _r values (7,'Je Uebergang genau EIN Outbox-Event, jeweils mit dem tatsaechlichen Akteur',
+    'gestartet=1/abgeschlossen=1/akteure=Ahmed Start,Mohammed Ende', v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- B. SZENARIO 2 — Gegenrichtung: der sekundaere startet
+-- =========================================================
+
+-- CASE 8: An J2 ist MOHAMMED der Legacy-Primaer. AHMED (sekundaer) startet.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000002',
+                                 timestamptz '2026-07-31 09:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status||'/start_by='||coalesce(j.started_by::text,'NULL')
+       ||'/legacy='||coalesce(j.assigned_to::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000002';
+
+  insert into _r values (8,'Sekundaerer AHMED startet J2; der Legacy-Zeiger bleibt unveraendert bei MOHAMMED',
+    'OK/status=in_progress/start_by=f2000000-0000-0000-0000-000000000002/legacy=f2000000-0000-0000-0000-000000000003', v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- CASE 9: NIEMAND KANN ZWEIMAL STARTEN. MOHAMMED versucht es danach:
+-- No-Op, er erhaelt AHMEDs geteilte Startzeit zurueck (nicht die eigene).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    select 'rueckgabe='||to_char(
+             public.start_own_job('f4000000-0000-0000-0000-000000000002',
+                                  timestamptz '2026-07-31 11:30+00') at time zone 'UTC','HH24:MI')
+      into v;
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/start='||to_char(j.started_at at time zone 'UTC','HH24:MI')
+       ||'/start_by='||coalesce(j.started_by::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000002';
+
+  insert into _r values (9,'Zweiter Start ist No-Op und liefert die GETEILTE Startzeit des Ersten zurueck',
+    'rueckgabe=09:00/start=09:00/start_by=f2000000-0000-0000-0000-000000000002', v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- CASE 10: Abschluss durch den Primaer MOHAMMED funktioniert weiterhin
+-- (keine Regression fuer den bisher einzig Berechtigten).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000002',
+                                    timestamptz '2026-07-31 12:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status||'/dauer_min='||(extract(epoch from (j.completed_at - j.started_at))/60)::int::text
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000002';
+
+  insert into _r values (10,'Primaerer MOHAMMED schliesst J2 ab (geteilte Dauer 180 Min)',
+    'OK/status=completed/dauer_min=180', v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- C. SZENARIO 3 — nicht Zugewiesene bleiben aussen
+-- =========================================================
+
+-- CASE 11: FREMD A (Firma A, aber J6 nicht zugewiesen) kann nicht starten.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000006');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (11,'Nicht zugewiesener Mitarbeiter derselben Firma kann NICHT starten','ABGELEHNT',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: und auch nicht abschliessen (J2 laeuft/ist fertig, er ist nicht
+-- zugewiesen -> Ablehnung schon an der Berechtigung, nicht am Status).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (12,'Nicht zugewiesener Mitarbeiter kann NICHT abschliessen','ABGELEHNT',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- CASE 13: Mitarbeiter der FREMDEN Firma kann den Firma-A-Auftrag nicht
+-- starten (Firmengrenze, doppelt gesichert: RPC + is_assigned_to_job).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000006');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000006');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (13,'Mitarbeiter einer FREMDEN Firma kann nicht starten','ABGELEHNT',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+-- CASE 14: DEAKTIVIERTES Konto kann seinen zugewiesenen Auftrag nicht
+-- starten (current_user_role()/company_id sind NULL, is_assigned_to_job
+-- liefert false).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000007');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000006');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (14,'Deaktivierter Mitarbeiter kann seinen zugewiesenen Auftrag NICHT starten','ABGELEHNT',v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: der ADMIN der eigenen Firma kann ebenfalls nicht ueber die RPC
+-- starten (role='employee' bleibt Bedingung — Admins aendern den Status
+-- nie hierueber).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000006');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (15,'Admin kann nicht ueber start_own_job starten','ABGELEHNT',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: J6 ist nach allen Fehlversuchen unveraendert offen.
+do $$
+declare v text;
+begin
+  select 'status='||status
+       ||'/start='||coalesce(started_at::text,'NULL')
+       ||'/start_by='||coalesce(started_by::text,'NULL')
+    into v
+  from public.jobs where id='f4000000-0000-0000-0000-000000000006';
+  insert into _r values (16,'J6 bleibt nach allen abgelehnten Versuchen unberuehrt offen',
+    'status=open/start=NULL/start_by=NULL', v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- D. SZENARIO 4 — Recurring-Parent bleibt nicht ausfuehrbar
+-- =========================================================
+
+-- CASE 17: MOHAMMED ist der Parent-REGEL J3 zugewiesen (Vorlage, Phase 4).
+-- is_assigned_to_job() liefert dafuer true — job_type='single' steht
+-- deshalb bewusst AUSSERHALB der ODER-Klammer. Ohne das waere eine
+-- Regel ab jetzt startbar.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000003');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (17,'Zugewiesener kann eine RECURRING-PARENT-Regel NICHT starten','ABGELEHNT',v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: Gegenprobe, dass CASE 17 nicht an der Zuweisung scheiterte:
+-- is_assigned_to_job() bestaetigt fuer MOHAMMED die Parent-Regel.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select 'zugewiesen='||public.is_assigned_to_job('f4000000-0000-0000-0000-000000000003')::text into v;
+  execute 'reset role';
+  insert into _r values (18,'Gegenprobe: MOHAMMED IST der Parent-Regel zugewiesen (Ablehnung kam von job_type)',
+    'zugewiesen=true', v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: die Parent-Regel ist unveraendert offen geblieben.
+do $$
+declare v text;
+begin
+  select 'status='||status||'/start='||coalesce(started_at::text,'NULL') into v
+  from public.jobs where id='f4000000-0000-0000-0000-000000000003';
+  insert into _r values (19,'Parent-Regel J3 bleibt unberuehrt offen','status=open/start=NULL',v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- E. Bestandsfall: nur Legacy-Zeiger, keine Zuweisungszeile
+-- =========================================================
+
+-- CASE 20: AHMED darf J4 starten, obwohl KEINE job_assignments-Zeile
+-- existiert. Genau dafuer bleibt der Legacy-Zweig in der ODER-Klammer —
+-- ein Ersetzen statt Erweitern haette diesen Mitarbeitern den Start
+-- entzogen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000004',
+                                 timestamptz '2026-07-31 07:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status||'/start_by='||coalesce(j.started_by::text,'NULL')
+       ||'/anzahl_zuweisungen='||(select count(*)::text from public.job_assignments where job_id=j.id)
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000004';
+
+  insert into _r values (20,'Legacy-Primaer ohne Zuweisungszeile kann weiterhin starten (Bestandsschutz)',
+    'OK/status=in_progress/start_by=f2000000-0000-0000-0000-000000000002/anzahl_zuweisungen=0', v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: MOHAMMED darf J4 NICHT abschliessen — an diesem Auftrag ist er
+-- weder Primaer noch zugewiesen. Beide Zweige der Klammer sind falsch.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000004');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (21,'An einem Auftrag ohne eigene Zuweisung bleibt MOHAMMED abgewiesen','ABGELEHNT',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- F. Zustandsuebergaenge: kein Abschluss ohne Start
+-- =========================================================
+
+-- CASE 22: J6 ist offen. Ein zugewiesener Mitarbeiter darf NICHT
+-- abschliessen, ohne dass gestartet wurde — ohne Startzeit gaebe es keine
+-- Dauer, und ein stiller Erfolg wuerde einen Auftrag ohne Arbeitszeit als
+-- abgeschlossen fuehren. (Bewusst unveraendertes Bestandsverhalten.)
+-- Zuweisung dafuer auf den aktiven AHMED umstellen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('f4000000-0000-0000-0000-000000000006',
+    array['f2000000-0000-0000-0000-000000000002']::uuid[]);
+  execute 'reset role';
+
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('f4000000-0000-0000-0000-000000000006');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+
+  select v||'/status='||status||'/ende_by='||coalesce(completed_by::text,'NULL') into v
+  from public.jobs where id='f4000000-0000-0000-0000-000000000006';
+
+  insert into _r values (22,'Abschluss eines NICHT gestarteten Auftrags wird abgelehnt (kein completed_by)',
+    'ABGELEHNT/status=open/ende_by=NULL', v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: Neustart eines abgeschlossenen Auftrags aendert nichts (J1 ist
+-- completed). Wichtig, weil der Start-Zweig completed_at/completed_by
+-- nullen WUERDE, wenn er greifen koennte — die Statusbedingung 'open'
+-- verhindert genau das.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('f4000000-0000-0000-0000-000000000001',
+                                 timestamptz '2026-08-01 06:00+00');
+    v := 'OK(No-Op)';
+  exception when others then v := 'FEHLER: '||sqlerrm;
+  end;
+  execute 'reset role';
+
+  select v||'/status='||j.status
+       ||'/start='||to_char(j.started_at   at time zone 'UTC','HH24:MI')
+       ||'/ende='||to_char(j.completed_at at time zone 'UTC','HH24:MI')
+       ||'/ende_by='||coalesce(j.completed_by::text,'NULL')
+    into v
+  from public.jobs j where j.id='f4000000-0000-0000-0000-000000000001';
+
+  insert into _r values (23,'Start auf einem abgeschlossenen Auftrag ist No-Op und nullt den Abschluss NICHT',
+    'OK(No-Op)/status=completed/start=08:00/ende=10:00/ende_by=f2000000-0000-0000-0000-000000000003', v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- G. Was diese Phase ausdruecklich NICHT anfasst
+-- =========================================================
+
+-- CASE 24: job_assignments ist unberuehrt — keine Anwesenheitserfassung.
+-- attendance bleibt 'assigned', die Audit-Zeitstempel bleiben NULL, und
+-- counts_for_timesheet (generiert daraus) bleibt false. Der Stundenzettel
+-- filtert bewusst NICHT darauf (siehe PR #58 und CASE 5).
+do $$
+declare v text;
+begin
+  select 'attendance='||string_agg(distinct ja.attendance::text,',' order by ja.attendance::text)
+       ||'/emp_start_gesetzt='||count(*) filter (where ja.employee_started_at is not null)::text
+       ||'/emp_ende_gesetzt='||count(*) filter (where ja.employee_completed_at is not null)::text
+       ||'/counts='||string_agg(distinct ja.counts_for_timesheet::text,',' order by ja.counts_for_timesheet::text)
+    into v
+  from public.job_assignments ja
+  where ja.job_id in ('f4000000-0000-0000-0000-000000000001','f4000000-0000-0000-0000-000000000002');
+  insert into _r values (24,'KEINE Anwesenheitserfassung: attendance/Audit-Stempel/counts_for_timesheet unveraendert',
+    'attendance=assigned/emp_start_gesetzt=0/emp_ende_gesetzt=0/counts=false', v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: der Kommentar-Schreibpfad bleibt am Legacy-Primaer. MOHAMMED
+-- darf J1 abschliessen (CASE 3), aber weiterhin keinen Kommentar anlegen —
+-- diese INSERT-Policy ist NICHT Teil dieser Phase. Der Client gated das
+-- Eingabefeld entsprechend (isPrimaryAssignee), es entsteht also kein
+-- Button, der fehlschlaegt.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_comments (company_id, job_id, author_id, message)
+    values ('f1000000-0000-0000-0000-000000000001','f4000000-0000-0000-0000-000000000001',
+            'f2000000-0000-0000-0000-000000000003','Test');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (25,'Kommentar-INSERT bleibt fuer den Sekundaeren abgelehnt (bewusste Asymmetrie)','ABGELEHNT',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+-- CASE 26: Mitarbeiter haben weiterhin KEIN direktes UPDATE auf jobs — der
+-- Statuswechsel bleibt auf die zwei RPC-Uebergaenge beschraenkt. Geprueft
+-- ueber die Zeilenwirkung (die Employee-Policy erlaubt nur SELECT, ein
+-- UPDATE trifft daher 0 Zeilen).
+do $$
+declare betroffen int; v text;
+begin
+  perform pg_temp.act_as('f2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set customer_name='Gekapert'
+    where id='f4000000-0000-0000-0000-000000000001';
+    get diagnostics betroffen = row_count;
+    v := 'zeilen='||betroffen::text;
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+
+  select v||'/kunde='||customer_name into v
+  from public.jobs where id='f4000000-0000-0000-0000-000000000001';
+
+  insert into _r values (26,'Mitarbeiter kann jobs nicht direkt aendern (kein neues UPDATE-Recht)',
+    'zeilen=0/kunde=K1', v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _r order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _r where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'SHARED JOB TIME TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE 27 FAELLE PASS';
+end $$;
+
+rollback;

--- a/types/job.ts
+++ b/types/job.ts
@@ -58,6 +58,25 @@ export type Job = {
   startedAt?: string | null;
   completedAt?: string | null;
 
+  /**
+   * AKTEURE der beiden Statusübergänge (Phase 7, „Shared Job Time").
+   *
+   * WER gedrückt hat — NICHT, wem die Arbeitszeit gehört. Die offizielle
+   * Dauer (`completedAt - startedAt`) gilt für ALLE Zugewiesenen, auch für
+   * den, der Start nie gedrückt hat. Diese Felder sind daher reine
+   * Nachvollziehbarkeit und dürfen NIE als Abrechnungs- oder
+   * Berechtigungsgrundlage dienen.
+   *
+   * `null` bedeutet zweierlei und ist nicht unterscheidbar: der Übergang hat
+   * nie stattgefunden ODER das Konto des Akteurs wurde gelöscht
+   * (ON DELETE SET NULL). Die Anzeige lässt den Namen dann weg.
+   *
+   * Nur die ID — der Name wird über `assignees` aufgelöst (der Akteur ist
+   * zugewiesen), was eine zusätzliche Abfrage erspart.
+   */
+  startedBy?: string | null;
+  completedBy?: string | null;
+
   // ── Terminierung (single vs. recurring) ──
   // jobType "single": einmaliger Auftrag mit date + startTime.
   // jobType "recurring": wiederkehrend an recurringDays (Wochentage) + startTime.

--- a/utils/jobAssignees.ts
+++ b/utils/jobAssignees.ts
@@ -8,11 +8,16 @@ import type { Job, JobAssignee } from "@/types/job";
  * neu beantwortet werden. Job-Karte, Detail, Dashboard, Mitarbeiter-Detail,
  * Suche und Filter nutzen ausschließlich diese Funktionen.
  *
- * WICHTIG — Anzeige vs. Berechtigung: diese Helfer beantworten NUR, wer
- * angezeigt wird. Sie sind KEINE Grundlage für Aktions-Buttons. Start und
- * Abschluss laufen über start_own_job/complete_own_job, die serverseitig
- * weiterhin jobs.assigned_to = auth.uid() verlangen (Phase 7). Dafür gibt es
- * bewusst `isPrimaryAssignee`.
+ * WICHTIG — Anzeige vs. Berechtigung: die Formatier-Helfer beantworten NUR,
+ * wer angezeigt wird. Für Aktions-Buttons gibt es genau zwei Gates, die dem
+ * jeweiligen SERVER-Prädikat entsprechen müssen:
+ *
+ *   canRunJobActions()  → Start/Abschluss. Serverseitig erlauben
+ *                         start_own_job/complete_own_job seit Phase 7 die
+ *                         volle Zuweisungsmenge (ODER Legacy-Primär).
+ *   isPrimaryAssignee() → Kommentar schreiben, Foto-Upload, Ungelesen-Status.
+ *                         Deren INSERT-Policies verlangen weiterhin
+ *                         jobs.assigned_to = auth.uid().
  */
 
 export const UNASSIGNED_LABEL = "Nicht zugewiesen";
@@ -39,7 +44,9 @@ export function isUnassigned(job: Pick<Job, "assignees">): boolean {
 
 /**
  * true, wenn der Mitarbeiter dem Auftrag zugewiesen ist (egal an welcher
- * Stelle der Menge). Für ANZEIGE und FILTER — nicht für Aktions-Gating.
+ * Stelle der Menge). Für ANZEIGE und FILTER — und seit Phase 7 zusätzlich
+ * die Grundlage von `canRunJobActions` (Start/Abschluss). NICHT ausreichend
+ * für Kommentar-/Foto-Schreibrechte, dafür siehe `isPrimaryAssignee`.
  */
 export function isAssignedTo(
   job: Pick<Job, "assignees">,
@@ -52,11 +59,18 @@ export function isAssignedTo(
 /**
  * true, wenn der Mitarbeiter der LEGACY-PRIMÄR des Auftrags ist.
  *
- * Ausschließlich für das Aktions-Gating (Start/Abschluss/Foto-Upload/
- * Kommentar) gedacht: die zugehörigen RPCs und Schreib-Policies verlangen
- * serverseitig weiterhin jobs.assigned_to = auth.uid(). Würde die UI hier
- * die volle Menge nutzen, bekäme ein sekundär Zugewiesener einen Button,
- * der mit „Job not found or not allowed" fehlschlägt. Fällt mit Phase 7.
+ * NUR NOCH für die Schreibpfade, die serverseitig weiterhin
+ * jobs.assigned_to = auth.uid() verlangen:
+ *   * Kommentar schreiben  (Policy „employee insert comments on own jobs")
+ *   * Foto-Upload          (job_photos + storage.objects INSERT)
+ *   * Ungelesen-Status     (job_comment_reads INSERT/UPDATE)
+ *
+ * Würde die UI dort die volle Zuweisungsmenge nutzen, bekäme ein sekundär
+ * Zugewiesener einen Button, der mit 42501 bzw. „Job not found or not
+ * allowed" fehlschlägt.
+ *
+ * NICHT MEHR für Start/Abschluss: diese laufen seit Phase 7 über die
+ * Zuweisungsmenge — siehe `canRunJobActions`.
  */
 export function isPrimaryAssignee(
   job: Pick<Job, "employeeId">,
@@ -74,26 +88,35 @@ export function isPrimaryAssignee(
  * Employee-Übersicht, Kalender, Home, Detail) und eine falsch-positive
  * Antwort einen Button erzeugt, der serverseitig garantiert fehlschlägt.
  *
- * Drei Bedingungen:
+ * Diese Funktion spiegelt bewusst ZEICHENGENAU das Prädikat von
+ * start_own_job/complete_own_job (Migration 20260731000000):
+ *
  *  1. Rolle 'employee' — Admins ändern den Status nie über diese RPCs.
  *  2. job_type 'single' — Parent-Recurring-Regeln sind keine ausführbaren
- *     Termine.
- *  3. LEGACY-PRIMÄR (nicht die Zuweisungsmenge!) — start_own_job und
- *     complete_own_job verlangen weiterhin assigned_to = auth.uid().
- *     Seit Phase 5 sieht ein Mitarbeiter auch Aufträge, denen er nur
- *     sekundär zugewiesen ist; ohne Bedingung 3 bekäme er dort einen
- *     Button, der mit „Job not found or not allowed" endet.
+ *     Termine. Steht wie serverseitig AUSSERHALB der Oder-Verknüpfung:
+ *     Recurring-Parent-Regeln tragen seit Phase 4 selbst Zuweisungen.
+ *  3. Zugewiesen — entweder über die Zuweisungsmenge (`assignees`, der
+ *     Normalfall) ODER über den Legacy-Zeiger `employeeId`.
  *
- * Bedingung 3 fällt mit Phase 7, wenn die RPCs die Zuweisungsmenge kennen.
+ * ZUM LEGACY-ZWEIG IN (3): er ist kein Rest, sondern nötig. Es existieren
+ * Bestands-Aufträge mit `assigned_to`, für die keine job_assignments-Zeile
+ * angelegt wurde (der Phase-1-Backfill hat nicht-konforme Zeilen bewusst
+ * erhalten). Serverseitig darf dieser Mitarbeiter starten; ohne den Zweig
+ * würde die App ihm den Button vorenthalten. Fällt mit Phase 11.
+ *
+ * Die Bedingung „nur der Legacy-Primär" ist mit Phase 7 ENTFALLEN: die
+ * Job-Uhr gehört dem Auftrag, nicht einem einzelnen Mitarbeiter. Jeder
+ * Zugewiesene darf starten und abschließen; der erste Erfolg gewinnt, alle
+ * anderen sehen danach denselben Status.
  */
 export function canRunJobActions(
-  job: Pick<Job, "employeeId" | "jobType">,
+  job: Pick<Job, "employeeId" | "jobType" | "assignees">,
   role: string | null | undefined,
   employeeId: string | null | undefined,
 ): boolean {
   if (role !== "employee") return false;
   if (job.jobType !== "single") return false;
-  return isPrimaryAssignee(job, employeeId);
+  return isAssignedTo(job, employeeId) || isPrimaryAssignee(job, employeeId);
 }
 
 /**


### PR DESCRIPTION
## Ziel

Ein Auftrag kann mehrere Mitarbeiter tragen — aber **starten und abschließen** durfte bisher nur der Legacy-Primär `jobs.assigned_to`. Welcher der Zugewiesenen das ist, entscheidet `compat_primary_assignee()` und ist bei gleichzeitiger Zuweisung **arbiträr** (Tiebreak über die Zufalls-UUID, `20260726000000`). Im Beta-Test konnte deshalb einer von zwei zugewiesenen Mitarbeitern seinen Auftrag nicht starten.

**Die Job-Uhr gehört ab jetzt dem Auftrag, nicht einem Mitarbeiter.**

Ahmed startet 08:00 · Mohammed drückt Start nie · Mohammed schließt 10:00 ab → **beide** erhalten 08:00–10:00 im Stundenzettel.

---

## 1. Architektur (Stand vor diesem PR)

Der Auftrags-Lebenszyklus läuft über **fünf** Schichten, die alle bereits mehrfachzuweisungsfähig waren — bis auf die letzte:

| Schicht | Zustand vor diesem PR |
|---|---|
| **Daten** | `job_assignments` (n:m, Phase 1) ist die Zuweisungsmenge. `jobs.assigned_to` ist ein abgeleiteter Legacy-Zeiger, den die Kompatibilitäts-Trigger aus Phase 2/4.1 in beide Richtungen synchron halten. |
| **RLS lesen** | Seit `20260730000000` sehen **alle** Zugewiesenen Auftrag, Kommentare und Fotos: `assigned_to = auth.uid() OR is_assigned_to_job(id)`, mit `job_type='single'` als eigenständigem AND (Parent-Regeln tragen selbst Zuweisungen). |
| **RLS schreiben** | Kommentar-, Foto- und Ungelesen-INSERTs hängen weiterhin an `assigned_to = auth.uid()`. |
| **Statuswechsel** | `start_own_job` / `complete_own_job` — SECURITY DEFINER, weil Mitarbeiter **kein** UPDATE auf `jobs` haben. Beide prüften `assigned_to = auth.uid()` **hart im Funktionskörper**. |
| **Stundenzettel** | Seit PR #58 über `job_assignments!inner(employee_id)` — credited also schon **alle** Zugewiesenen mit der offiziellen Job-Dauer. |

Genau eine Stelle war die Bremse: der Statuswechsel. Die App gated ihre Buttons korrekt daran (`isPrimaryAssignee`), weil ein Button für sekundär Zugewiesene serverseitig mit „Job not found or not allowed" fehlgeschlagen wäre.

**Fachmodell (unverändert):** ein Auftrag hat genau **eine** offizielle Dauer, `completed_at - started_at`. Sie wird nirgends dupliziert.

---

## 2. Backend — Migration `20260731000000_shared_job_time_multi_assignment.sql`

> ⚠️ **Nicht angewandt.** Wie alle Schemaänderungen hier manuell im Supabase SQL Editor ausführen (CLAUDE.md). Vollständig idempotent.

### Warum eine Migration unvermeidbar ist

Es gibt keinen clientseitigen Weg: das Prädikat `assigned_to = auth.uid()` steht im **Funktionskörper** der beiden RPCs. Alternativen (alle im Migrations-Header ausführlich begründet):

| Alternative | Verworfen weil |
|---|---|
| Nur die App ändern | Button erscheint, scheitert serverseitig. Löst nichts. |
| Mitarbeitern UPDATE-Policy auf `jobs` geben | Größerer Eingriff, und eine Policy kann keine Spalten einschränken → Mitarbeiter könnten Kunde, Adresse, Terminierung, `started_at` überschreiben. |
| `assigned_to` beim Start auf den Handelnden umbiegen | **Datenverlust.** Ein Legacy-Schreibvorgang bedeutet seit `20260729000000` *Menge ersetzen* — der Start eines Mitarbeiters würde alle übrigen Zuweisungen löschen, also genau die Stundenzettel-Grundlage aus PR #58. |
| `attendance` / `employee_started_at` in `job_assignments` pflegen | Das **ist** Anwesenheitserfassung (ausdrücklich außer Scope) und hätte zwei Nebenwirkungen: es verändert `counts_for_timesheet` und entzieht die Zeile der Primär-Auswahl (`attendance='assigned'`). |

### Was die Migration tut

**Zwei neue Spalten** auf `public.jobs` — rein additiv, nullable, `ON DELETE SET NULL`:

```sql
started_by   uuid references public.profiles(id) on delete set null
completed_by uuid references public.profiles(id) on delete set null
```

Vorher war der Akteur *implizit* (es konnte nur `assigned_to` sein). Genau diese Implikation fällt hier weg: die geteilte Uhr schreibt einem Mitarbeiter Zeit zu, die ein Kollege gestartet hat — wer die Uhr gestellt hat, muss nachvollziehbar bleiben. `notification_outbox` trägt den Akteur auch, ist aber eine Versand-Warteschlange, kein Nachweis.

FK-Verhalten ist nicht verhandelbar: in diesem Repo hat `job_photos.uploaded_by` mit `NOT NULL` + `RESTRICT` schon einmal in Produktion die Kontolöschung blockiert (`20260722000000`/`…001`). Deshalb nullable + SET NULL, plus partielle Rückwärtsindizes, damit die Löschung nicht über einen Seq Scan läuft. Bewusst **keine** CHECK-Constraint gegen `started_at` — ein CHECK würde beim SET-NULL-UPDATE erneut geprüft und genau diese Blockade wiederholen; die Kopplung erzwingen die RPCs zum Schreibzeitpunkt.

**Beide RPCs** ändern sich in genau drei Punkten, alles andere bleibt Zeichen für Zeichen:

```diff
-    and assigned_to = auth.uid()
+    and (
+      assigned_to = auth.uid()                    -- Legacy-Primär (Bestand)
+      or public.is_assigned_to_job(job_id_input)  -- Zuweisungsmenge
+    )
```
plus `started_by = auth.uid()` bzw. `completed_by = auth.uid()` beim echten Übergang, plus `completed_by = null` im Rückwärts-Übergang von `start_own_job` (das `completed_at = null` dort gab es schon).

Drei Punkte, die dabei wichtig sind:

- **Echte Obermenge** — niemand verliert ein Recht. Der Legacy-Zweig bleibt, weil Bestandszeilen mit `assigned_to` ohne `job_assignments`-Zeile existieren (der Phase-1-Backfill hat 6 nicht-konforme Zeilen bewusst erhalten). Fällt erst mit Phase 11.
- **`job_type='single'` bleibt außerhalb der ODER-Klammer.** Recurring-Parent-Regeln tragen seit Phase 4 selbst Zuweisungen, und `is_assigned_to_job()` kennt `job_type` nicht — innerhalb der Klammer wäre eine Regel ab sofort startbar. Dieselbe Falle wie in Abschnitt (B) von `20260730000000`.
- **Derselbe Helfer wie die Lesepolicies** (`is_assigned_to_job`, SECURITY DEFINER, STABLE, prüft die Firma selbst, seit Phase 3 für `authenticated` ausführbar). Lese- und Aktionsrecht können damit nicht auseinanderlaufen; **kein neuer Grant, keine neue Funktion, keine neue Policy.**

**„Niemand kann zweimal starten"** ist keine App-Zusicherung, sondern die Statusbedingung im UPDATE: zwei gleichzeitige Starts konkurrieren um die Zeilensperre, der Zweite wertet seine WHERE-Klausel nach dem Commit des Ersten gegen die neue Zeilenversion aus (EvalPlanQual), trifft nichts und läuft in den No-Op-Zweig — er bekommt die **geteilte** Startzeit zurück, keinen Fehler (wichtig für Doppel-Tap und Offline-Retry). `started_at`, `started_by` und das Outbox-Event können nie überschrieben oder verdoppelt werden.

---

## 3. Frontend

- **`utils/jobAssignees.ts`** — `canRunJobActions()` gated jetzt über `isAssignedTo(assignees) || isPrimaryAssignee(employeeId)` und spiegelt damit zeichengenau das Server-Prädikat (inkl. `role`/`jobType` außerhalb der ODER-Verknüpfung). `isPrimaryAssignee()` bleibt — aber **nur noch** für Kommentar-, Foto- und Ungelesen-Schreibpfade.
- **`JobsListScreen`** hatte ein zweites, eigenes Gate (`isAdmin || !isPrimaryAssignee`) ohne `jobType`-Prüfung → nutzt jetzt dieselbe `canRunJobActions` wie Home, Übersicht, Kalender und Detail. Ein Gate statt zwei.
- **`JobDetailScreen`** — `canStart`/`canComplete` über `canRunJobActions`. Foto-/Kommentar-Gates bleiben unverändert, mit ausdrücklichem Kommentar zur Asymmetrie.
- **`EmployeeOverviewScreen`** — die „aktiver Job"-Abschlusskarte gehört jetzt jedem Zugewiesenen (vorher nur dem Primär).
- **`WorkedTimeCard`** nennt den Akteur (`von Ahmed`) — und zwar **nur, wenn es ein anderer war**; „von mir" wäre Rauschen. Bei Mehrfachzuweisung erklärt der Hinweis die geteilte Zeit. Der Name kommt aus `job.assignees` (der Akteur ist zugewiesen) — **keine** zusätzliche Abfrage.
- **`Job.startedBy`/`completedBy`** in Typ, `JOB_SELECT`, `mapJob`, Offline-Merge und den optimistischen Updates. Der Typ dokumentiert explizit: Nachvollziehbarkeit, **nie** Abrechnungs- oder Berechtigungsgrundlage.

**Stundenzettel: unverändert.** PR #58 filtert schon über `job_assignments` und liefert damit von sich aus das gewünschte Ergebnis (Testfall 5 sichert das ab). Bewusst **nicht** auf `counts_for_timesheet` umgestellt — nichts pflegt `attendance`, ein Filter darauf lieferte heute leere Stundenzettel.

**Benachrichtigungen: unverändert.** Beide RPCs schreiben ihr Outbox-Event wie bisher, mit dem *handelnden* Mitarbeiter. Vorher war das zwangsläufig der Primär, jetzt der tatsächliche Akteur — der Admin-Push wird genauer, nicht anders.

---

## 4. Security-Review

**Hinzugekommen ist genau ein Recht:** ein Mitarbeiter, der über `job_assignments` einem Auftrag **seiner eigenen Firma** zugewiesen ist, darf diesen starten und abschließen. Nicht mehr.

Unverändert fail-closed:

| Grenze | Mechanismus | Test |
|---|---|---|
| Nicht Zugewiesene (eigene Firma) | beide ODER-Zweige falsch → `Job not found or not allowed`; der Auftrag ist per RLS ohnehin unsichtbar | 11, 12, 21 |
| Fremde Firma | doppelt: `current_user_company_id()` in der RPC **und** die Firmenprüfung in `is_assigned_to_job()` | 13 |
| Deaktivierte Konten | `current_user_role()`/`current_user_company_id()` → NULL (`20260714000000`), `is_assigned_to_job()` → false | 14 |
| Admins | `role='employee'` bleibt Bedingung | 15 |
| Recurring-Parent-Regeln | `job_type='single'` als eigenständiges AND | 17, 18, 19 |
| Kein direktes UPDATE auf `jobs` | keine neue Policy, kein neuer Grant | 26 |
| Doppelter Start/Abschluss | Statusbedingung im UPDATE + Zeilensperre | 6, 9, 23 |

Zwei Dinge, die ich ausdrücklich benenne:

1. **Admins könnten `started_by`/`completed_by` direkt schreiben** — sie haben eine UPDATE-Policy auf `jobs`, genau wie heute schon für `started_at`/`completed_at`. Die App tut es nicht (`updateJob` sendet die Spalten nicht). Admin-Zeitkorrekturen sind ein eigenes Thema und werden hier nicht eröffnet.
2. **Die Besitzer-Bindung der Offline-Queue (PR #58) ist wichtiger geworden, nicht weniger.** Der Sonderfall „B ist demselben Auftrag zugewiesen", vor dem sie schützt, ist bei mehrfach zugewiesenen Aufträgen jetzt der Normalfall. Der Kommentar in `jobs.queue.ts` sagt das jetzt so.

---

## 5. Geänderte Dateien

**Backend**
- `supabase/migrations/20260731000000_shared_job_time_multi_assignment.sql` *(neu)*
- `supabase/tests/shared_job_time_multi_assignment.test.sql` *(neu, 27 Fälle)*
- `lib/schema.sql` — Referenz nachgezogen (Spalten, beide RPC-Körper, Kommentare)

**Frontend**
- `utils/jobAssignees.ts` — `canRunJobActions` erweitert, Rollen der beiden Gates dokumentiert
- `types/job.ts`, `services/jobs/jobs.service.ts` — `startedBy`/`completedBy`
- `context/JobContext.tsx`, `services/offline/jobs.merge.ts` — optimistische Akteure (online + offline)
- `services/offline/jobs.queue.ts` — Sicherheitsbegründung aktualisiert
- `features/jobs/JobsListScreen.tsx`, `features/jobs/JobDetailScreen.tsx` — Gating
- `features/jobs/components/WorkedTimeCard.tsx` — Akteur + Hinweis auf geteilte Zeit
- `features/home/EmployeeOverviewScreen.tsx`, `features/home/HomeScreen.tsx`, `features/jobs/EmployeeJobsCalendarScreen.tsx` — Kommentare
- `CLAUDE.md` — die Konvention „immer über `isPrimaryAssignee` gaten" war nach diesem PR falsch

---

## 6. Manuelle Test-Checkliste

**Voraussetzung:** Migration `20260731000000` im SQL Editor angewandt. Auftrag J mit **zwei** Mitarbeitern A und B, `job_type='single'`, heute fällig.

**Szenario 1 — A startet, B schließt ab (der Kern)**
- [ ] A und B sehen bei J je einen **Start**-Button (Detail + Liste + Übersicht + Kalender)
- [ ] A drückt Start → Status `in_progress`, Arbeitszeit-Karte läuft
- [ ] **B** (ohne App-Neustart, Realtime): Start-Button verschwindet, **Abschließen** erscheint, Startzeit ist A's Zeit, darunter „von A"
- [ ] B drückt Abschließen → `completed`, Endzeit B's Zeit
- [ ] **Stundenzettel A** (Admin → Mitarbeiter → Monat): J mit `08:00–10:00`
- [ ] **Stundenzettel B**: J mit **derselben** `08:00–10:00` — obwohl B nie Start gedrückt hat
- [ ] Admin erhält zwei Pushes: „gestartet" nennt A, „abgeschlossen" nennt B

**Szenario 2 — B startet zuerst (Gegenrichtung)**
- [ ] Neuer Auftrag, gleiche Zuweisung: B startet, A schließt ab → identisches Ergebnis
- [ ] A drückt Start, **nachdem** B gestartet hat → kein Fehler, Startzeit bleibt B's (kein Überschreiben)

**Szenario 3 — nicht zugewiesen**
- [ ] Mitarbeiter C (gleiche Firma, J nicht zugewiesen) sieht J überhaupt nicht
- [ ] Admin sieht J, aber **keine** Start-/Abschließen-Buttons
- [ ] Deaktivierter Mitarbeiter mit Zuweisung: Login wird gesperrt, keine Aktion möglich

**Szenario 4 — schon abgeschlossen**
- [ ] Bei `completed` zeigt J für **niemanden** einen Abschließen-Button
- [ ] Doppel-Tap auf Abschließen (schnell zweimal): kein Fehler, Endzeit und „von" bleiben unverändert
- [ ] Admin erhält **nicht** zwei „abgeschlossen"-Pushes

**Szenario 5 — Offline (Regression PR #58)**
- [ ] A offline: Start → Offline-Banner + Zähler, Karte zeigt optimistisch „läuft"
- [ ] A wieder online → Sync, Status/Startzeit/Akteur stimmen mit dem Server überein
- [ ] A offline Start **und** Abschließen, dann online → beide Aktionen in dieser Reihenfolge, Dauer korrekt
- [ ] **Geteiltes Gerät:** A offline eine Aktion erfassen, ausloggen, B einloggen und syncen → A's Aktion wird **nicht** ausgeführt und **nicht** gelöscht; B sieht A's gecachte Jobs nicht
- [ ] App-Kaltstart offline: gecachte Jobs erscheinen mit korrektem Status

**Recurring**
- [ ] Parent-Regel (Admin-Detail) hat **keine** Start-/Abschließen-Buttons
- [ ] Eine generierte Occurrence derselben Regel ist für jeden Zugewiesenen startbar

**Nicht-Regression**
- [ ] Sekundär Zugewiesener sieht Kommentare und Fotos, aber **kein** Eingabefeld / keinen Upload-Button (bewusste Asymmetrie, unverändert)
- [ ] Einzeln zugewiesener Auftrag verhält sich exakt wie vorher; kein „von mir" in der Zeit-Karte

**SQL-Suite** (27 Fälle, transaktional, keine Rückstände):
```
docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
  -v ON_ERROR_STOP=1 -f - < supabase/tests/shared_job_time_multi_assignment.test.sql
```

---

## 7. Bekannte Grenzen

1. **Die SQL-Suite ist noch nicht ausgeführt.** Auf diesem Rechner läuft kein Docker (`supabase start` nicht möglich), und ich habe sie bewusst **nicht** gegen Produktion laufen lassen: sie legt Fixdaten an und stellt für einen Fixture-Fall zwei Kompatibilitäts-Trigger kurz still (`ALTER TABLE … DISABLE TRIGGER` nimmt eine ACCESS EXCLUSIVE Lock auf `public.jobs`). Vor dem Merge sollte sie gegen Staging laufen — wie in Phase 3/4.
2. **Offline + geteilte Uhr:** startet A **offline** und schließt B **online** ab, scheitert B's Abschluss mit „Job not in progress" (serverseitig ist der Auftrag noch offen). Nach A's Sync funktioniert es. Bestandsverhalten des Queue-Modells, durch diesen PR erstmals erreichbar; die Aktion bleibt in der Queue und wird nicht verworfen.
3. **Kommentare, Fotos und der Ungelesen-Punkt bleiben am Legacy-Primär.** Deren INSERT-Policies gehören nicht zur Job-Uhr; sie zu erweitern wäre eine zweite, eigenständige Rechteausweitung (eigener PR). Client und Server sind konsistent — es entsteht kein Button, der fehlschlägt.
4. **Kein Namens-Schnappschuss für die Akteure.** Nach einer Kontolöschung zeigt die Karte nur noch den Zeitpunkt. Der belastbare Nachweis liegt in `job_assignments.employee_name_snapshot`; eine zweite Namenskopie wäre Redundanz.
5. **Keine Occurrence-Semantik** (bestehende, dokumentierte Schuld): `status`/`started_at`/`completed_at` gelten pro Recurring-**Regel**, nicht pro Tag. Dieser PR ändert daran nichts.
6. **Ausdrücklich nicht enthalten:** Anwesenheit, Einzel-Arbeitssitzungen, Payroll, Admin-Zeitkorrektur, Audit-Log, Ausschluss einzelner Mitarbeiter aus den Arbeitsstunden. `job_assignments` wird von diesem PR **nicht angefasst** (Testfall 24 sichert das ab).

---

## 8. Validierung

- `npx tsc --noEmit -p tsconfig.json` → **fehlerfrei**
- `npm run lint` (`expo lint`) → **fehlerfrei**
- `npx eslint .` (der volle Baum — `expo lint` prüft nur `app/` + `components/`) → **byte-identisch zu `main`**, keine neuen Findings. Die 29 vorhandenen Meldungen sind Bestand und wurden nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
