### PR TITLE
fix(web): make confirm/error dialogs work so logout and photo upload are usable

### DIFF
--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -10,6 +10,7 @@ import { useJobs } from "@/context/JobContext";
 import { JobFormFields } from "@/features/jobs/components/JobFormFields";
 import { useJobForm } from "@/features/jobs/hooks/useJobForm";
 import { formatDateISO, formatTimeHHmm, formatToISO } from "@/utils/date";
+import { alertDialog, confirmDialog } from "@/utils/dialogs";
 import type { CreateJobInput } from "@/types/job";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -133,28 +134,34 @@ export default function AdminScreen() {
     ]).start();
   }, [fadeAnim, slideAnim]);
 
-  // ── Logout (unveränderte Logik)
+  // ── Logout
+  // Über confirmDialog/alertDialog statt Alert.alert — Alert ist im Web eine
+  // leere Attrappe, der onPress-Callback lief dort nie (siehe utils/dialogs.ts).
   const handleLogout = async () => {
-    Alert.alert("Abmelden", "Möchtest du dich wirklich abmelden?", [
-      { text: "Abbrechen", style: "cancel" },
-      {
-        text: "Abmelden",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            await signOut();
-            // Explizit zur Anmeldung navigieren, statt uns auf das Neu-Mounten
-            // der Auth-Gruppe durch die Auth-Gates zu verlassen (das konnte den
-            // zuletzt sichtbaren Auth-Screen — Register — wieder aufdecken).
-            router.replace("/login");
-          } catch (err: unknown) {
-            const msg =
-              err instanceof Error ? err.message : "Abmeldung fehlgeschlagen.";
-            Alert.alert("Fehler", msg);
-          }
-        },
-      },
-    ]);
+    const bestaetigt = await confirmDialog({
+      title: "Abmelden",
+      message: "Möchtest du dich wirklich abmelden?",
+      confirmLabel: "Abmelden",
+      destructive: true,
+    });
+
+    if (!bestaetigt) {
+      return;
+    }
+
+    try {
+      await signOut();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error && err.message ? err.message : "Abmeldung fehlgeschlagen.";
+      await alertDialog("Abmelden fehlgeschlagen", `${msg}\n\nDu bist weiterhin angemeldet.`);
+      return;
+    }
+
+    // Explizit zur Anmeldung navigieren, statt uns auf das Neu-Mounten der
+    // Auth-Gruppe durch die Auth-Gates zu verlassen (das konnte den zuletzt
+    // sichtbaren Auth-Screen — Register — wieder aufdecken).
+    router.replace("/login");
   };
 
   // ── Job erstellen

--- a/features/jobs/components/JobPhotos.tsx
+++ b/features/jobs/components/JobPhotos.tsx
@@ -7,6 +7,7 @@ import { Button, Card, ErrorBanner } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useJobPhotos } from "@/features/jobs/hooks/useJobPhotos";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { alertDialog } from "@/utils/dialogs";
 import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import * as ImagePicker from "expo-image-picker";
