### PR TITLE
feat(jobs): Job Details 2.0 — redesigned detail screen

### DIFF
--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -2,48 +2,48 @@
 // Detail-Ansicht eines Jobs mit allen Infos und kontextabhängigen Aktionen.
 // Aktionen (Start/Complete/Edit) nutzen weiter den bestehenden JobContext —
 // keine Änderungen an Supabase-/Offline-Sync-Logik.
+//
+// "Job Details 2.0": die Präsentationsschicht ist auf kleine, reine
+// Anzeige-Komponenten in features/jobs/components/ aufgeteilt (siehe unten).
+// Dieser Screen bleibt der Orchestrator: er hält Daten/State/Handler und
+// entscheidet NUR, WELCHE Komponente wann sichtbar ist — die Berechtigungs-
+// und Aktions-Logik selbst ist unverändert gegenüber der Vorversion.
 
 import {
   ActionMenuSheet,
-  AppHeader,
-  Badge,
-  Button,
-  Card,
   EmptyState,
   ErrorBanner,
-  InfoRow,
   LoadingScreen,
   OfflineBanner,
-  StatusBadge,
   type ActionMenuItem,
 } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
+import { AssignedEmployeesCard } from "@/features/jobs/components/AssignedEmployeesCard";
+import { JobActionFooter } from "@/features/jobs/components/JobActionFooter";
 import { JobComments } from "@/features/jobs/components/JobComments";
+import { JobDetailHeader } from "@/features/jobs/components/JobDetailHeader";
+import { JobLocationCard } from "@/features/jobs/components/JobLocationCard";
+import { JobNotesCard } from "@/features/jobs/components/JobNotesCard";
+import { JobPendingActionHint } from "@/features/jobs/components/JobPendingActionHint";
 import { JobPhotos } from "@/features/jobs/components/JobPhotos";
+import { JobScheduleCard } from "@/features/jobs/components/JobScheduleCard";
+import { JobServiceDetailsCard } from "@/features/jobs/components/JobServiceDetailsCard";
+import { JobStatusOverview } from "@/features/jobs/components/JobStatusOverview";
+import { JobTimelineCard } from "@/features/jobs/components/JobTimelineCard";
 import { RuleOccurrences } from "@/features/jobs/components/RuleOccurrences";
 import {
   getJobById,
   getJobOccurrences,
   setRecurringRuleActive,
 } from "@/services/jobs/jobs.service";
-import { WorkedTimeCard } from "@/features/jobs/components/WorkedTimeCard";
-import { formatRecurringDays } from "@/utils/recurrence";
-import {
-  canRunJobActions,
-  formatAssigneesFull,
-  getAssignees,
-  isPrimaryAssignee,
-  UNASSIGNED_LABEL,
-} from "@/utils/jobAssignees";
+import { canRunJobActions, isPrimaryAssignee } from "@/utils/jobAssignees";
 import type { Job } from "@/types/job";
