### PR TITLE
fix(jobs): remove obsolete Abmelden button from Edit Job screen

### DIFF
--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -61,7 +61,7 @@ export default function EditJobScreen() {
     updateJob,
     deleteJob,
   } = useJobs();
-  const { signOut, role, loading: authLoading } = useAuth();
+  const { role, loading: authLoading } = useAuth();
 
   // Cache-first mit Direktabruf-Fallback: Regeln/Jobs außerhalb des (für Admins
   // begrenzten) Ladefensters müssen dennoch bearbeitbar sein. RLS begrenzt die
@@ -240,26 +240,6 @@ export default function EditJobScreen() {
       !sameEndDate
     );
   }, [job, values, assignedEmployeeIds]);
-
-  // ── Logout (unveränderte Logik)
-  const handleLogout = async () => {
-    Alert.alert("Abmelden", "Möchtest du dich wirklich abmelden?", [
-      { text: "Abbrechen", style: "cancel" },
-      {
-        text: "Abmelden",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            await signOut();
-          } catch (err: unknown) {
-            const msg =
-              err instanceof Error ? err.message : "Abmeldung fehlgeschlagen.";
-            Alert.alert("Fehler", msg);
-          }
-        },
-      },
-    ]);
-  };
 
   // ── Speichern (unveränderte Logik)
   const handleSave = async () => {
@@ -472,13 +452,8 @@ export default function EditJobScreen() {
             )}
           </View>
 
-          <TouchableOpacity
-            onPress={handleLogout}
-            style={styles.logoutButton}
-            activeOpacity={0.7}
-          >
-            <Text style={styles.logoutText}>Abmelden</Text>
-          </TouchableOpacity>
+          {/* Gegengewicht zum Zurück-Button, damit der Titel mittig bleibt. */}
+          <View style={styles.headerSpacer} />
         </View>
 
         {/* ── Scroll-Inhalt ── */}
@@ -657,16 +632,8 @@ function createStyles(theme: AppTheme) {
       fontWeight: theme.typography.weight.medium,
       color: theme.colors.statusInProgress,
     },
-    logoutButton: {
-      paddingVertical: theme.spacing.xs,
+    headerSpacer: {
       minWidth: 70,
-      alignItems: "flex-end",
-    },
-    logoutText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.error,
     },
 
     // ── Scroll-Container


### PR DESCRIPTION
## Problem

Der **Job bearbeiten**-Screen zeigte oben rechts einen eigenen `Abmelden`-Button.
Das ist ein Überbleibsel aus einem alten Experiment und gehört nicht in den
Bearbeiten-Flow — Abmelden ist im Profil zuhause.

**Ort:** `features/jobs/EditJobScreen.tsx` — der Header ist komplett
handgebaut (`headerShown: false` global in `app/_layout.tsx`). Der Button war
also **lokal zu diesem Screen**, keine geteilte Navigations-/Header-Konfiguration.
`app/jobs/[id]/edit.tsx` ist nur ein Re-Export.

## Änderung

Entfernt wurde ausschließlich der Button plus der dadurch tote Code:

- der `TouchableOpacity` mit `Abmelden` im Header
- `handleLogout` (nur von diesem Button genutzt)
- `signOut` aus dem `useAuth()`-Destructuring (`role`/`loading` bleiben)
- die Styles `logoutButton` / `logoutText`

An seine Stelle tritt ein `headerSpacer` als Gegengewicht zum Zurück-Button
(beide `minWidth: 70`), damit der Titel mittig bleibt — dasselbe Idiom wie in
`ChangePasswordScreen` und `DeleteAccountScreen`. Kein Button, kein Handler,
keine Touch-Fläche.

## Ausdrücklich unverändert

- Zurück-Navigation (`router.back()`)
- Abmelden in `ProfileScreen`, `AdminScreen`, `app/index.tsx`
- Formular-Layout, Felder, Validierung, Speichern/Löschen, Rechte, Navigation
- Job Details 2.0
- keine Schema-/Migration-/RLS-/RPC-/Supabase-/Service-/Offline-/Notification-/
  Dependency-/Config-Änderungen

## Validierung

- `npx tsc --noEmit` — clean (exit 0)
- `npm run lint` — clean (exit 0)
- Diff: 1 Datei, +4 / −37

🤖 Generated with [Claude Code](https://claude.com/claude-code)