### PR TITLE
feat(auth): friendly German error messages across auth flows

### DIFF
--- a/features/auth/AcceptInviteScreen.tsx
+++ b/features/auth/AcceptInviteScreen.tsx
@@ -10,6 +10,7 @@ import type { AppTheme } from "@/constants/theme";
 import { useAuthLinkSession } from "@/features/auth/useAuthLinkSession";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 import { validateNewPassword } from "@/utils/passwordValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -29,13 +30,16 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const DEFAULT_INVALID_MESSAGE =
-  "Diese Einladung ist ungültig oder abgelaufen. Bitte wende dich an deinen Administrator für eine neue Einladung.";
+  "Diese Einladung ist ungültig. Bitte wende dich an deinen Administrator für eine neue Einladung.";
+const EXPIRED_INVITE_MESSAGE =
+  "Diese Einladung ist abgelaufen. Bitte bitte deinen Administrator, dir eine neue Einladung zu senden.";
 
 export default function AcceptInviteScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { status, invalidMessage, recheck } = useAuthLinkSession(
     DEFAULT_INVALID_MESSAGE,
+    EXPIRED_INVITE_MESSAGE,
   );
 
   const [formSuccess, setFormSuccess] = useState(false);
@@ -60,7 +64,9 @@ export default function AcceptInviteScreen() {
       });
 
       if (error) {
-        setFormError(error.message || "Passwort konnte nicht gesetzt werden.");
+        setFormError(
+          toFriendlyAuthErrorMessage(error, "Passwort konnte nicht gesetzt werden."),
+        );
         return;
       }
 
@@ -79,10 +85,8 @@ export default function AcceptInviteScreen() {
       await supabase.auth.signOut().catch(() => {});
 
       setFormSuccess(true);
-    } catch {
-      setFormError(
-        "Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut.",
-      );
+    } catch (err) {
+      setFormError(toFriendlyAuthErrorMessage(err));
     } finally {
       setSubmitting(false);
     }

--- a/features/auth/ForgotPasswordScreen.tsx
+++ b/features/auth/ForgotPasswordScreen.tsx
@@ -5,6 +5,7 @@
 import { ErrorBanner, Input } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 import { Ionicons } from "@expo/vector-icons";
 import * as Linking from "expo-linking";
 import { router } from "expo-router";
@@ -59,13 +60,15 @@ export default function ForgotPasswordScreen() {
       );
 
       if (error) {
-        setFormError(error.message || "Reset fehlgeschlagen. Bitte versuche es erneut.");
+        setFormError(
+          toFriendlyAuthErrorMessage(error, "Reset fehlgeschlagen. Bitte versuche es erneut."),
+        );
         return;
       }
 
       setSuccess(true);