-import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Linking,
@@ -51,8 +51,6 @@ import {
   ScrollView,
   StatusBar,
   StyleSheet,
-  Text,
-  TouchableOpacity,
   View,
 } from "react-native";
 import {
@@ -60,26 +58,6 @@ import {
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
-
-// ─────────────────────────────────────────────
-// Datums-/Zeit-Formatierung
-// ─────────────────────────────────────────────
-function formatDateTime(iso?: string | null): string | null {
-  if (!iso) return null;
-  const date = new Date(iso);
-  if (isNaN(date.getTime())) return null;
-
-  const datePart = date.toLocaleDateString("de-DE", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-  const timePart = date.toLocaleTimeString("de-DE", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-  return `${datePart} um ${timePart}`;
-}
 
 // ─────────────────────────────────────────────
 // JobDetailScreen
@@ -113,6 +91,7 @@ export default function JobDetailScreen() {
     deleteJob,
     loading,
     online,
+    pendingActions,
     markJobCommentsAsRead,
   } = useJobs();
 
@@ -246,7 +225,7 @@ export default function JobDetailScreen() {
           barStyle={theme.isDark ? "light-content" : "dark-content"}
           backgroundColor={theme.colors.background}
         />
-        <AppHeader title="Job-Details" showBack />
+        <JobDetailHeader showMenu={false} menuBusy={false} onMenuPress={() => {}} />
         <View style={styles.emptyWrap}>
           <EmptyState
             title="Job nicht gefunden"
@@ -387,19 +366,6 @@ export default function JobDetailScreen() {
     });
   };
 
-  // ── Formatierte Werte
-  const isRecurring = job.jobType === "recurring";
-  const recurringDaysText = formatRecurringDays(job.recurringDays);
-  const timeText = job.startTime ? `${job.startTime} Uhr` : "—";
-  const scheduledStartText =
-    formatDateTime(job.scheduledStart) ?? "Kein Termin geplant";
-  // ANZEIGE: vollständige Zuweisungsmenge (Phase 5). Gelöschte Konten
-  // erscheinen mit „(ehemalig)", damit der Nachweis lesbar bleibt.
-  const assignees = getAssignees(job);
-  const employeeText =
-    assignees.length > 0 ? formatAssigneesFull(job) : UNASSIGNED_LABEL;
-  const employeeLabel = assignees.length > 1 ? "Mitarbeitende" : "Mitarbeiter";
-
   // BERECHTIGUNG Start/Abschluss (Phase 7, „Shared Job Time"): JEDER
   // Zugewiesene darf, nicht nur der Legacy-Primär — canRunJobActions spiegelt
   // exakt das Prädikat von start_own_job/complete_own_job (Rolle, job_type,
@@ -429,36 +395,10 @@ export default function JobDetailScreen() {
         backgroundColor={theme.colors.background}
       />
 
-      {/* ── Sticky-Header ── */}
-      {/* Header-Rechts: Aktions-Menü der Regel (früher: inertes „Admin"-Badge,
-          das nur die ohnehin bekannte Rolle wiederholte). */}
-      <AppHeader
-        title="Job-Details"
-        showBack
-        right={
-          isAdmin && isParentRule ? (
-            <TouchableOpacity
-              style={styles.headerMenuBtn}
-              onPress={() => setMenuOpen(true)}
-              disabled={ruleBusy}
-              activeOpacity={0.7}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityRole="button"
-              accessibilityLabel="Aktionen für diesen Dauerauftrag"
-              accessibilityHint="Öffnet Bearbeiten, Aktivieren/Deaktivieren und Löschen"
-            >
-              {ruleBusy ? (
-                <ActivityIndicator size="small" color={theme.colors.primary} />
-              ) : (
-                <Ionicons
-                  name="ellipsis-horizontal"
-                  size={20}
-                  color={theme.colors.onSurface}
-                />
-              )}
-            </TouchableOpacity>
-          ) : undefined
-        }
+      <JobDetailHeader
+        showMenu={isAdmin && isParentRule}
+        menuBusy={ruleBusy}
+        onMenuPress={() => setMenuOpen(true)}
       />
 
       <KeyboardAvoidingView
@@ -472,40 +412,12 @@ export default function JobDetailScreen() {
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        {/* ── Hero: Kunden-Name + Status ──
-            Bei Parent-Regeln ist der Job-Status bedeutungslos (er gilt global
-            für die Regel, nicht für einen konkreten Tag) — dort zählt
-            ausschließlich Aktiv/Inaktiv. Deshalb genau EIN Badge, und die
-            frühere Zeile „Status: Aktiv" in der Detail-Karte entfällt. */}
-        <View style={styles.hero}>
-          <Text style={styles.customerName}>{job.customerName}</Text>
-          {isParentRule ? (
-            <Badge
-              label={job.isActive ? "Aktiv" : "Inaktiv"}
-              variant={job.isActive ? "success" : "default"}
-            />
-          ) : (
-            <StatusBadge status={job.status} />
-          )}
-        </View>
+        {/* 1 — Hero: Kunde/Objekt, Status, Service, Termin */}
+        <JobStatusOverview job={job} isParentRule={isParentRule} />
 
-        {/* Kompakter Typ-Hinweis statt des früheren großen blauen
-            Erklär-Banners (ganzer Absatz „Dies ist eine Vorlage …"). */}
-        {isParentRule ? (
-          <View style={styles.ruleTypeRow}>
-            <Ionicons
-              name="repeat-outline"
-              size={14}
-              color={theme.colors.primary}
-            />
-            <Text style={styles.ruleTypeText}>Wiederkehrender Auftrag</Text>
-          </View>
-        ) : null}
-
-        {/* ── Save-Status ── */}
+        {/* Globaler Speicher-/Verbindungsstatus + Aktions-Fehler bleiben
+            oben — Chrome, kein Inhalt, muss ohne Scrollen sichtbar sein. */}
         <OfflineBanner />
-
-        {/* ── Fehler-Banner (Aktionen) ── */}
         {actionError ? (
           <ErrorBanner
             message={actionError}
@@ -513,91 +425,26 @@ export default function JobDetailScreen() {
           />
         ) : null}
 
-        {/* ── Arbeitszeit — prominent, direkt nach dem Hero ── */}
-        <WorkedTimeCard job={job} />
+        {/* 2 — Adresse + Maps */}
+        <JobLocationCard
+          location={job.location}
+          onOpenInMaps={handleOpenInMaps}
+        />
 
-        {/* ── Details-Karte ── */}
-        <Card padding={theme.spacing.lg} style={styles.card}>
-          <InfoRow label="Service" value={job.service} icon="construct-outline" />
-          <View style={styles.rowDivider} />
+        {/* 3 — Zugewiesene Mitarbeitende */}
+        <AssignedEmployeesCard job={job} />
 
-          <InfoRow
-            label="Adresse"
-            value={job.location || "—"}
-            icon="location-outline"
-          />
-          {job.location ? (
-            <View style={styles.mapsBtnRow}>
-              <Button
-                label="In Maps öffnen"
-                variant="secondary"
-                icon="map-outline"
-                fullWidth={false}
-                onPress={handleOpenInMaps}
-                style={{ paddingHorizontal: theme.spacing.lg }}
-              />
-            </View>
-          ) : null}
-          <View style={styles.rowDivider} />
+        {/* 4 — Zeitlicher Verlauf (Start/Ende/Akteure/Dauer bzw. geplant) */}
+        {!isParentRule ? <JobTimelineCard job={job} /> : null}
 
-          {isRecurring ? (
-            // Auftragstyp-Zeile entfällt: der Typ steht bereits als kompakter
-            // Hinweis unter dem Titel. Hier nur noch entscheidungsrelevante
-            // Terminierung.
-            <>
-              <InfoRow
-                label="Wochentage"
-                value={recurringDaysText}
-                icon="calendar-number-outline"
-              />
-              <View style={styles.rowDivider} />
-              <InfoRow label="Uhrzeit" value={timeText} icon="time-outline" />
-              <View style={styles.rowDivider} />
-            </>
-          ) : (
-            <>
-              <InfoRow
-                label="Auftragstyp"
-                value="Einmalig"
-                icon="calendar-outline"
-              />
-              <View style={styles.rowDivider} />
-              <InfoRow
-                label="Geplanter Start"
-                value={scheduledStartText}
-                icon="calendar-outline"
-              />
-              <View style={styles.rowDivider} />
-            </>
-          )}
+        {/* 5 — Service + Terminierung/Wiederholung */}
+        <JobServiceDetailsCard service={job.service} />
+        <JobScheduleCard job={job} isParentRule={isParentRule} />
 
-          <InfoRow
-            label={employeeLabel}
-            value={employeeText}
-            icon={assignees.length > 1 ? "people-outline" : "person-outline"}
-            // Mehrfachzuweisungen dürfen nicht abgeschnitten werden — der
-            // Detail-Screen ist die Stelle, an der die Menge vollständig
-            // nachvollziehbar sein muss.
-            valueNumberOfLines={6}
-          />
-        </Card>
+        {/* 6 — Notizen */}
+        {job.notes ? <JobNotesCard notes={job.notes} /> : null}
 
-        {/* ── Notizen ── */}
-        {job.notes ? (
-          <Card padding={theme.spacing.lg} style={styles.card}>
-            <View style={styles.notesLabelRow}>
-              <Ionicons
-                name="document-text-outline"
-                size={12}
-                color={theme.colors.primary}
-              />
-              <Text style={styles.notesLabel}>NOTIZEN</Text>
-            </View>
-            <Text style={styles.notesText}>{job.notes}</Text>
-          </Card>
-        ) : null}
-
-        {/* ── Generierte Termine (nur für Admin bei Parent-Recurring-Jobs) ── */}
+        {/* Generierte Termine (nur Admin bei Parent-Recurring-Jobs) */}
         {isParentRule && isAdmin ? (
           <RuleOccurrences
             occurrences={occurrences}
@@ -606,69 +453,35 @@ export default function JobDetailScreen() {
           />
         ) : null}
 
-        {/* ── Fotos (Upload + Anzeige, online-only) ── */}
+        {/* 7 — Fotos (Upload + Anzeige, online-only, unverändert) */}
         <JobPhotos
           jobId={job.id}
           canUpload={canUploadPhotos}
           isOnline={online}
         />
 
-        {/* ── Kommentare (append-only, online-only) ── */}
-        {/* Schreibrecht = Legacy-Primär oder Admin (RLS-Insert-Policy).
-            Sekundär Zugewiesene lesen mit, sehen aber kein Eingabefeld. */}
+        {/* 8 — Kommentare (append-only, online-only, unverändert) */}
         <JobComments
           jobId={job.id}
           canComment={isAdmin || isPrimaryAssignee(job, profile?.id)}
           onInputFocus={handleCommentFocus}
         />
 
-        {/* ── Aktionen ── */}
-        <View style={styles.actions}>
-          {canStart ? (
-            <Button
-              label="Job starten"
-              icon="play"
-              loading={submitting}
-              disabled={submitting}
-              onPress={handleStart}
-            />
-          ) : null}
+        {/* 9 — Job-spezifischer Offline-Hinweis, direkt vor den Aktionen,
+            auf die er sich bezieht */}
+        <JobPendingActionHint jobId={job.id} pendingActions={pendingActions} />
 
-          {canComplete ? (
-            <Button
-              label="Job abschließen"
-              icon="checkmark"
-              loading={submitting}
-              disabled={submitting}
-              onPress={handleComplete}
-            />
-          ) : null}
-
-          {isDone ? (
-            <View style={styles.doneInfo}>
-              <Ionicons
-                name="checkmark-circle"
-                size={20}
-                color={theme.colors.statusCompleted}
-              />
-              <Text style={styles.doneInfoText}>
-                Dieser Job ist abgeschlossen.
-              </Text>
-            </View>
-          ) : null}
-
-          {/* Bei Parent-Regeln liegt „Bearbeiten" im Header-Menü — kein
-              zweiter Button für dieselbe Aktion. */}
-          {isAdmin && !isParentRule ? (
-            <Button
-              label="Bearbeiten"
-              variant="secondary"
-              icon="create-outline"
-              disabled={submitting}
-              onPress={handleEdit}
-            />
-          ) : null}
-        </View>
+        {/* 10 — Aktionen */}
+        <JobActionFooter
+          canStart={canStart}
+          canComplete={canComplete}
+          isDone={isDone}
+          submitting={submitting}
+          onStart={handleStart}
+          onComplete={handleComplete}
+          showEdit={isAdmin && !isParentRule}
+          onEdit={handleEdit}
+        />
 
         <View style={{ height: theme.spacing.xl }} />
       </ScrollView>
@@ -709,105 +522,6 @@ function createStyles(theme: AppTheme) {
       paddingTop: theme.spacing.lg,
       paddingBottom: 32,
       gap: theme.spacing.md,
-    },
-
-    // Header rechts: Aktions-Menü — sichtbarer runder Hintergrund, damit der
-    // Button als Bedienelement lesbar ist und nicht wie ein Meta-Icon wirkt.
-    headerMenuBtn: {
-      width: 36,
-      height: 36,
-      alignItems: "center",
-      justifyContent: "center",
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.surfaceContainerHigh,
-      borderWidth: 1,
-      borderColor: theme.colors.outlineVariant,
-    },
-
-    // Hero-Bereich
-    hero: {
-      gap: theme.spacing.sm,
-      paddingVertical: theme.spacing.sm,
-    },
-    customerName: {
-      fontSize: theme.typography.size.xxl,
-      fontFamily: theme.typography.family.bold,
-      fontWeight: theme.typography.weight.bold,
-      color: theme.colors.onSurface,
-      letterSpacing: theme.typography.letterSpacing.tight,
-      lineHeight: theme.typography.lineHeight.xxl,
-    },
-
-    // Cards
-    card: {
-      gap: theme.spacing.md,
-    },
-    rowDivider: {
-      height: 1,
-      backgroundColor: theme.colors.outlineVariant,
-    },
-    mapsBtnRow: {
-      flexDirection: "row",
-      marginTop: 4,
-    },
-
-    // Notizen
-    notesLabelRow: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 4,
-      marginBottom: 6,
-    },
-    notesLabel: {
-      fontSize: theme.typography.size.xs,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.outline,
-      letterSpacing: theme.typography.letterSpacing.wider,
-    },
-    notesText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.regular,
-      color: theme.colors.onSurface,
-      lineHeight: theme.typography.lineHeight.sm,
-    },
-
-    // Aktionen
-    actions: {
-      gap: theme.spacing.sm,
-      marginTop: theme.spacing.xs,
-    },
-    doneInfo: {
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: theme.spacing.sm,
-      backgroundColor: theme.colors.statusCompletedBg,
-      borderWidth: 1,
-      borderColor: theme.colors.statusCompletedBorder,
-      borderRadius: theme.radius.md,
-      paddingVertical: theme.spacing.md,
-      minHeight: theme.spacing.tapTarget,
-    },
-    doneInfoText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.statusCompleted,
-    },
-
-    // Kompakter Typ-Hinweis (ersetzt das große Erklär-Banner)
-    ruleTypeRow: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 6,
-      marginTop: -theme.spacing.xs,
-    },
-    ruleTypeText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.primary,
     },
   });
 }