@@ -77,6 +78,24 @@ export function JobPhotos({ jobId, canUpload, isOnline }: JobPhotosProps) {
   // ── Quelle wählen: Kamera oder Galerie ──
   function handleAddPhoto() {
     setUploadError(null);
+
+    // WEB: Alert.alert ist in react-native-web eine leere Attrappe
+    // (`static alert() {}`, siehe utils/dialogs.ts). Der Quellen-Dialog wäre
+    // dort nie erschienen und KEINER der onPress-Callbacks je gelaufen — der
+    // Button "Foto hinzufügen" war im Browser damit vollständig wirkungslos:
+    // kein Dateidialog, kein Upload, kein Fehler, kein Log-Eintrag.
+    //
+    // Im Browser gibt es ohnehin keine sinnvolle Unterscheidung zwischen
+    // Kamera und Galerie: expo-image-picker öffnet dort in beiden Fällen
+    // denselben Datei-Dialog. Deshalb wird die Auswahl übersprungen und direkt
+    // der Datei-Dialog geöffnet.
+    //
+    // iOS/Android bleiben unverändert bei der Drei-Wege-Auswahl.
+    if (Platform.OS === "web") {
+      void pickFromLibrary();
+      return;
+    }
+
     Alert.alert(
       "Foto hinzufügen",
       "Wähle eine Quelle:",
@@ -95,10 +114,15 @@ export function JobPhotos({ jobId, canUpload, isOnline }: JobPhotosProps) {
 
     const permission = await ImagePicker.requestCameraPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert(
+      // Über alertDialog statt Alert.alert, damit die Meldung auch im Web
+      // sichtbar ist. Zusätzlich als uploadError spiegeln — so bleibt der
+      // Grund am Bildschirm stehen und verschwindet nicht mit dem Dialog.
+      setUploadError(
+        "Kamera-Zugriff verweigert. Bitte erteile die Berechtigung in den Einstellungen.",
+      );
+      await alertDialog(
         "Kamera-Zugriff verweigert",
         "Damit du ein Foto aufnehmen kannst, benötigt die App Zugriff auf die Kamera. Bitte erteile die Berechtigung in den Einstellungen.",
-        [{ text: "OK" }],
       );
       return;
     }
@@ -119,10 +143,13 @@ export function JobPhotos({ jobId, canUpload, isOnline }: JobPhotosProps) {
 
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert(
+      // Siehe pickFromCamera: sichtbar im Web UND dauerhaft am Bildschirm.
+      setUploadError(
+        "Zugriff auf die Fotomediathek verweigert. Bitte erteile die Berechtigung in den Einstellungen.",
+      );
+      await alertDialog(
         "Zugriff verweigert",
         "Damit du Fotos hochladen kannst, benötigt die App Zugriff auf deine Fotomediathek. Bitte erteile die Berechtigung in den Einstellungen.",
-        [{ text: "OK" }],
       );
       return;
     }

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -9,6 +9,7 @@
 // - "Erscheinungsbild" → Info, dass die App der Systemeinstellung folgt (kein eigener Toggle)
 
 import { Card, InitialsAvatar } from "@/components/ui";
+import { alertDialog, confirmDialog } from "@/utils/dialogs";
 import { useAuth } from "@/context/AuthContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
@@ -53,26 +54,40 @@ export default function ProfileScreen({
   const isAdmin = role === "admin";
   const hasCompany = !!profile?.company_id;
 
-  // ── Logout mit Bestätigung (signOut-Logik unverändert)
-  const handleLogout = () => {
-    Alert.alert("Abmelden", "Möchtest du dich wirklich abmelden?", [
-      { text: "Abbrechen", style: "cancel" },
-      {
-        text: "Abmelden",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            await signOut();
-            // Nach dem Abmelden immer zur Anmeldung (Login). router.replace
-            // ersetzt die aktuelle Route und die geschützten Gruppen werden
-            // durch die Auth-Gates entfernt → kein Zurück in geschützte Screens.
-            router.replace("/login");
-          } catch {
-            Alert.alert("Fehler", "Logout fehlgeschlagen.");
-          }
-        },
-      },
-    ]);
+  // ── Logout mit Bestätigung
+  // Läuft über confirmDialog/alertDialog statt direkt über Alert.alert:
+  // Alert ist im Web eine leere Attrappe, der onPress-Callback wurde dort nie
+  // ausgeführt und das Abmelden war damit unmöglich (siehe utils/dialogs.ts).
+  // Die signOut-Logik selbst ist unverändert — sie wurde nur nie erreicht.
+  const handleLogout = async () => {
+    const bestaetigt = await confirmDialog({
+      title: "Abmelden",
+      message: "Möchtest du dich wirklich abmelden?",
+      confirmLabel: "Abmelden",
+      destructive: true,
+    });
+
+    if (!bestaetigt) {
+      return;
+    }
+
+    try {
+      await signOut();
+    } catch (error) {
+      // Fehler NICHT verschlucken: vorher lief dieser Zweig in ein Alert, das
+      // im Web nichts anzeigte — ein fehlgeschlagener Logout sah damit aus wie
+      // gar keine Reaktion. Der Nutzer bleibt bewusst angemeldet, statt in
+      // einen halb abgemeldeten Zustand zu geraten.
+      const grund =
+        error instanceof Error && error.message ? error.message : "Unbekannter Fehler.";
+      await alertDialog("Abmelden fehlgeschlagen", `${grund}\n\nDu bist weiterhin angemeldet.`);
+      return;
+    }
+
+    // Nach dem Abmelden immer zur Anmeldung (Login). router.replace ersetzt die
+    // aktuelle Route und die geschützten Gruppen werden durch die Auth-Gates
+    // entfernt → kein Zurück in geschützte Screens.
+    router.replace("/login");
   };
 
   return (

--- a/utils/dialogs.ts
+++ b/utils/dialogs.ts
@@ -1,0 +1,97 @@
+// utils/dialogs.ts
+// ─────────────────────────────────────────────────────────────────
+// Plattformübergreifende Bestätigungs-/Hinweis-Dialoge.
+//
+// WARUM ES DIESE DATEI GIBT
+//   `Alert.alert()` aus react-native ist im WEB eine leere Attrappe. Wörtlich
+//   (node_modules/react-native-web/dist/exports/Alert/index.js):
+//
+//       class Alert { static alert() {} }
+//
+//   Der Aufruf tut also NICHTS: kein Dialog, keine Buttons, und vor allem wird
+//   kein `onPress` je ausgeführt. Jede Aktion, die hinter einer Alert-
+//   Bestätigung hängt, ist im Browser damit unerreichbar — und jede
+//   Fehlermeldung, die per Alert gezeigt wird, ist unsichtbar. Genau das hat
+//   das Abmelden auf der Web-Version blockiert: der Bestätigungsdialog kam
+//   nie, also lief signOut() nie an, und es gab auch keinerlei Rückmeldung.
+//
+//   Wichtig: das ist KEIN Fehler in der Abmelde-Logik selbst. AuthContext
+//   .signOut() ist korrekt — es wurde schlicht nie aufgerufen.
+//
+// VERHALTEN
+//   * Native (iOS/Android): unverändert `Alert.alert` mit denselben Buttons,
+//     Rollen und Texten wie bisher. Für den Nutzer ändert sich dort NICHTS.
+//   * Web: `window.confirm` / `window.alert` — synchron, aber über dieselbe
+//     Promise-Schnittstelle, damit der Aufrufer plattformunabhängig bleibt.
+//
+//   Beide Funktionen geben ein Promise zurück, statt mit Callbacks zu
+//   arbeiten. Damit lässt sich der Ablauf linear als `await` schreiben, und
+//   ein `try/catch` um die Folgeaktion greift auch wirklich — bei der
+//   Callback-Variante lief der `onPress`-Body ausserhalb des umgebenden
+//   try/catch, ein Fehler darin wurde also zu einer unbehandelten Promise.
+// ─────────────────────────────────────────────────────────────────
+
+import { Alert, Platform } from "react-native";
+
+type ConfirmOptions = {
+  title: string;
+  message: string;
+  /** Beschriftung des bestätigenden Buttons (z. B. "Abmelden"). */
+  confirmLabel: string;
+  /** Beschriftung des Abbruch-Buttons. Standard: "Abbrechen". */
+  cancelLabel?: string;
+  /** Rot einfärben (nur nativ wirksam) — für destruktive Aktionen. */
+  destructive?: boolean;
+};
+
+/**
+ * Fragt den Nutzer um Bestätigung.
+ * @returns true, wenn bestätigt wurde; false bei Abbruch.
+ */
+export function confirmDialog({
+  title,
+  message,
+  confirmLabel,
+  cancelLabel = "Abbrechen",
+  destructive = false,
+}: ConfirmOptions): Promise<boolean> {
+  if (Platform.OS === "web") {
+    // window.confirm kennt keine eigenen Button-Beschriftungen, deshalb wandert
+    // die Aktion in den Text — sonst stünde dort nur ein nacktes "OK".
+    const bestaetigt =
+      typeof window !== "undefined" &&
+      window.confirm(`${title}\n\n${message}`);
+    return Promise.resolve(!!bestaetigt);
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(title, message, [
+      // onPress am Abbrechen-Button ist nötig: ohne ihn bliebe das Promise
+      // offen, wenn der Nutzer per Android-Zurück-Geste abbricht.
+      { text: cancelLabel, style: "cancel", onPress: () => resolve(false) },
+      {
+        text: confirmLabel,
+        style: destructive ? "destructive" : "default",
+        onPress: () => resolve(true),
+      },
+    ]);
+  });
+}
+
+/**
+ * Zeigt einen reinen Hinweis (eine Schaltfläche) und wartet, bis er
+ * weggeklickt wurde. Wird vor allem für Fehlermeldungen genutzt — auf dem Web
+ * wären diese über Alert.alert sonst komplett unsichtbar.
+ */
+export function alertDialog(title: string, message: string): Promise<void> {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") {
+      window.alert(`${title}\n\n${message}`);
+    }
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(title, message, [{ text: "OK", onPress: () => resolve() }]);
+  });
+}


### PR DESCRIPTION
## Problem

`Alert.alert` from react-native is an empty stub on web. Verbatim from `node_modules/react-native-web/dist/exports/Alert/index.js`:

```js
class Alert { static alert() {} }
```

No dialog, no buttons, and critically **no `onPress` ever fires**. Every action behind an Alert confirmation was unreachable in a browser, and every error surfaced via Alert was invisible. Two consequences were reproduced against Staging:

**1. Logging out was impossible.** The confirmation never appeared, so `signOut()` never ran. Clicking "Abmelden" left the path on `/profile` with the `sb-…-auth-token` still in `localStorage`. The signOut logic itself was always correct — it was simply never reached.

**2. Photo upload was impossible.** `handleAddPhoto()` was the only entry point to the picker and consisted of an Alert with three `onPress` buttons. The "Foto hinzufügen" button was completely inert in the browser: no file dialog, no upload, no error, nothing logged. A QA run was therefore reported as passing while Staging held **0 `job_photos` rows and 0 bucket objects** — the photo existed in no environment at all.

## Change

New `utils/dialogs.ts` with `confirmDialog()` / `alertDialog()`, both Promise-based rather than callback-based — so a `try/catch` around the follow-up action actually applies. With the callback form the `onPress` body ran *outside* the enclosing `try/catch`, turning any failure into an unhandled rejection.

- **Web:** `window.confirm` / `window.alert`
- **Native:** unchanged `Alert.alert`, same buttons and roles. The cancel button gains an `onPress` — without it the promise would hang on an Android back-gesture dismissal.

`JobPhotos` opens the file dialog directly on web instead of the source chooser: a browser has no meaningful camera/gallery split, expo-image-picker opens the same dialog either way. The permission notices now go through `alertDialog` **and** set `uploadError`, so the reason stays on screen after the dialog closes.

## Test evidence

- `npx tsc --noEmit` — clean · `npx eslint` on all four files — clean
- **Web, against Staging:** logout reaches `/login` and clears the `sb-` keys; cancel keeps you signed in; switching accounts shows no trace of the previous user (verified `offline_profile_cache` / `offline_jobs_cache` are scoped to the new user's id); the photo button now produces `input[type=file] accept=",image/*"` where it previously produced nothing.
- **Manual staging retest (by the maintainer):** employee upload and admin upload both succeed; photos stay visible; admin sees employee photos and vice versa.
- **Server-side confirmation:** 2 `job_photos` rows with byte-exact matching bucket objects, paths correctly `{company_id}/{job_id}/…`, `storage.objects.owner = uploaded_by`, **0 orphans in either direction**.

## Native impact

Small and intentional:

- Cancel button now has an `onPress` (resolves the promise) — no visible change.
- Logout error dialog: title `"Fehler"` → `"Abmelden fehlgeschlagen"`, plus *"Du bist weiterhin angemeldet."*
- Denied photo permissions now **also** persist as an error banner, not just a dismissable dialog.

Everything else on native matches the previous `Alert.alert` path exactly.

## Limitations

- **This is a partial remediation.** ~33 further `Alert.alert` calls across 7 other files remain dead on web — `ChangePasswordScreen`, `DeleteAccountScreen`, `EmployeeDetailScreen`, `EditJobScreen`, `RecurringRuleDetailScreen`, `AdminRecurringRulesScreen`, `app/(admin-tabs)/employees.tsx`. Migration is mechanical but belongs in its own PR. **Do not read this PR as "web dialogs fixed".**
- Verified on web only; native was not exercised on a device.
- Camera capture is untested (web only offers a file dialog).
- **Depends on #67** — without the notification boot guard the web bundle crashes before first render, so none of this is testable in a browser. Merge #67 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