-    } catch {
-      setFormError("Ein unbekannter Fehler ist aufgetreten.");
+    } catch (err) {
+      setFormError(toFriendlyAuthErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/features/auth/LoginScreen.tsx
+++ b/features/auth/LoginScreen.tsx
@@ -6,6 +6,7 @@ import { ErrorBanner, PasswordInput, Input } from "@/components/ui";
 import { AuthBrand } from "@/features/auth/components/AuthBrand";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 import { router } from "expo-router";
 import React, { useMemo, useRef, useState } from "react";
 import {
@@ -73,13 +74,13 @@ export default function LoginScreen() {
         password,
       });
       if (error) {
-        setFormError("E-Mail oder Passwort ist falsch.");
+        setFormError(toFriendlyAuthErrorMessage(error, "E-Mail oder Passwort ist falsch."));
         return;
       }
       // Erfolgreich → index.tsx übernimmt die Weiterleitung
       router.replace("/");
-    } catch {
-      setFormError("Login fehlgeschlagen. Bitte erneut versuchen.");
+    } catch (err) {
+      setFormError(toFriendlyAuthErrorMessage(err, "Login fehlgeschlagen. Bitte erneut versuchen."));
     } finally {
       setLoading(false);
     }

--- a/features/auth/ResetPasswordScreen.tsx
+++ b/features/auth/ResetPasswordScreen.tsx
@@ -9,6 +9,7 @@ import type { AppTheme } from "@/constants/theme";
 import { useAuthLinkSession } from "@/features/auth/useAuthLinkSession";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 import { validateNewPassword } from "@/utils/passwordValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -27,7 +28,9 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const DEFAULT_INVALID_MESSAGE =
-  "Der Link ist ungültig oder abgelaufen. Bitte fordere einen neuen Link an.";
+  "Der Link ist ungültig. Bitte fordere einen neuen Link an.";
+const EXPIRED_RESET_MESSAGE =
+  "Der Link zum Zurücksetzen des Passworts ist abgelaufen. Bitte fordere einen neuen Link an.";
 
 export default function ResetPasswordScreen() {
   const theme = useAppTheme();
@@ -35,6 +38,7 @@ export default function ResetPasswordScreen() {
 
   const { status, invalidMessage, recheck } = useAuthLinkSession(
     DEFAULT_INVALID_MESSAGE,
+    EXPIRED_RESET_MESSAGE,
   );
 
   const [formSuccess, setFormSuccess] = useState(false);
@@ -59,7 +63,9 @@ export default function ResetPasswordScreen() {
       });
 
       if (error) {
-        setFormError(error.message || "Passwort konnte nicht gesetzt werden.");
+        setFormError(
+          toFriendlyAuthErrorMessage(error, "Passwort konnte nicht gesetzt werden."),
+        );
         return;
       }
 
@@ -69,10 +75,8 @@ export default function ResetPasswordScreen() {
       await supabase.auth.signOut().catch(() => {});
 
       setFormSuccess(true);
-    } catch {
-      setFormError(
-        "Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut.",
-      );
+    } catch (err) {
+      setFormError(toFriendlyAuthErrorMessage(err));
     } finally {
       setSubmitting(false);
     }

--- a/features/auth/useAuthLinkSession.ts
+++ b/features/auth/useAuthLinkSession.ts
@@ -22,6 +22,7 @@
 
 import { useAuthLinkUrl } from "@/features/auth/AuthLinkUrlProvider";
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthLinkErrorMessage } from "@/utils/authErrorMessages";
 import { useLocalSearchParams } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -104,7 +105,13 @@ function firstString(value: string | string[] | undefined): string {
   return value ?? "";
 }
 
-export function useAuthLinkSession(defaultInvalidMessage: string): {
+export function useAuthLinkSession(
+  defaultInvalidMessage: string,
+  // Eigene Meldung für den Fall, dass Supabase den Link explizit als
+  // abgelaufen kennzeichnet (error_code/error_description enthält
+  // "expired") — fehlt sie, wird defaultInvalidMessage auch dafür verwendet.
+  expiredMessage: string = defaultInvalidMessage,
+): {
   status: AuthLinkStatus;
   invalidMessage: string;
   /** Nochmals die Kaltstart-URL auswerten (z.B. wenn der Deep-Link verzögert ankam). */
@@ -183,11 +190,18 @@ export function useAuthLinkSession(defaultInvalidMessage: string): {
           recovery.errorCode ?? "?",
           recovery.errorDescription ?? "",
         );
+        // Supabase liefert error/error_description als englischen,
+        // technischen Text (z.B. "Email link is invalid or has expired") —
+        // NIE direkt anzeigen, sondern nur zur Unterscheidung
+        // ungültig/abgelaufen verwenden (siehe toFriendlyAuthLinkErrorMessage).
         finish(
           "invalid",
-          recovery.errorDescription
-            ? recovery.errorDescription.replace(/\+/g, " ")
-            : defaultInvalidMessage,
+          toFriendlyAuthLinkErrorMessage(
+            recovery.errorCode,
+            recovery.errorDescription?.replace(/\+/g, " "),
+            defaultInvalidMessage,
+            expiredMessage,
+          ),
         );
         return;
       }
@@ -233,7 +247,7 @@ export function useAuthLinkSession(defaultInvalidMessage: string): {
         finish("invalid", defaultInvalidMessage);
       }
     },
-    [finish, readySessionOrInvalid, defaultInvalidMessage],
+    [finish, readySessionOrInvalid, defaultInvalidMessage, expiredMessage],
   );
 
   // Unabhängiger Watchdog: steht der Screen nach RECHECK_TIMEOUT_MS immer noch