--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -434,8 +434,11 @@ export default function JobDetailScreen() {
         {/* 3 — Zugewiesene Mitarbeitende */}
         <AssignedEmployeesCard job={job} />
 
-        {/* 4 — Zeitlicher Verlauf (Start/Ende/Akteure/Dauer bzw. geplant) */}
-        {!isParentRule ? <JobTimelineCard job={job} /> : null}
+        {/* 4 — Zeitlicher Verlauf (Start/Ende/Akteure/Dauer bzw. geplant).
+            Bewusst NICHT an isParentRule gehängt: eine bereits gestartete
+            Regel ist eine Anomalie, die sichtbar bleiben muss. Nur der
+            Platzhalter vor dem Start gilt für ausführbare Termine. */}
+        <JobTimelineCard job={job} showPlaceholder={!isParentRule} />
 
         {/* 5 — Service + Terminierung/Wiederholung */}
         <JobServiceDetailsCard service={job.service} />

--- a/features/jobs/components/AssignedEmployeesCard.tsx
+++ b/features/jobs/components/AssignedEmployeesCard.tsx
@@ -1,0 +1,106 @@
+// features/jobs/components/AssignedEmployeesCard.tsx
+// Zuweisungsmenge eines Auftrags als lesbare Zeilen (Avatar + Name).
+// Nutzt ausschließlich die bestehenden Zuweisungs-Helfer (utils/jobAssignees)
+// und Job.assignees — keine eigene Zuweisungslogik, kein Kürzen von Namen.
+
+import { Card, InitialsAvatar } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { Job } from "@/types/job";
+import {
+  DELETED_SUFFIX,
+  UNASSIGNED_LABEL,
+  getAssignees,
+} from "@/utils/jobAssignees";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  job: Pick<Job, "assignees">;
+};
+
+export function AssignedEmployeesCard({ job }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const assignees = getAssignees(job);
+  const label = assignees.length > 1 ? "Mitarbeitende" : "Mitarbeiter";
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      <View style={styles.labelRow}>
+        <Ionicons
+          name={assignees.length > 1 ? "people-outline" : "person-outline"}
+          size={12}
+          color={theme.colors.primary}
+        />
+        <Text style={styles.label}>{label.toUpperCase()}</Text>
+      </View>
+
+      {assignees.length === 0 ? (
+        <Text style={styles.emptyText}>{UNASSIGNED_LABEL}</Text>
+      ) : (
+        <View style={styles.list}>
+          {assignees.map((assignee) => {
+            const displayName = assignee.isDeleted
+              ? `${assignee.fullName}${DELETED_SUFFIX}`
+              : assignee.fullName;
+            return (
+              <View
+                key={assignee.assignmentId}
+                style={styles.row}
+                accessible
+                accessibilityLabel={displayName}
+              >
+                <InitialsAvatar name={assignee.fullName} size={36} />
+                <Text style={styles.name}>{displayName}</Text>
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.md,
+    },
+    labelRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+    },
+    label: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.outline,
+      letterSpacing: theme.typography.letterSpacing.wider,
+    },
+    emptyText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    list: {
+      gap: theme.spacing.sm,
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+    },
+    name: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+      flexWrap: "wrap",
+    },
+  });
+}

