### PR TITLE
feat(auth): add branded HTML templates for invite/reset-password emails

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -238,10 +238,20 @@ otp_expiry = 3600
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+# Custom email templates (siehe supabase/templates/) — reine Präsentation,
+# keine Auth-Logik. content_path ist relativ zur Repo-Wurzel, nicht zu dieser
+# Datei. WICHTIG: Diese lokale Konfiguration wirkt nur gegen die lokale
+# Supabase-CLI-Instanz — das Projekt in Prod nutzt das im Supabase Dashboard
+# hinterlegte Template (Authentication → Email Templates), daher muss der
+# HTML-Inhalt zusätzlich dort eingefügt werden (siehe DEPLOY.md-Hinweis in
+# supabase/functions/create-employee/).
+[auth.email.template.invite]
+subject = "Deine Einladung zu TaskOps Manager"
+content_path = "./supabase/templates/invite.html"
+
+[auth.email.template.recovery]
+subject = "Passwort zurücksetzen – TaskOps Manager"
+content_path = "./supabase/templates/recovery.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]

--- a/supabase/functions/create-employee/DEPLOY.md
+++ b/supabase/functions/create-employee/DEPLOY.md
@@ -51,9 +51,17 @@ folglich nur in Dev-Client- oder Standalone-Builds, **nicht** in Expo Go.
 
 ## E-Mail-Template
 