--- a/features/profile/ChangePasswordScreen.tsx
+++ b/features/profile/ChangePasswordScreen.tsx
@@ -1,6 +1,7 @@
 import { ErrorBanner, PasswordInput } from "@/components/ui";
 import { supabase } from "@/lib/supabase";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 import type { AppTheme } from "@/constants/theme";
 import { router } from "expo-router";
 import React, { useMemo, useState } from "react";
@@ -50,15 +51,17 @@ export default function ChangePasswordScreen() {
       });
 
       if (updateError) {
-        setError(updateError.message);
+        setError(
+          toFriendlyAuthErrorMessage(updateError, "Passwort konnte nicht geändert werden."),
+        );
         return;
       }
 
       Alert.alert("Gespeichert", "Dein Passwort wurde erfolgreich geändert.", [
         { text: "OK", onPress: () => router.back() },
       ]);
-    } catch {
-      setError("Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut.");
+    } catch (err) {
+      setError(toFriendlyAuthErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/services/auth/registerAdmin.ts
+++ b/services/auth/registerAdmin.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabase";
 import { setupCompanyForAdmin } from "@/services/company/setupCompanyForAdmin";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 
 type RegisterAdminInput = {
     fullName: string;
@@ -45,7 +46,7 @@ export async function registerAdmin({
     });
 
     if (error) {
-        throw new Error(error.message || "Registrierung fehlgeschlagen.");
+        throw new Error(toFriendlyAuthErrorMessage(error, "Registrierung fehlgeschlagen."));
     }
 
     if (!data.user) {

--- a/services/company/setupCompanyForAdmin.ts
+++ b/services/company/setupCompanyForAdmin.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabase";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 
 export async function setupCompanyForAdmin(companyName: string): Promise<string> {
   const trimmedName = companyName.trim();
@@ -13,7 +14,7 @@ export async function setupCompanyForAdmin(companyName: string): Promise<string>
 
   if (error) {
     console.error("setupCompanyForAdmin RPC error:", error);
-    throw new Error(error.message || "Firma konnte nicht erstellt werden.");
+    throw new Error(toFriendlyAuthErrorMessage(error, "Firma konnte nicht erstellt werden."));
   }
 
   if (typeof data !== "string" || !data) {

--- a/services/employees/createEmployee.ts
+++ b/services/employees/createEmployee.ts
@@ -1,9 +1,12 @@
 import { supabase } from "@/lib/supabase";
+import { toFriendlyEdgeFunctionErrorMessage } from "@/utils/authErrorMessages";
 
 type CreateEmployeeInput = {
   fullName: string;
   email: string;
 };
+
+const DEFAULT_ERROR_MESSAGE = "Einladung konnte nicht verschickt werden.";
 
 // Legt den Mitarbeiter an und verschickt eine Einladungs-Mail (Edge Function
 // create-employee, admin.inviteUserByEmail) — kein Passwort wird hier
@@ -18,11 +21,13 @@ export async function createEmployee(input: CreateEmployeeInput) {
   });
 
   if (error) {
-    throw new Error(error.message);
+    throw new Error(await toFriendlyEdgeFunctionErrorMessage(error, DEFAULT_ERROR_MESSAGE));
   }
 
   if (data?.error) {
-    throw new Error(data.error);
+    throw new Error(
+      typeof data.error === "string" ? data.error : DEFAULT_ERROR_MESSAGE,
+    );
   }
 
   return data;

--- a/services/employees/resendInvite.ts
+++ b/services/employees/resendInvite.ts
@@ -1,4 +1,7 @@
 import { supabase } from "@/lib/supabase";
+import { toFriendlyEdgeFunctionErrorMessage } from "@/utils/authErrorMessages";
+
+const DEFAULT_ERROR_MESSAGE = "Einladung konnte nicht erneut verschickt werden.";
 
 // Verschickt die Einladungs-Mail für einen Mitarbeiter erneut (Edge Function
 // resend-invite) — z.B. wenn der ursprüngliche Link abgelaufen ist. Schlägt
@@ -10,10 +13,12 @@ export async function resendInvite(employeeId: string): Promise<void> {
   });
 
   if (error) {
-    throw new Error(error.message);
+    throw new Error(await toFriendlyEdgeFunctionErrorMessage(error, DEFAULT_ERROR_MESSAGE));
   }
 
   if (data?.error) {
-    throw new Error(data.error);
+    throw new Error(
+      typeof data.error === "string" ? data.error : DEFAULT_ERROR_MESSAGE,
+    );
   }
 }

--- a/utils/authErrorMessages.ts
+++ b/utils/authErrorMessages.ts
@@ -1,0 +1,146 @@
+// utils/authErrorMessages.ts
+// Zentrale Übersetzung technischer Auth-/Edge-Function-/Netzwerk-Fehler in
+// nutzerfreundliche, deutsche Meldungen — für alle Auth-Screens (Login,
+// Registrierung, Firma einrichten, Passwort vergessen/ändern/zurücksetzen,
+// Einladungs-Annahme, Mitarbeiter einladen/erneut einladen). Nutzer sollen
+// nie rohe Supabase-/Netzwerk-/Edge-Function-Fehlertexte sehen (z.B. "Edge
+// Function returned a non-2xx status code", "Failed to fetch", "Invalid
+// JWT", "AuthApiError", "Unexpected error").
+
+import { isNetworkError } from "@/utils/networkError";
+import { FunctionsHttpError } from "@supabase/supabase-js";
+
+export const GENERIC_AUTH_ERROR_MESSAGE =
+  "Es ist ein unerwarteter Fehler aufgetreten.";
+export const OFFLINE_ERROR_MESSAGE =
+  "Keine Internetverbindung. Bitte überprüfe deine Verbindung und versuche es erneut.";
+export const SERVER_UNAVAILABLE_ERROR_MESSAGE =
+  "Der Server ist momentan nicht erreichbar. Bitte versuche es später erneut.";
+
+// Bekannte technische GoTrue-/Supabase-Auth-Fehlertexte → deutsche
+// Nutzer-Meldung. Reihenfolge relevant: spezifischere Muster zuerst.
+const KNOWN_ERROR_PATTERNS: readonly {
+  pattern: RegExp;
+  message: string;
+}[] = [
+  {
+    pattern: /invalid login credentials/i,
+    message: "E-Mail oder Passwort ist falsch.",
+  },
+  {
+    pattern: /email not confirmed/i,
+    message: "Bitte bestätige zuerst deine E-Mail-Adresse.",
+  },
+  {
+    pattern: /user already registered|already been registered/i,
+    message:
+      "Diese E-Mail wurde bereits eingeladen oder ist bereits registriert.",
+  },
+  {
+    pattern:
+      /invalid refresh token|refresh_token_not_found|invalid jwt|jwt expired|session.{0,15}(missing|not found)/i,
+    message: "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+  },
+  {
+    pattern: /rate limit|too many requests/i,
+    message: "Zu viele Versuche. Bitte warte kurz und versuche es erneut.",
+  },
+  {
+    pattern: /password.{0,25}(should be at least|too short|weak)/i,
+    message: "Das Passwort erfüllt nicht die Mindestanforderungen.",
+  },
+];
+
+// Technische Fehlertexte, die NIE roh angezeigt werden dürfen (auch nicht,
+// wenn sie aus einem geparsten Edge-Function-Body stammen) — landen immer
+// beim übergebenen Fallback statt beim Nutzer.
+const RAW_TECHNICAL_PATTERN =
+  /edge function returned a non-2xx|failed to send a request to the edge function|failed to fetch|network request failed|authapierror|functionshttperror|functionsfetcherror|functionsrelayerror|typeerror:|unexpected error/i;
+
+function extractMessage(err: unknown): string {
+  if (!err) return "";
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  const maybeMessage = (err as { message?: unknown })?.message;
+  return typeof maybeMessage === "string" ? maybeMessage : "";
+}
+
+// Übersetzt einen beliebigen Fehler (Supabase AuthError, geworfene Errors,
+// rohe Strings) in eine nutzerfreundliche deutsche Meldung. `fallback`
+// erlaubt jedem Aufrufer einen zum Kontext passenden Default (z.B. "E-Mail
+// oder Passwort ist falsch." beim Login), falls kein bekanntes Muster greift.
+export function toFriendlyAuthErrorMessage(
+  err: unknown,
+  fallback: string = GENERIC_AUTH_ERROR_MESSAGE,
+): string {
+  if (isNetworkError(err)) return OFFLINE_ERROR_MESSAGE;
+
+  const message = extractMessage(err);
+  if (!message) return fallback;
+
+  if (
+    /^5\d{2}\b|internal server error|service unavailable|bad gateway/i.test(
+      message,
+    )
+  ) {
+    return SERVER_UNAVAILABLE_ERROR_MESSAGE;
+  }
+
+  for (const { pattern, message: friendly } of KNOWN_ERROR_PATTERNS) {
+    if (pattern.test(message)) return friendly;
+  }
+
+  if (RAW_TECHNICAL_PATTERN.test(message)) return fallback;
+
+  // Meldungen, die der Server (RPC/Edge Function) bereits selbst
+  // verständlich auf Deutsch formuliert (z.B. "Nur Admins dürfen Mitarbeiter
+  // erstellen.", "Mitarbeiter nicht gefunden."), unverändert durchreichen
+  // statt sie durch den Fallback zu ersetzen.
+  return message;
+}
+
+// Liest den JSON-Body einer fehlgeschlagenen Edge-Function-Antwort aus.
+// supabase-js liefert bei JEDEM Nicht-2xx-Status nur "Edge Function returned
+// a non-2xx status code" in error.message — die eigentliche, von der
+// Function selbst formulierte Meldung (meist schon Deutsch, siehe z.B.
+// supabase/functions/create-employee/index.ts) steckt im Response-Body unter
+// error.context (siehe supabase-js-Doku für invoke()). Fällt auf
+// toFriendlyAuthErrorMessage zurück, wenn der Body nicht gelesen werden kann
+// (Netzwerkfehler, kaputtes JSON, o.ä.).
+export async function toFriendlyEdgeFunctionErrorMessage(
+  error: unknown,
+  fallback: string = GENERIC_AUTH_ERROR_MESSAGE,
+): Promise<string> {
+  if (isNetworkError(error)) return OFFLINE_ERROR_MESSAGE;
+
+  if (error instanceof FunctionsHttpError) {
+    try {
+      const body = await (error.context as Response).json();
+      const bodyMessage = typeof body?.error === "string" ? body.error : "";
+      if (bodyMessage) {
+        return toFriendlyAuthErrorMessage(bodyMessage, fallback);
+      }
+    } catch {
+      // Body nicht lesbar (kein/kaputtes JSON) → unten generisch zuordnen.
+    }
+  }
+
+  return toFriendlyAuthErrorMessage(error, fallback);
+}
+
+// ── Auth-Link-Fehler (Passwort-Reset & Einladungs-Annahme) ──────────────────
+// Supabase hängt bei ungültigen/abgelaufenen Links error/error_description
+// als Query-/Hash-Parameter an die Redirect-URL an (z.B. "Email link is
+// invalid or has expired") — dieser Text darf NIE direkt angezeigt werden.
+// Die aufrufenden Screens (AcceptInviteScreen, ResetPasswordScreen) liefern
+// je einen eigenen, bereits deutschen Text für "ungültig" bzw. "abgelaufen".
+export function toFriendlyAuthLinkErrorMessage(
+  errorCode: string | undefined,
+  errorDescription: string | undefined,
+  invalidMessage: string,
+  expiredMessage: string,
+): string {
+  const looksExpired =
+    /expired/i.test(errorCode ?? "") || /expired/i.test(errorDescription ?? "");
+  return looksExpired ? expiredMessage : invalidMessage;
+}


### PR DESCRIPTION
## Summary

Recovers the still-relevant part of the abandoned `feature/employee-invite-system` post-merge work (commit `87fec02`, mislabeled at the time as "remove sorting" — its actual content was this error-handling layer). Adapted onto current `main`; the email-template portion of that old commit is **not** included here since it's already superseded by PR #60.

Adds `utils/authErrorMessages.ts` as a single translation layer so raw Supabase/GoTrue/Edge-Function technical error strings never reach the UI, and wires it into every auth-adjacent screen and service:

- `toFriendlyAuthErrorMessage()` — network-aware; maps known GoTrue error strings (invalid credentials, unconfirmed email, rate limit, expired session, weak password) to German copy; recognizes and blocks known raw technical strings (e.g. "Edge Function returned a non-2xx status code", "AuthApiError"), falling back to a caller-supplied default instead of ever showing them.
- `toFriendlyEdgeFunctionErrorMessage()` — unwraps the real message from a `FunctionsHttpError`'s JSON body, since `supabase-js` otherwise only surfaces a generic non-2xx status message for every Edge Function failure.
- `toFriendlyAuthLinkErrorMessage()` — distinguishes an **expired** invite/reset link from an **invalid** one, via a new optional `expiredMessage` parameter on `useAuthLinkSession` (non-breaking — defaults to existing invalid-message behavior when omitted).

## Files changed

- `utils/authErrorMessages.ts` (new)
- `features/auth/LoginScreen.tsx`
- `features/auth/ForgotPasswordScreen.tsx`
- `features/auth/ResetPasswordScreen.tsx`
- `features/auth/AcceptInviteScreen.tsx`
- `features/auth/useAuthLinkSession.ts`
- `features/profile/ChangePasswordScreen.tsx`
- `services/auth/registerAdmin.ts`
- `services/company/setupCompanyForAdmin.ts`
- `services/employees/createEmployee.ts`
- `services/employees/resendInvite.ts`

**Intentionally not recovered:** `supabase/templates/invite.html`, `supabase/templates/recovery.html`, `supabase/config.toml`, `supabase/functions/create-employee/DEPLOY.md` — already shipped with a refined color palette in PR #60.

## Test plan

- [x] `npx tsc --noEmit` — clean, no errors
- [x] `npm run lint` (`expo lint`) — clean, no warnings/errors
- [x] No JS/TS test runner exists in this repo (only SQL tests under `supabase/tests/`, none touching this code path) — typecheck + lint are this repo's actual CI gate (PR #39)
- [x] Traced each requirement through the code: network errors → `OFFLINE_ERROR_MESSAGE`; invalid credentials → mapped friendly message, never raw; expired vs. invalid link → distinct messages via `useAuthLinkSession`'s new param; Edge Function non-2xx → body unwrapped via `toFriendlyEdgeFunctionErrorMessage`; unknown raw technical strings → blocked by `RAW_TECHNICAL_PATTERN`, falls back to caller default
- [ ] Manual on-device verification of each auth flow (not run in this session — no dev/preview environment available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)