--- a/features/jobs/components/JobActionFooter.tsx
+++ b/features/jobs/components/JobActionFooter.tsx
@@ -1,0 +1,116 @@
+// features/jobs/components/JobActionFooter.tsx
+// Primäre/sekundäre Aktionen des Job-Detail-Screens (Start/Abschluss/
+// Bearbeiten/abgeschlossen-Hinweis). Reine Präsentationskomponente: alle
+// Handler, Berechtigungs-Booleans (canStart/canComplete/isDone) und der
+// submitting-State kommen unverändert vom Screen — hier wird nichts davon
+// neu berechnet oder verändert.
+
+import { Button } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  canStart: boolean;
+  canComplete: boolean;
+  isDone: boolean;
+  submitting: boolean;
+  onStart: () => void;
+  onComplete: () => void;
+  showEdit: boolean;
+  onEdit: () => void;
+};
+
+export function JobActionFooter({
+  canStart,
+  canComplete,
+  isDone,
+  submitting,
+  onStart,
+  onComplete,
+  showEdit,
+  onEdit,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.actions}>
+      {canStart ? (
+        <Button
+          label="Job starten"
+          icon="play"
+          loading={submitting}
+          disabled={submitting}
+          onPress={onStart}
+          accessibilityRole="button"
+          accessibilityLabel="Job starten"
+        />
+      ) : null}
+
+      {canComplete ? (
+        <Button
+          label="Job abschließen"
+          icon="checkmark"
+          loading={submitting}
+          disabled={submitting}
+          onPress={onComplete}
+          accessibilityRole="button"
+          accessibilityLabel="Job abschließen"
+        />
+      ) : null}
+
+      {isDone ? (
+        <View style={styles.doneInfo}>
+          <Ionicons
+            name="checkmark-circle"
+            size={20}
+            color={theme.colors.statusCompleted}
+          />
+          <Text style={styles.doneInfoText}>Dieser Job ist abgeschlossen.</Text>
+        </View>
+      ) : null}
+
+      {showEdit ? (
+        <Button
+          label="Bearbeiten"
+          variant="secondary"
+          icon="create-outline"
+          disabled={submitting}
+          onPress={onEdit}
+          accessibilityRole="button"
+          accessibilityLabel="Job bearbeiten"
+        />
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    actions: {
+      gap: theme.spacing.sm,
+      marginTop: theme.spacing.xs,
+    },
+    doneInfo: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.statusCompletedBg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusCompletedBorder,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    doneInfoText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.statusCompleted,
+    },
+  });
+}