-Nutzt Supabase's Standard-"Invite user"-Template. Für eigenes Branding:
-**Dashboard → Authentication → Email Templates → Invite user** — reiner
-Dashboard-Schritt, nicht Teil dieses Repos.
+Eigenes Branding liegt als HTML in `supabase/templates/invite.html` (Invite)
+und `supabase/templates/recovery.html` (Passwort-Reset) im Repo und ist über
+`config.toml` (`[auth.email.template.invite]` / `[auth.email.template.recovery]`)
+für die **lokale** Supabase-CLI-Instanz aktiv.
+
+**Für Prod wirkt das nicht automatisch** — das gehostete Projekt liest seine
+Mail-Templates aus dem Dashboard, nicht aus `config.toml`. Der HTML-Inhalt
+der beiden Dateien muss daher manuell eingefügt werden unter:
+**Dashboard → Authentication → Email Templates → Invite user** bzw.
+**→ Reset Password**. Bei Änderungen an den Templates im Repo diesen Schritt
+wiederholen, sonst laufen Repo und Prod auseinander.
 
 ## Sicherheit
 

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="de" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>Einladung zu TaskOps Manager</title>
+<!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<style>
+  table { border-collapse: collapse; }
+  td, th, p, h1 { font-family: Arial, sans-serif; }
+</style>
+<![endif]-->
+<style>
+  body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+  table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+  img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+  body { margin: 0; padding: 0; width: 100% !important; height: 100% !important; }
+  a { color: #2563EB; }
+
+  @media only screen and (max-width: 620px) {
+    .email-wrapper { width: 100% !important; max-width: 100% !important; }
+    .email-card { border-radius: 0 !important; }
+    .content-padding { padding: 32px 24px !important; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .body-bg { background-color: #0B1326 !important; }
+    .email-card { background-color: #131B2E !important; box-shadow: none !important; }
+    .heading-text { color: #DAE2FD !important; }
+    .body-text { color: #C2C6D6 !important; }
+    .muted-text { color: #8C909F !important; }
+    .divider { border-color: #424754 !important; }
+  }
+  [data-ogsc] .body-bg { background-color: #0B1326 !important; }
+  [data-ogsc] .email-card { background-color: #131B2E !important; }
+  [data-ogsc] .heading-text { color: #DAE2FD !important; }
+  [data-ogsc] .body-text { color: #C2C6D6 !important; }
+  [data-ogsc] .muted-text { color: #8C909F !important; }
+</style>
+</head>
+<body class="body-bg" style="margin:0; padding:0; background-color:#F0F2F5; -webkit-font-smoothing:antialiased;">
+
+  <!-- Preheader: controls the inbox preview snippet, hidden in the body -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; mso-hide:all; font-size:1px; line-height:1px; color:#F0F2F5;">
+    Aktiviere dein Konto bei TaskOps Manager und lege dein Passwort fest.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="body-bg" style="background-color:#F0F2F5;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" class="email-wrapper" style="width:600px; max-width:600px;">
+
+          <!-- Logo / Wordmark -->
+          <!-- Placeholder: replace this table-based "T" badge with a hosted
+               logo image once available, e.g.
+               <img src="https://YOUR_CDN/logo.png" width="32" height="32"
+                    alt="TaskOps Manager" style="display:block;border:0;"> -->
+          <tr>
+            <td align="center" style="padding: 0 0 24px 0;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="vertical-align:middle; padding-right:10px;">
+                    <table role="presentation" width="32" height="32" cellpadding="0" cellspacing="0" border="0" style="width:32px; height:32px; background-color:#2563EB; border-radius:8px;">
+                      <tr>
+                        <td align="center" valign="middle" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:16px; line-height:32px; color:#FFFFFF; font-weight:700;">T</td>
+                      </tr>
+                    </table>
+                  </td>
+                  <td style="vertical-align:middle;">
+                    <span class="heading-text" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:17px; font-weight:700; color:#0F172A;">TaskOps Manager</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td class="email-card" style="background-color:#FFFFFF; border-radius:16px; box-shadow:0 1px 3px rgba(15,23,42,0.06);">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td class="content-padding" style="padding: 48px 48px 40px 48px;">
+
+                    <h1 class="heading-text" style="margin:0 0 16px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:22px; line-height:30px; font-weight:700; color:#0F172A;">
+                      Du wurdest eingeladen
+                    </h1>
+
+                    <p class="body-text" style="margin:0 0 16px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; line-height:24px; color:#475569;">
+                      Hallo{{ if .Data.full_name }} {{ .Data.full_name }}{{ end }},
+                    </p>
+
+                    <p class="body-text" style="margin:0 0 32px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; line-height:24px; color:#475569;">
+                      dein Unternehmen nutzt <strong>TaskOps&nbsp;Manager</strong>, um Reinigungseinsätze und Teams zu organisieren. Du wurdest als Mitarbeiter eingeladen — aktiviere jetzt dein Konto, um loszulegen.
+                    </p>
+
+                    <!-- CTA Button (bulletproof: VML rounded button for Outlook, styled <a> for all other clients) -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="margin: 0 0 32px 0;">
+                      <tr>
+                        <td>
+                          <!--[if mso]>
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:240px;" arcsize="20%" stroke="f" fillcolor="#2563EB">
+                          <w:anchorlock/>
+                          <center style="color:#FFFFFF;font-family:Arial,sans-serif;font-size:15px;font-weight:bold;">Konto aktivieren</center>
+                          </v:roundrect>
+                          <![endif]-->
+                          <!--[if !mso]><!-->
+                          <a href="{{ .ConfirmationURL }}" target="_blank" style="background-color:#2563EB; border-radius:10px; color:#FFFFFF; display:inline-block; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; font-weight:600; line-height:48px; text-align:center; text-decoration:none; width:240px; -webkit-text-size-adjust:none;">Konto aktivieren</a>
+                          <!--<![endif]-->
+                        </td>
+                      </tr>
+                    </table>
+
+                    <p class="body-text" style="margin:0 0 12px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:14px; line-height:22px; color:#475569;">
+                      Beim Aktivieren legst du dein eigenes Passwort fest — nur du kennst es.
+                    </p>
+
+                    <p class="muted-text" style="margin:0 0 32px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:13px; line-height:20px; color:#94A3B8;">
+                      Aus Sicherheitsgründen ist dieser Link nur für eine begrenzte Zeit gültig. Ist er abgelaufen, kann dich dein Administrator jederzeit erneut einladen.
+                    </p>
+
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td class="divider" style="border-top:1px solid #CBD5E1; font-size:1px; line-height:1px;">&nbsp;</td>
+                      </tr>
+                    </table>
+
+                    <p class="muted-text" style="margin:24px 0 0 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; line-height:19px; color:#94A3B8;">
+                      Falls du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren — ohne deine Bestätigung wird kein Konto aktiviert.
+                    </p>
+
+                    <p class="muted-text" style="margin:16px 0 0 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; line-height:18px; color:#94A3B8; word-break:break-all;">
+                      Button funktioniert nicht? Link kopieren:<br>
+                      <a href="{{ .ConfirmationURL }}" style="color:#2563EB; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                    </p>
+
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding: 32px 24px 0 24px;">
+              <p class="muted-text" style="margin:0 0 4px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:13px; font-weight:600; color:#475569;">
+                TaskOps Manager
+              </p>
+              <p class="muted-text" style="margin:0 0 12px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; color:#94A3B8;">
+                Auftragsverwaltung für Reinigungsteams
+              </p>
+              <p class="muted-text" style="margin:0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:11px; color:#94A3B8;">
+                Diese E-Mail wurde an {{ .Email }} gesendet.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="de" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>Passwort zurücksetzen – TaskOps Manager</title>
+<!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<style>
+  table { border-collapse: collapse; }
+  td, th, p, h1 { font-family: Arial, sans-serif; }
+</style>
+<![endif]-->
+<style>
+  body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+  table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+  img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+  body { margin: 0; padding: 0; width: 100% !important; height: 100% !important; }
+  a { color: #2563EB; }
+
+  @media only screen and (max-width: 620px) {
+    .email-wrapper { width: 100% !important; max-width: 100% !important; }
+    .email-card { border-radius: 0 !important; }
+    .content-padding { padding: 32px 24px !important; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .body-bg { background-color: #0B1326 !important; }
+    .email-card { background-color: #131B2E !important; box-shadow: none !important; }
+    .heading-text { color: #DAE2FD !important; }
+    .body-text { color: #C2C6D6 !important; }
+    .muted-text { color: #8C909F !important; }
+    .divider { border-color: #424754 !important; }
+  }
+  [data-ogsc] .body-bg { background-color: #0B1326 !important; }
+  [data-ogsc] .email-card { background-color: #131B2E !important; }
+  [data-ogsc] .heading-text { color: #DAE2FD !important; }
+  [data-ogsc] .body-text { color: #C2C6D6 !important; }
+  [data-ogsc] .muted-text { color: #8C909F !important; }
+</style>
+</head>
+<body class="body-bg" style="margin:0; padding:0; background-color:#F0F2F5; -webkit-font-smoothing:antialiased;">
+
+  <!-- Preheader: controls the inbox preview snippet, hidden in the body -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; mso-hide:all; font-size:1px; line-height:1px; color:#F0F2F5;">
+    Setze dein Passwort für TaskOps Manager zurück.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="body-bg" style="background-color:#F0F2F5;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" class="email-wrapper" style="width:600px; max-width:600px;">
+
+          <!-- Logo / Wordmark -->
+          <!-- Placeholder: replace this table-based "T" badge with a hosted
+               logo image once available, e.g.
+               <img src="https://YOUR_CDN/logo.png" width="32" height="32"
+                    alt="TaskOps Manager" style="display:block;border:0;"> -->
+          <tr>
+            <td align="center" style="padding: 0 0 24px 0;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="vertical-align:middle; padding-right:10px;">
+                    <table role="presentation" width="32" height="32" cellpadding="0" cellspacing="0" border="0" style="width:32px; height:32px; background-color:#2563EB; border-radius:8px;">
+                      <tr>
+                        <td align="center" valign="middle" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:16px; line-height:32px; color:#FFFFFF; font-weight:700;">T</td>
+                      </tr>
+                    </table>
+                  </td>
+                  <td style="vertical-align:middle;">
+                    <span class="heading-text" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:17px; font-weight:700; color:#0F172A;">TaskOps Manager</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td class="email-card" style="background-color:#FFFFFF; border-radius:16px; box-shadow:0 1px 3px rgba(15,23,42,0.06);">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td class="content-padding" style="padding: 48px 48px 40px 48px;">
+
+                    <h1 class="heading-text" style="margin:0 0 16px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:22px; line-height:30px; font-weight:700; color:#0F172A;">
+                      Passwort zurücksetzen
+                    </h1>
+
+                    <p class="body-text" style="margin:0 0 16px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; line-height:24px; color:#475569;">
+                      Hallo,
+                    </p>
+
+                    <p class="body-text" style="margin:0 0 32px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; line-height:24px; color:#475569;">
+                      wir haben eine Anfrage erhalten, das Passwort für dein <strong>TaskOps&nbsp;Manager</strong>-Konto zurückzusetzen. Klicke auf den Button unten, um ein neues Passwort festzulegen.
+                    </p>
+
+                    <!-- CTA Button (bulletproof: VML rounded button for Outlook, styled <a> for all other clients) -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="margin: 0 0 32px 0;">
+                      <tr>
+                        <td>
+                          <!--[if mso]>
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:260px;" arcsize="20%" stroke="f" fillcolor="#2563EB">
+                          <w:anchorlock/>
+                          <center style="color:#FFFFFF;font-family:Arial,sans-serif;font-size:15px;font-weight:bold;">Passwort zurücksetzen</center>
+                          </v:roundrect>
+                          <![endif]-->
+                          <!--[if !mso]><!-->
+                          <a href="{{ .ConfirmationURL }}" target="_blank" style="background-color:#2563EB; border-radius:10px; color:#FFFFFF; display:inline-block; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; font-weight:600; line-height:48px; text-align:center; text-decoration:none; width:260px; -webkit-text-size-adjust:none;">Passwort zurücksetzen</a>
+                          <!--<![endif]-->
+                        </td>
+                      </tr>
+                    </table>
+
+                    <p class="muted-text" style="margin:0 0 32px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:13px; line-height:20px; color:#94A3B8;">
+                      Aus Sicherheitsgründen ist dieser Link nur für eine begrenzte Zeit gültig. Ist er abgelaufen, kannst du jederzeit einen neuen Link anfordern.
+                    </p>
+
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td class="divider" style="border-top:1px solid #CBD5E1; font-size:1px; line-height:1px;">&nbsp;</td>
+                      </tr>
+                    </table>
+
+                    <p class="muted-text" style="margin:24px 0 0 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; line-height:19px; color:#94A3B8;">
+                      Falls du keine Passwort-Zurücksetzung angefordert hast, kannst du diese E-Mail einfach ignorieren — dein Passwort bleibt unverändert.
+                    </p>
+
+                    <p class="muted-text" style="margin:16px 0 0 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; line-height:18px; color:#94A3B8; word-break:break-all;">
+                      Button funktioniert nicht? Link kopieren:<br>
+                      <a href="{{ .ConfirmationURL }}" style="color:#2563EB; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                    </p>
+
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding: 32px 24px 0 24px;">
+              <p class="muted-text" style="margin:0 0 4px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:13px; font-weight:600; color:#475569;">
+                TaskOps Manager
+              </p>
+              <p class="muted-text" style="margin:0 0 12px 0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:12px; color:#94A3B8;">
+                Auftragsverwaltung für Reinigungsteams
+              </p>
+              <p class="muted-text" style="margin:0; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:11px; color:#94A3B8;">
+                Diese E-Mail wurde an {{ .Email }} gesendet.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Recovers the branded email templates work that was designed, approved, and then stranded on `feature/employee-invite-system` (commit `87fec02`) after that branch's PR (#27) had already merged — so it never reached `main`, and its `config.toml` change only ever applied to the local Supabase CLI, never to production (Prod reads templates from the Dashboard, not the repo).

This PR rebuilds the two templates from scratch on top of current `main` — not a cherry-pick, not a merge of the old branch, no old Auth code revived. Only presentation/config/docs.

- `supabase/templates/invite.html` — "Du wurdest eingeladen" (employee invite)
- `supabase/templates/recovery.html` — "Passwort zurücksetzen" (password reset)
- `supabase/config.toml` — wires both templates for the local Supabase CLI via `[auth.email.template.invite]` / `[auth.email.template.recovery]`
- `supabase/functions/create-employee/DEPLOY.md` — documents that Prod needs the HTML manually pasted into the Dashboard

## What changed vs. the original (stranded) version

- Colors now pulled exactly from `constants/colors.ts` instead of a close-but-different generic slate palette:
  - brand/button/link `#1E88E5` → `#2563EB` (app's actual `primary`)
  - light bg `#F1F5F9` → `#F0F2F5`, body text `#334155` → `#475569` (`onSurfaceVariant`)
  - dark bg `#0F172A` → `#0B1326`, card `#1E293B` → `#131B2E`, heading `#F1F5F9` → `#DAE2FD`, body `#CBD5E1` → `#C2C6D6`, muted/divider updated to match `outline`/`outlineVariant`
- Footer tagline translated to German (`Auftragsverwaltung für Reinigungsteams`) — the old English "Cleaning Operations Platform" was inconsistent with the rest of the app's German UI copy.
- Verified `{{ .Data.full_name }}` is still populated today by `supabase/functions/create-employee/index.ts`, and `{{ .ConfirmationURL }}` / `{{ .Email }}` are still the correct Supabase Go-template vars — no stale variables.
- "TaskOps Manager" app name confirmed current (`app.json`).

## Intentionally NOT recovered (and why)

The rest of commit `87fec02` was unrelated Auth/UI wiring (a new `utils/authErrorMessages.ts`, and edits to `AcceptInviteScreen`, `ForgotPasswordScreen`, `LoginScreen`, `ResetPasswordScreen`, `useAuthLinkSession`, `ChangePasswordScreen`, `registerAdmin`, `setupCompanyForAdmin`, `createEmployee`, `resendInvite`). None of it is required for the templates to render or send — templates work purely through Supabase config + Dashboard, independent of client code — so per the "don't resurrect old Auth code blindly" instruction it was left out of scope.

## Verification

- Rendered both templates in-browser: light mode, dark mode (`prefers-color-scheme`), and mobile viewport (375px) — all match current brand palette, no overflow, CTA and footer legible in both themes.
- Outlook compatibility preserved: VML `<v:roundrect>` bulletproof button, `xmlns:v`/`xmlns:o`, MSO conditional comments, table-based bulletproof layout — unchanged from the original approved structure other than color values.
- `tidy -e` run on both files: only expected warnings (role="presentation", proprietary VML/MSO attributes, Go `{{ }}` template syntax read as "malformed URI") — no structural errors.

## Manual step required after merge (cannot be done by this PR)

Supabase Prod does **not** read `supabase/config.toml` — the HTML must be pasted manually into **Dashboard → Authentication → Email Templates → Invite user** and **→ Reset Password**. This is documented in `DEPLOY.md` and will be provided as ready-to-paste HTML separately.