### PR TITLE
feat(comments): show "Heute um HH:mm" for today's job comments

### DIFF
--- a/features/jobs/components/JobComments.tsx
+++ b/features/jobs/components/JobComments.tsx
@@ -14,6 +14,7 @@
 import { Button, Card, ErrorBanner, Input } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useJobComments } from "@/features/jobs/hooks/useJobComments";
+import { formatDateISO, isSameLocalDate } from "@/utils/date";
 import { isNetworkError } from "@/utils/networkError";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { Ionicons } from "@expo/vector-icons";
@@ -22,20 +23,29 @@ import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
 // ─────────────────────────────────────────────
 // Datums-/Zeit-Formatierung (analog JobDetailScreen)
+// Heutige Kommentare: kompaktes "Heute um HH:mm" statt vollem Datum.
+// Tagesvergleich über die zentralen Helfer aus utils/date.ts (formatDateISO +
+// isSameLocalDate), damit "heute" überall im lokalen Kalendertag ausgewertet
+// wird — keine eigene Duplikat-Logik hier.
 // ─────────────────────────────────────────────
 function formatDateTime(iso?: string | null): string | null {
   if (!iso) return null;
   const date = new Date(iso);
   if (isNaN(date.getTime())) return null;
 
+  const timePart = date.toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  if (isSameLocalDate(formatDateISO(date), new Date())) {
+    return `Heute um ${timePart}`;
+  }
+
   const datePart = date.toLocaleDateString("de-DE", {
     day: "2-digit",
     month: "2-digit",
     year: "numeric",
-  });
-  const timePart = date.toLocaleTimeString("de-DE", {
-    hour: "2-digit",
-    minute: "2-digit",
   });
   return `${datePart} um ${timePart}`;
 }


### PR DESCRIPTION
## Summary

Reimplements the idea from the abandoned `ai/daily-task-2026-06-30` branch cleanly against current `main`, rather than restoring its file directly. Today's job comments show a compact `Heute um HH:mm` instead of the full `dd.mm.yyyy um HH:mm`; older comments are unchanged.

The original branch defined its own local `isSameDay(Date, Date)` helper. This PR reuses the two existing centralized helpers from `utils/date.ts` instead — `formatDateISO()` (converts a `Date` to its local `YYYY-MM-DD`) composed with `isSameLocalDate()` (already used elsewhere for job-scheduling "is this due today" checks) — so there's no new duplicate date-comparison logic, and "today" is evaluated the same local-timezone-safe way everywhere in the app.

## Files changed

- `features/jobs/components/JobComments.tsx`

## Intentionally not recovered

- The old branch's `AI_BACKLOG.md` session-log entry — `main`'s current backlog already documents this as a pending item (see the 07-06 entry), so reintroducing that text would be redundant/stale.

## Test plan

- [x] `npx tsc --noEmit` — clean, no errors
- [x] `npm run lint` (`expo lint`) — clean, no warnings/errors
- [x] No JS/TS test runner exists in this repo (only SQL tests under `supabase/tests/`, none touching this file) — typecheck + lint are this repo's actual CI gate (PR #39)
- [x] Verified invalid/missing-timestamp handling (`isNaN` guard) and German locale formatting (`toLocaleDateString`/`toLocaleTimeString` with `de-DE`) are unchanged from the original implementation
- [x] Verified the day-comparison uses only local `Date` getters end-to-end (`formatDateISO` → `getFullYear`/`getMonth`/`getDate`), so there's no UTC/local mismatch or DST edge case
- [ ] Manual on-device verification (not run in this session — no dev/preview environment with seeded comment data available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)