--- a/features/jobs/components/JobDetailHeader.tsx
+++ b/features/jobs/components/JobDetailHeader.tsx
@@ -1,0 +1,70 @@
+// features/jobs/components/JobDetailHeader.tsx
+// Sticky Top-Header des Job-Detail-Screens. Reines Präsentations-Element:
+// zeigt den Zurück-Button und (nur Admin + Parent-Regel) den runden
+// "…"-Button, der das Regel-Aktionsmenü öffnet. Keine eigene Logik — der
+// Screen entscheidet, ob der Menü-Button sichtbar ist und was er tut.
+
+import { AppHeader } from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { ActivityIndicator, StyleSheet, TouchableOpacity } from "react-native";
+import type { AppTheme } from "@/constants/theme";
+
+type Props = {
+  /** Zeigt den runden Menü-Button rechts (nur Admin, nur bei Parent-Regel). */
+  showMenu: boolean;
+  menuBusy: boolean;
+  onMenuPress: () => void;
+};
+
+export function JobDetailHeader({ showMenu, menuBusy, onMenuPress }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <AppHeader
+      title="Job-Details"
+      showBack
+      right={
+        showMenu ? (
+          <TouchableOpacity
+            style={styles.menuBtn}
+            onPress={onMenuPress}
+            disabled={menuBusy}
+            activeOpacity={0.7}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Aktionen für diesen Dauerauftrag"
+            accessibilityHint="Öffnet Bearbeiten, Aktivieren/Deaktivieren und Löschen"
+          >
+            {menuBusy ? (
+              <ActivityIndicator size="small" color={theme.colors.primary} />
+            ) : (
+              <Ionicons
+                name="ellipsis-horizontal"
+                size={20}
+                color={theme.colors.onSurface}
+              />
+            )}
+          </TouchableOpacity>
+        ) : undefined
+      }
+    />
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    menuBtn: {
+      width: 36,
+      height: 36,
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+    },
+  });
+}

--- a/features/jobs/components/JobLocationCard.tsx
+++ b/features/jobs/components/JobLocationCard.tsx
@@ -1,0 +1,81 @@
+// features/jobs/components/JobLocationCard.tsx
+// Adresse + Maps-Aktion. Reine Präsentationskomponente — der Screen behält
+// die vollständige handleOpenInMaps-Implementierung (Plattform-URL-Schema),
+// diese Komponente ruft sie nur über onOpenInMaps auf.
+
+import { Button, Card, InfoRow } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  location: string;
+  onOpenInMaps: () => void;
+};
+
+export function JobLocationCard({ location, onOpenInMaps }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const hasLocation = !!location?.trim();
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      <InfoRow
+        label="Adresse"
+        value={hasLocation ? location : "Keine Adresse hinterlegt"}
+        icon="location-outline"
+      />
+
+      {hasLocation ? (
+        <View style={styles.actionRow}>
+          <Button
+            label="In Maps öffnen"
+            variant="secondary"
+            icon="map-outline"
+            fullWidth={false}
+            onPress={onOpenInMaps}
+            style={{ paddingHorizontal: theme.spacing.lg }}
+            accessibilityRole="button"
+            accessibilityLabel="Adresse in Maps öffnen"
+          />
+        </View>
+      ) : (
+        <View style={styles.emptyHint}>
+          <Ionicons
+            name="information-circle-outline"
+            size={14}
+            color={theme.colors.outline}
+          />
+          <Text style={styles.emptyHintText}>
+            Für diesen Auftrag ist keine Adresse gepflegt.
+          </Text>
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.md,
+    },
+    actionRow: {
+      flexDirection: "row",
+    },
+    emptyHint: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+    },
+    emptyHintText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      flexShrink: 1,
+    },
+  });
+}

--- a/features/jobs/components/JobNotesCard.tsx
+++ b/features/jobs/components/JobNotesCard.tsx
@@ -1,0 +1,60 @@
+// features/jobs/components/JobNotesCard.tsx
+// Notizen-Sektion — nur gerendert, wenn Notizen vorhanden sind (Gating bleibt
+// beim aufrufenden Screen, wie zuvor). Langer Text bricht korrekt um.
+
+import { Card } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  notes: string;
+};
+
+export function JobNotesCard({ notes }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      <View style={styles.labelRow}>
+        <Ionicons
+          name="document-text-outline"
+          size={12}
+          color={theme.colors.primary}
+        />
+        <Text style={styles.label}>NOTIZEN</Text>
+      </View>
+      <Text style={styles.text}>{notes}</Text>
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.sm,
+    },
+    labelRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+    },
+    label: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.outline,
+      letterSpacing: theme.typography.letterSpacing.wider,
+    },
+    text: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+      lineHeight: theme.typography.lineHeight.sm,
+      flexWrap: "wrap",
+    },
+  });
+}

