### PR TITLE
fix(web): guard expo-notifications so the web build boots

### DIFF
--- a/hooks/useNotificationNavigation.ts
+++ b/hooks/useNotificationNavigation.ts
@@ -15,10 +15,29 @@
 //   data = { type, jobId, companyId, employeeId, status }
 // ─────────────────────────────────────────────────────────────────
 
+// PLATTFORM-GUARD (Web): expo-notifications hat im Web KEINE Implementierung
+// für useLastNotificationResponse — der Hook ruft intern
+// getLastNotificationResponseAsync auf und wirft dort ERR_UNAVAILABLE
+// ("The method or property ExpoNotifications.getLastNotificationResponseAsync
+// is not available on web"). Da dieser Hook in app/_layout.tsx im
+// RootNavigator hängt, hat das die GESAMTE Web-App vor dem ersten Render in
+// die AppErrorBoundary geworfen ("Etwas ist schiefgelaufen") — Login war im
+// Browser überhaupt nicht erreichbar.
+//
+// Gelöst über zwei Implementierungen, die beim Modul-Laden EINMAL ausgewählt
+// werden (siehe Export unten). Bewusst NICHT über ein `if (Platform.OS ===
+// "web") return;` INNERHALB des Hooks: das wäre ein bedingter Hook-Aufruf und
+// verstößt gegen die Rules of Hooks. Platform.OS ist zur Laufzeit konstant,
+// die Hook-Reihenfolge bleibt damit über alle Renders stabil.
+//
+// iOS/Android bleiben unverändert: dort wird exakt die bisherige
+// Implementierung exportiert.
+
 import { useAuth } from "@/context/AuthContext";
 import * as Notifications from "expo-notifications";
 import { router } from "expo-router";
 import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
 
 function extractJobId(
   response: Notifications.NotificationResponse | null,
@@ -34,7 +53,7 @@ function extractJobId(
   return null;
 }
 
-export function useNotificationNavigation() {
+function useNotificationNavigationNative() {
   const { session, profile } = useAuth();
   const lastResponse = Notifications.useLastNotificationResponse();
 
@@ -81,3 +100,17 @@ export function useNotificationNavigation() {
     router.push({ pathname: "/jobs/[id]", params: { id: jobId } });
   }, [session, profile?.company_id, lastResponse]);
 }
+
+// Web-Variante: bewusst ein No-Op. Im Browser gibt es keine Push-Tokens
+// (registerForPushNotifications liefert dort seit jeher null) und damit auch
+// keine Notification, die angetippt werden könnte — es geht also keine
+// Funktion verloren. Die Signatur bleibt identisch, damit der Aufrufer in
+// app/_layout.tsx plattformunabhängig bleibt.
+function useNotificationNavigationWeb() {
+  // absichtlich leer
+}
+
+export const useNotificationNavigation =
+  Platform.OS === "web"
+    ? useNotificationNavigationWeb
+    : useNotificationNavigationNative;

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -10,6 +10,18 @@ export function setupNotifications() {
     return;
   }
 
+  // PLATTFORM-GUARD (Web): expo-notifications ist im Browser nicht
+  // implementiert. Es gibt dort keine Push-Tokens (siehe
+  // registerForPushNotifications unten, das seit jeher früh mit null
+  // zurückkehrt), also auch nichts zu konfigurieren. Ohne diesen Guard hinge
+  // die Web-Tauglichkeit der App am Wohlwollen einer nicht unterstützten
+  // Plattform-API. Früher Ausstieg, BEVOR notificationsConfigured gesetzt
+  // wird — so bleibt der Aufruf auf einer künftig unterstützten Plattform
+  // wiederholbar.
+  if (Platform.OS === "web") {
+    return;
+  }
+
   Notifications.setNotificationHandler({
     handleNotification: async () => ({
       shouldPlaySound: true,


### PR DESCRIPTION
## Problem

The web build crashed before the first render. `AppErrorBoundary` caught it and showed *"Etwas ist schiefgelaufen"* — the login screen was never reachable in a browser at all.

```
ERR_UNAVAILABLE: The method or property
ExpoNotifications.getLastNotificationResponseAsync is not available on web
```

## Root cause

`Notifications.useLastNotificationResponse()` in `useNotificationNavigation` has no web implementation. That hook hangs in `app/_layout.tsx` inside `<RootNavigator>`, so the failure took down the entire tree.

Worth noting: `npx expo export --platform web` **succeeds** regardless. A green export says nothing about the web runtime — that is why this went unnoticed.

## Change

- `useNotificationNavigation` now picks between the unchanged native implementation and a web no-op **at module load**.
- `setupNotifications()` returns early on web, *before* setting `notificationsConfigured`, so the call stays repeatable if the platform is ever supported.

Deliberately **not** `if (Platform.OS === "web") return;` inside the hook — that would be a conditional hook call and violates the Rules of Hooks. `Platform.OS` is constant at runtime, so hook order stays stable across renders.

No functionality is lost on web: there are no push tokens in a browser (`registerForPushNotifications` has always returned `null` early there), so there is no notification to tap.

## Test evidence

- `npx tsc --noEmit` — clean
- `npx eslint` on both files — clean (incl. `react-hooks/rules-of-hooks`)
- `npx expo start --web --clear` — boots to the login screen, **zero** `ExpoNotifications` errors in the console

## Native impact

**None.** On iOS/Android the module exports the byte-for-byte previous implementation, and `setupNotifications` only returns early on web.

## Limitations

- Verified on **web only**. No dev client or Android SDK was available, so the native deep-link-from-push path was reasoned about from the code, **not executed on a device**.
- This unblocks web; it does not make the app web-complete (see the follow-up dialogs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