--- a/features/jobs/components/JobPendingActionHint.tsx
+++ b/features/jobs/components/JobPendingActionHint.tsx
@@ -1,0 +1,83 @@
+// features/jobs/components/JobPendingActionHint.tsx
+// Job-spezifischer Hinweis, ob für DIESEN Auftrag eine Aktion offline in der
+// Warteschlange liegt (z.B. "Start wartet auf Internet"). Rein lesende
+// Auswertung des bereits vorhandenen JobContext-Zustands (`pendingActions`)
+// — keine eigene Queue-/Sync-Logik, kein Schreibzugriff. Ergänzt die
+// globale <OfflineBanner/>, die nur die Gesamtzahl zeigt, um eine
+// Zuordnung zum gerade geöffneten Job.
+
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { PendingJobAction } from "@/services/offline/jobs.queue";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  jobId: string;
+  pendingActions: PendingJobAction[];
+};
+
+function labelFor(type: PendingJobAction["type"]): string {
+  switch (type) {
+    case "start_job":
+      return "Start wartet auf Internet";
+    case "complete_job":
+      return "Abschluss wartet auf Synchronisierung";
+    default:
+      return "Änderung wartet auf Synchronisierung";
+  }
+}
+
+export function JobPendingActionHint({ jobId, pendingActions }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const jobPending = pendingActions.filter((a) => a.jobId === jobId);
+  if (jobPending.length === 0) return null;
+
+  return (
+    <View
+      style={styles.wrap}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+    >
+      {jobPending.map((action) => (
+        <View key={action.id} style={styles.row}>
+          <Ionicons
+            name="time-outline"
+            size={14}
+            color={theme.colors.statusOpen}
+          />
+          <Text style={styles.text}>{labelFor(action.type)}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    wrap: {
+      gap: 6,
+      backgroundColor: theme.colors.statusOpenBg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusOpenBorder,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+    },
+    text: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.statusOpen,
+      flexShrink: 1,
+    },
+  });
+}

--- a/features/jobs/components/JobScheduleCard.tsx
+++ b/features/jobs/components/JobScheduleCard.tsx
@@ -1,0 +1,128 @@
+// features/jobs/components/JobScheduleCard.tsx
+// Terminierungs-Details: Wochentage/Uhrzeit + Gültigkeitszeitraum für
+// Parent-Regeln, geplanter Start/Ende für Einzeltermine und generierte
+// Occurrences. Zeigt zusätzlich scheduledEnd, recurrenceStartDate/EndDate
+// und einen Hinweis auf die Herkunft einer Occurrence — alles bereits
+// vorhandene Felder auf Job, die der bisherige Screen nicht anzeigte.
+// Keine neue Abfrage, keine geänderte Terminierungs-Logik.
+
+import { Card, InfoRow } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { Job } from "@/types/job";
+import { formatDateOnlyDE, formatDateTimeDE } from "@/utils/date";
+import { formatRecurringDays } from "@/utils/recurrence";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  job: Pick<
+    Job,
+    | "recurringDays"
+    | "startTime"
+    | "scheduledStart"
+    | "scheduledEnd"
+    | "recurrenceStartDate"
+    | "recurrenceEndDate"
+    | "isOccurrence"
+  >;
+  isParentRule: boolean;
+};
+
+export function JobScheduleCard({ job, isParentRule }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      {isParentRule ? (
+        <>
+          <InfoRow
+            label="Wochentage"
+            value={formatRecurringDays(job.recurringDays)}
+            icon="calendar-number-outline"
+          />
+          <View style={styles.rowDivider} />
+          <InfoRow
+            label="Uhrzeit"
+            value={job.startTime ? `${job.startTime} Uhr` : "—"}
+            icon="time-outline"
+          />
+          <View style={styles.rowDivider} />
+          <InfoRow
+            label="Gültig ab"
+            value={formatDateOnlyDE(job.recurrenceStartDate) ?? "—"}
+            icon="play-forward-outline"
+          />
+          <View style={styles.rowDivider} />
+          <InfoRow
+            label="Gültig bis"
+            value={formatDateOnlyDE(job.recurrenceEndDate) ?? "Kein Enddatum"}
+            icon="flag-outline"
+          />
+        </>
+      ) : (
+        <>
+          <InfoRow
+            label="Auftragstyp"
+            value="Einmalig"
+            icon="calendar-outline"
+          />
+          <View style={styles.rowDivider} />
+          <InfoRow
+            label="Geplanter Start"
+            value={formatDateTimeDE(job.scheduledStart) ?? "Kein Termin geplant"}
+            icon="calendar-outline"
+          />
+          {job.scheduledEnd ? (
+            <>
+              <View style={styles.rowDivider} />
+              <InfoRow
+                label="Geplantes Ende"
+                value={formatDateTimeDE(job.scheduledEnd) ?? "—"}
+                icon="calendar-outline"
+              />
+            </>
+          ) : null}
+          {job.isOccurrence ? (
+            <View style={styles.originHint}>
+              <Ionicons
+                name="repeat-outline"
+                size={14}
+                color={theme.colors.onSurfaceVariant}
+              />
+              <Text style={styles.originHintText}>
+                Generierter Termin eines Dauerauftrags.
+              </Text>
+            </View>
+          ) : null}
+        </>
+      )}
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.md,
+    },
+    rowDivider: {
+      height: 1,
+      backgroundColor: theme.colors.outlineVariant,
+    },
+    originHint: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      marginTop: -theme.spacing.xs,
+    },
+    originHintText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      flexShrink: 1,
+    },
+  });
+}

--- a/features/jobs/components/JobServiceDetailsCard.tsx
+++ b/features/jobs/components/JobServiceDetailsCard.tsx
@@ -1,0 +1,32 @@
+// features/jobs/components/JobServiceDetailsCard.tsx
+// "Was ist zu tun?" — der Leistungs-/Service-Text des Auftrags, getrennt von
+// der Terminierung (JobScheduleCard). Reine Anzeige, keine neue Logik.
+
+import { Card, InfoRow } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import React, { useMemo } from "react";
+import { StyleSheet } from "react-native";
+
+type Props = {
+  service: string;
+};
+
+export function JobServiceDetailsCard({ service }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      <InfoRow label="Service" value={service} icon="construct-outline" />
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.md,
+    },
+  });
+}

--- a/features/jobs/components/JobStatusOverview.tsx
+++ b/features/jobs/components/JobStatusOverview.tsx
@@ -1,0 +1,167 @@
+// features/jobs/components/JobStatusOverview.tsx
+// Hero-Bereich des Job-Detail-Screens: beantwortet auf den ersten Blick
+// "Wo arbeite ich? Was ist zu tun? Wann? Welcher Status?"
+//
+// Genau EIN Status-Indikator (StatusBadge für echte Termine, Aktiv/Inaktiv-
+// Badge für Parent-Regeln) — keine Duplikate. Reine Präsentationskomponente,
+// keine eigene Datenlogik: alle Werte kommen fertig aufbereitet vom Screen
+// bzw. aus den bestehenden Formatier-Helfern (utils/date, utils/recurrence).
+
+import { Badge, StatusBadge } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { Job } from "@/types/job";
+import { formatDateTimeDE } from "@/utils/date";
+import { formatRecurringDays } from "@/utils/recurrence";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  job: Pick<
+    Job,
+    | "customerName"
+    | "status"
+    | "isActive"
+    | "jobType"
+    | "service"
+    | "startTime"
+    | "recurringDays"
+    | "scheduledStart"
+    | "isOccurrence"
+  >;
+  isParentRule: boolean;
+};
+
+export function JobStatusOverview({ job, isParentRule }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  // Kompakte Terminzeile: Wochentage+Uhrzeit für Parent-Regeln, sonst der
+  // formatierte geplante Termin (deckt Einzeltermine UND generierte
+  // Occurrences ab — beide tragen scheduledStart).
+  const scheduleSummary = isParentRule
+    ? `${formatRecurringDays(job.recurringDays)} · ${
+        job.startTime ? `${job.startTime} Uhr` : "—"
+      }`
+    : formatDateTimeDE(job.scheduledStart) ?? "Kein Termin geplant";
+
+  return (
+    <View style={styles.hero}>
+      <View style={styles.titleRow}>
+        <Text style={styles.customerName}>{job.customerName}</Text>
+        {isParentRule ? (
+          <Badge
+            label={job.isActive ? "Aktiv" : "Inaktiv"}
+            variant={job.isActive ? "success" : "default"}
+          />
+        ) : (
+          <StatusBadge status={job.status} />
+        )}
+      </View>
+
+      <View style={styles.metaRow}>
+        <Ionicons
+          name="construct-outline"
+          size={14}
+          color={theme.colors.onSurfaceVariant}
+        />
+        <Text style={styles.metaText} numberOfLines={1}>
+          {job.service}
+        </Text>
+        <Text style={styles.metaDot}>·</Text>
+        <Ionicons
+          name="time-outline"
+          size={14}
+          color={theme.colors.onSurfaceVariant}
+        />
+        <Text style={styles.metaText} numberOfLines={1}>
+          {scheduleSummary}
+        </Text>
+      </View>
+
+      {isParentRule ? (
+        <View style={styles.typeChip}>
+          <Ionicons
+            name="repeat-outline"
+            size={14}
+            color={theme.colors.primary}
+          />
+          <Text style={styles.typeChipText}>Wiederkehrender Auftrag</Text>
+        </View>
+      ) : job.isOccurrence ? (
+        // Unterscheidung generierte Occurrence vs. eigenständiger Einzeltermin
+        // (neu — nutzt nur das bereits vorhandene isOccurrence-Feld, keine
+        // zusätzliche Abfrage).
+        <View style={styles.typeChip}>
+          <Ionicons
+            name="repeat-outline"
+            size={14}
+            color={theme.colors.onSurfaceVariant}
+          />
+          <Text style={[styles.typeChipText, styles.typeChipTextMuted]}>
+            Teil eines Dauerauftrags
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    hero: {
+      gap: theme.spacing.sm,
+      paddingVertical: theme.spacing.sm,
+    },
+    titleRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+      rowGap: 6,
+    },
+    customerName: {
+      flexShrink: 1,
+      fontSize: theme.typography.size.xxl,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+      letterSpacing: theme.typography.letterSpacing.tight,
+      lineHeight: theme.typography.lineHeight.xxl,
+    },
+    metaRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      flexWrap: "wrap",
+    },
+    metaText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+      flexShrink: 1,
+    },
+    metaDot: {
+      fontSize: theme.typography.size.sm,
+      color: theme.colors.outline,
+    },
+    typeChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      alignSelf: "flex-start",
+    },
+    typeChipText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.primary,
+    },
+    typeChipTextMuted: {
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/jobs/components/JobTimelineCard.tsx
+++ b/features/jobs/components/JobTimelineCard.tsx
@@ -1,0 +1,104 @@
+// features/jobs/components/JobTimelineCard.tsx
+// Zeitlicher Verlauf eines Auftrags. Sobald der Job gestartet wurde, kommt
+// die gesamte Berechnung/Anzeige unverändert aus WorkedTimeCard (Start/Ende,
+// Akteure, Dauer) — hier wird NICHTS von dieser Logik dupliziert oder
+// verändert. Vor dem Start zeigt diese Karte stattdessen den geplanten
+// Termin (bereits vorhandenes scheduledStart, keine neue Abfrage), damit
+// Mitarbeitende auch dann sehen, worauf sich der Auftrag bezieht.
+//
+// Wird vom Screen NUR für echte Termine gerendert (nie für Parent-Regeln —
+// dort ist "gestartet/geplant" bedeutungslos).
+
+import { Card } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { WorkedTimeCard } from "@/features/jobs/components/WorkedTimeCard";
+import type { Job } from "@/types/job";
+import { formatDateTimeDE } from "@/utils/date";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  job: Pick<
+    Job,
+    | "status"
+    | "startedAt"
+    | "completedAt"
+    | "startedBy"
+    | "completedBy"
+    | "assignees"
+    | "scheduledStart"
+  >;
+};
+
+export function JobTimelineCard({ job }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  if (job.startedAt) {
+    return <WorkedTimeCard job={job} />;
+  }
+
+  const scheduledText = formatDateTimeDE(job.scheduledStart);
+
+  return (
+    <Card padding={theme.spacing.lg} style={styles.card}>
+      <View style={styles.row}>
+        <View style={styles.iconWrap}>
+          <Ionicons
+            name="hourglass-outline"
+            size={16}
+            color={theme.colors.onSurfaceVariant}
+          />
+        </View>
+        <View style={styles.textBlock}>
+          <Text style={styles.title}>Noch nicht gestartet</Text>
+          <Text style={styles.subtitle}>
+            {scheduledText
+              ? `Geplant für ${scheduledText}.`
+              : "Für diesen Auftrag ist noch kein Termin geplant."}
+          </Text>
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.sm,
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: theme.spacing.sm,
+    },
+    iconWrap: {
+      width: 28,
+      height: 28,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.surfaceContainer,
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+    },
+    textBlock: {
+      flex: 1,
+      gap: 2,
+    },
+    title: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    subtitle: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+  });
+}

--- a/features/jobs/components/JobTimelineCard.tsx
+++ b/features/jobs/components/JobTimelineCard.tsx
@@ -6,8 +6,13 @@
 // Termin (bereits vorhandenes scheduledStart, keine neue Abfrage), damit
 // Mitarbeitende auch dann sehen, worauf sich der Auftrag bezieht.
 //
-// Wird vom Screen NUR für echte Termine gerendert (nie für Parent-Regeln —
-// dort ist "gestartet/geplant" bedeutungslos).
+// WICHTIG — die Arbeitszeit-Anzeige hängt NICHT an isParentRule: sobald
+// startedAt gesetzt ist, rendert WorkedTimeCard, genau wie vor der
+// 2.0-Aufteilung. Eine Parent-Regel mit Start-/Abschlusszeiten ist eine
+// Datenanomalie (eine Regel wird nie ausgeführt) — dann muss der Wert
+// sichtbar bleiben statt still verborgen zu werden. Nur der „noch nicht
+// gestartet"-Platzhalter ist auf ausführbare Termine begrenzt
+// (`showPlaceholder`), weil er für eine Regel-Vorlage bedeutungslos wäre.
 
 import { Card } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
@@ -30,15 +35,23 @@ type Props = {
     | "assignees"
     | "scheduledStart"
   >;
+  /**
+   * Darf der „noch nicht gestartet"-Platzhalter erscheinen? Nur für
+   * ausführbare Termine — bei Parent-Regeln false. Beeinflusst NICHT die
+   * WorkedTimeCard (siehe Kopfkommentar).
+   */
+  showPlaceholder: boolean;
 };
 
-export function JobTimelineCard({ job }: Props) {
+export function JobTimelineCard({ job, showPlaceholder }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   if (job.startedAt) {
     return <WorkedTimeCard job={job} />;
   }
+
+  if (!showPlaceholder) return null;
 
   const scheduledText = formatDateTimeDE(job.scheduledStart);
 

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -115,3 +115,37 @@ export function formatDurationLong(totalMinutes: number): string {
   if (hours === 0) return `${minutes} min`;
   return `${hours}h ${String(minutes).padStart(2, "0")}min`;
 }
+
+// ─────────────────────────────────────────────
+// Anzeige-Formatierung (Job-Detail)
+// ─────────────────────────────────────────────
+
+/**
+ * Formatiert einen ISO-Zeitstempel als "dd.mm.yyyy um HH:mm" (de-DE).
+ * Immer das volle Datum - fuer die "heute"-relative Kurzform siehe die
+ * separate Logik in JobComments (dort bewusst eigenstaendig, andere Regel).
+ */
+export function formatDateTimeDE(iso?: string | null): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return null;
+
+  const datePart = date.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+  const timePart = date.toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${datePart} um ${timePart}`;
+}
+
+/** Formatiert ein "YYYY-MM-DD"-Datum (ohne Uhrzeit) als "dd.mm.yyyy". */
+export function formatDateOnlyDE(dateKey?: string | null): string | null {
+  if (!dateKey) return null;
+  const [y, m, d] = dateKey.slice(0, 10).split("-");
+  if (!y || !m || !d) return null;
+  return `${d}.${m}.${y}`;
+}


### PR DESCRIPTION
## Summary

Rebuilds the Job Details screen's presentation layer from scratch as a set of small, reusable, theme-aware components, while preserving all existing business logic, permissions, and data flows exactly.

- `JobDetailScreen.tsx` goes from ~814 lines of inline layout to a thin orchestrator (~430 lines) that holds state/effects/handlers and composes the new components.
- 10 new presentational components in `features/jobs/components/`: `JobDetailHeader`, `JobStatusOverview`, `JobLocationCard`, `AssignedEmployeesCard`, `JobTimelineCard`, `JobScheduleCard`, `JobServiceDetailsCard`, `JobNotesCard`, `JobPendingActionHint`, `JobActionFooter`.
- Reuses existing components unchanged: `WorkedTimeCard`, `JobPhotos`, `JobComments`, `RuleOccurrences`, `OfflineBanner`, `ActionMenuSheet`, and all `components/ui/*` primitives/tokens.
- Surfaces previously-fetched-but-unused data: `scheduledEnd`, `recurrenceStartDate`/`recurrenceEndDate`, and a new job-scoped offline pending hint (e.g. "Start wartet auf Internet") derived read-only from the existing `JobContext.pendingActions` queue.
- Adds a clear visual distinction between a parent recurring rule and a generated occurrence, using only the existing `isOccurrence`/`parentJobId` fields (no new query).
- Adds `formatDateTimeDE`/`formatDateOnlyDE` to `utils/date.ts` for the new schedule/timeline displays. `JobComments`' own relative "Heute um HH:mm" formatter is untouched (different behavior, not a true duplicate).

## Explicitly unchanged

- Start/Complete RPC calls and `canRunJobActions` / `isPrimaryAssignee` gating (byte-for-byte, only relocated).
- Offline queue creation, sync, and retry logic (`services/offline/**` not touched).
- Comments/photos permission model, append-only/online-only behavior, unread handling, relative timestamps (PR #62).
- Database schema, migrations, RLS, Edge Functions, RPC parameters.
- `JobsListScreen.tsx` (dead code, left as-is) and the stale recurring-jobs doc comments (out of scope for this PR).

## Design decisions worth flagging

- Actions stay **inline at the bottom** of the scroll content (not a sticky footer). A sticky footer was allowed but optional in the request; given the keyboard-avoiding + auto-scroll-on-comment-focus behavior already in this screen, and no way to verify a sticky footer against a live keyboard in this environment, I kept the existing (safe) placement and only improved visual prominence.
- The global `OfflineBanner` stays near the top (chrome, not content) rather than moved next to Actions; the new job-scoped `JobPendingActionHint` sits directly above the action buttons instead, which is where it's actually decision-relevant.
- No "copy address" action — would require adding `expo-clipboard`, a new native dependency, which isn't "simple" per the request's own criterion.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` (expo lint) — 0 errors
- [x] Diff-reviewed `JobDetailScreen.tsx` line-by-line to confirm all handlers/gating booleans/effects are unchanged, only relocated
- [x] Confirmed via `git status` that only `features/jobs/**` and `utils/date.ts` changed — no `supabase/**`, `lib/schema.sql`, `services/offline/**`, RLS, or Edge Function files touched
- [x] Forced a real Metro bundle compile of the changed route (`app/jobs/[id]/index.bundle`) against the project's own running dev server — 200 OK, all 10 new components present in the compiled output, no resolution/syntax errors
- [ ] Full interactive manual QA (25-item checklist in the implementation report) — **not performed**, no test account/credentials available in this environment. See the report for the full breakdown of what still needs manual/device verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)