### PR TITLE
fix(security): isolate job photos in storage and revoke direct employee UPDATE on jobs

### DIFF
--- a/supabase/migrations/20260805000000_lock_down_job_photo_storage_and_job_updates.sql
+++ b/supabase/migrations/20260805000000_lock_down_job_photo_storage_and_job_updates.sql
@@ -1,0 +1,318 @@
+-- =========================================================
+-- MIGRATION: Foto-Speicher abdichten + direktes Employee-UPDATE auf jobs entziehen
+-- Datum: 2026-08-05
+-- =========================================================
+-- Dies ist der in 20260730000000_employee_read_via_assignments.sql
+-- angekuendigte „eigene Storage-PR". Dort wurden die beiden zu weiten
+-- Policies auf public.job_photos bereits entfernt; die entsprechenden
+-- Policies auf storage.objects wurden ausdruecklich vertagt. Sie werden
+-- hier entfernt.
+--
+-- Zusaetzlich wird die Policy "employee update own assigned jobs" auf
+-- public.jobs entzogen (Abschnitt 3).
+--
+-- =========================================================
+-- BEFUND (empirisch auf PRODUKTION nachgewiesen, 2026-08-05)
+-- =========================================================
+-- Nachgewiesen mit einer synthetischen Fixture in einer garantiert
+-- zurueckgerollten Transaktion (BEGIN … RAISE EXCEPTION), Rueckstaende
+-- danach mit 0 verifiziert. Rollen wurden per SET ROLE authenticated +
+-- request.jwt.claims gesetzt, also exakt der PostgREST-Pfad der App:
+--
+--   T1  Mitarbeiter E2, NICHT auf Auftrag J1 zugewiesen, liest das
+--       storage-Objekt eines J1-Fotos                     -> 1 Zeile  (LECK)
+--   T2  derselbe E2 laedt in den Ordner <firma>/<J1>/ hoch -> ERLAUBT   (LECK)
+--   T3  derselbe E2 liest die jobs-Zeile J1               -> 0 Zeilen (korrekt)
+--   T4  E1 (Legacy-Primaer von J1) setzt per direktem UPDATE
+--       started_at = now()-9h, completed_at = now(),
+--       status = 'completed'                              -> ERLAUBT   (LECK)
+--
+-- T3 zeigt: die Firmen-Isolation ist intakt. Gebrochen ist ausschliesslich
+-- die Isolation ZWISCHEN MITARBEITERN DERSELBEN FIRMA.
+--
+-- =========================================================
+-- URSACHE
+-- =========================================================
+-- RLS-Policies desselben Kommandos sind PERMISSIVE und werden mit ODER
+-- verknuepft. In Produktion existieren auf storage.objects fuenf Policies,
+-- davon zwei ohne jeden Auftragsbezug:
+--
+--   "job-photos storage: Lesen aus eigenem Firma-Ordner"    (SELECT)
+--   "job-photos storage: Hochladen in eigenen Firma-Ordner" (INSERT)
+--
+-- Beide pruefen NUR bucket_id und (storage.foldername(name))[1] =
+-- current_user_company_id(). Da sie mit ODER neben den strengen Policies
+-- stehen, sind die strengen Policies FAKTISCH WIRKUNGSLOS: jeder
+-- Mitarbeiter der Firma kommt an jeden Auftragsordner der Firma.
+--
+-- DRIFT: Diese beiden Policies werden von KEINER Migration im Repository
+-- erzeugt. Sie existieren ausschliesslich in der Produktionsdatenbank
+-- (vermutlich per Dashboard angelegt) und sind bislang nur als Kommentar
+-- in 20260730000000 beschrieben. Gleiches gilt fuer
+-- "job-photos insert allowed" und "job-photos delete own upload" — beide
+-- sind in Produktion aktiv, aber in keiner Migration definiert. Nur
+-- "job-photos read allowed" stammt aus einer Migration (20260730000000).
+--
+-- Abschnitt 2 holt diese Drift deshalb ins Repository nach: die drei
+-- korrekten Policies werden mit ihrer EXAKTEN Produktionsdefinition neu
+-- angelegt. Auf Produktion ist das ein No-Op (identischer Wortlaut); auf
+-- einer aus Migrationen gebauten Datenbank stellt es erstmals denselben
+-- Stand her. Ab dieser Migration beschreibt das Repository den Storage-
+-- Zustand vollstaendig.
+
+
+-- =========================================================
+-- 1. DIE BEIDEN ZU WEITEN STORAGE-POLICIES ENTFERNEN
+-- =========================================================
+-- Ersatzlos: der von ihnen legitim abgedeckte Personenkreis (Admin der
+-- Firma, zugewiesener Mitarbeiter) ist von den Policies in Abschnitt 2
+-- vollstaendig abgedeckt. Was wegfaellt, ist ausschliesslich der Zugriff
+-- auf Auftragsordner OHNE Auftragsbezug — also genau das Leck.
+--
+-- "if exists", weil sie in aus Migrationen gebauten Datenbanken (Staging,
+-- lokal, CI) gar nicht existieren. Dort laufen die DROPs ins Leere und die
+-- Migration ist ein reiner No-Op fuer diesen Abschnitt.
+drop policy if exists "job-photos storage: Lesen aus eigenem Firma-Ordner"    on storage.objects;
+drop policy if exists "job-photos storage: Hochladen in eigenen Firma-Ordner" on storage.objects;
+
+
+-- =========================================================
+-- 2. DIE DREI KORREKTEN STORAGE-POLICIES IM REPOSITORY VERANKERN
+-- =========================================================
+-- Wortlaut identisch zum heutigen Produktionsstand (ausgelesen aus
+-- pg_policies am 2026-08-05). drop+create statt „create if not exists",
+-- weil Postgres fuer Policies kein CREATE OR REPLACE kennt und der
+-- Wortlaut damit deterministisch wird — unabhaengig davon, was in der
+-- jeweiligen Umgebung vorher stand.
+--
+-- Pfadkonvention im Bucket: <company_id>/<job_id>/<datei>
+--   foldername(name)[1] = company_id
+--   foldername(name)[2] = job_id
+--
+-- WARUM `j.id::text = (storage.foldername(name))[2]` UND NICHT
+-- `j.id = ((storage.foldername(name))[2])::uuid`:
+--
+-- Der Bucket enthaelt beliebige, von aussen benennbare Objekte. Liegt dort
+-- auch nur EIN Objekt, dessen zweites Pfadsegment kein gueltiges UUID ist
+-- (Altlast, Fehl-Upload, gezielt angelegt), dann wirft die Cast-Variante
+-- beim Auswerten der Policy 22P02 „invalid input syntax for type uuid".
+-- Postgres garantiert KEINE Auswertungsreihenfolge der AND-Glieder — der
+-- vorgelagerte Firmen-Ordner-Vergleich schuetzt also nicht zuverlaessig
+-- davor. Ein solcher Fehler bricht die GESAMTE Abfrage ab, statt nur die
+-- eine Zeile abzulehnen: ein einziges kaputt benanntes Objekt koennte so
+-- das Laden JEDER Fotoliste der Firma lahmlegen (und waere, absichtlich
+-- platziert, ein billiger DoS gegen die eigene Firma).
+--
+-- Der Textvergleich ist dagegen total: er liefert fuer jeden Unsinn im
+-- Pfad schlicht `false` und lehnt damit genau dieses eine Objekt ab. Die
+-- Isolationswirkung ist identisch — j.id ist ein UUID und seine
+-- Textdarstellung ist kanonisch (klein geschrieben, mit Bindestrichen),
+-- ein zufaelliger Treffer ist also ausgeschlossen.
+--
+-- PREIS, DER HIER BEWUSST BEZAHLT WIRD: `j.id::text = …` ist nicht
+-- sargable, der Primaerschluessel-Index auf jobs.id wird fuer diesen
+-- Vergleich nicht genutzt. Bei aktuell ~900 jobs-Zeilen ist der Seq Scan
+-- pro Policy-Auswertung ohne Bedeutung. Sollte die Tabelle je in die
+-- Hunderttausende wachsen, ist der saubere Ausweg ein funktionaler Index
+-- (`create index on public.jobs ((id::text))`) — NICHT die Rueckkehr zum
+-- Cast.
+
+-- ── LESEN ──
+-- Admin: alle Auftraege der eigenen Firma.
+-- Mitarbeiter: nur Auftraege der eigenen ZUWEISUNGSMENGE — Legacy-Zeiger
+-- assigned_to ODER job_assignments (is_assigned_to_job). Sekundaer
+-- Zugewiesene lesen also weiterhin mit; das ist der Stand seit
+-- 20260730000000 und wird hier NICHT veraendert.
+drop policy if exists "job-photos read allowed" on storage.objects;
+create policy "job-photos read allowed"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'job-photos'
+  and (storage.foldername(name))[1] = public.current_user_company_id()::text
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id::text = (storage.foldername(name))[2]
+      and j.company_id = public.current_user_company_id()
+      and (
+        public.current_user_role() = 'admin'
+        or (
+          public.current_user_role() = 'employee'
+          and (
+            j.assigned_to = auth.uid()
+            or public.is_assigned_to_job(j.id)
+          )
+        )
+      )
+  )
+);
+
+-- ── HOCHLADEN ──
+-- ACHTUNG, BEWUSSTE ENTSCHEIDUNG — hier steht assigned_to, NICHT
+-- is_assigned_to_job:
+--
+-- Der Schreibpfad fuer Fotos und Kommentare haengt projektweit am
+-- Legacy-PRIMAER, nicht an der vollen Zuweisungsmenge. Das ist in
+-- CLAUDE.md als gewollte Asymmetrie dokumentiert, die Client-Seite gated
+-- exakt genauso (JobDetailScreen.tsx:306 nutzt isPrimaryAssignee, nicht
+-- isAssignedTo), und die INSERT-Policy auf public.job_photos verlangt
+-- ebenfalls assigned_to = auth.uid().
+--
+-- FOLGE DIESER MIGRATION, DIE MAN KENNEN MUSS: ein SEKUNDAER Zugewiesener
+-- kann heute — allein durch die weite Drift-Policy — Dateien hochladen.
+-- Nach dieser Migration kann er das nicht mehr. Das ist KEIN Verlust eines
+-- genutzten Rechts: die App bietet ihm den Upload gar nicht an, und die
+-- zugehoerige job_photos-ZEILE haette er ohnehin nie anlegen koennen (die
+-- Tabellen-Policy blockiert das seit jeher) — er haette also nur eine
+-- verwaiste Datei ohne DB-Zeile erzeugen koennen.
+--
+-- Die Angleichung des Schreibpfads an die volle Zuweisungsmenge
+-- (job_photos + job_comments + job_comment_reads + storage, konsistent in
+-- einem Zug) ist eine FACHLICHE Erweiterung und gehoert in einen eigenen
+-- PR — nicht in eine Sicherheitsabdichtung.
+drop policy if exists "job-photos insert allowed" on storage.objects;
+create policy "job-photos insert allowed"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'job-photos'
+  and (storage.foldername(name))[1] = public.current_user_company_id()::text
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id::text = (storage.foldername(name))[2]
+      and j.company_id = public.current_user_company_id()
+      and (
+        public.current_user_role() = 'admin'
+        or (
+          public.current_user_role() = 'employee'
+          and j.assigned_to = auth.uid()
+        )
+      )
+  )
+);
+
+-- ── LOESCHEN ──
+-- Nur die EIGENE hochgeladene Datei (owner = auth.uid()) und nur innerhalb
+-- der eigenen Firma. Unveraendert zum Produktionsstand.
+drop policy if exists "job-photos delete own upload" on storage.objects;
+create policy "job-photos delete own upload"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'job-photos'
+  and owner = auth.uid()
+  and (storage.foldername(name))[1] = public.current_user_company_id()::text
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id::text = (storage.foldername(name))[2]
+      and j.company_id = public.current_user_company_id()
+  )
+);
+
+
+-- =========================================================
+-- 3. "employee update own assigned jobs" ENTZIEHEN
+-- =========================================================
+-- Diese Policy stammt aus der Baseline 20260713000000 und erlaubt dem
+-- Legacy-Primaer ein direktes UPDATE auf SEINER jobs-Zeile:
+--
+--   USING/CHECK: current_user_role() = 'employee'
+--                and assigned_to = auth.uid()
+--                and company_id = current_user_company_id()
+--
+-- RLS ist ZEILEN-, nicht spaltenbasiert: die Policy kann nicht zwischen
+-- „Notiz aendern" und „started_at faelschen" unterscheiden. Ein
+-- Mitarbeiter kann damit per PATCH /rest/v1/jobs?id=eq.<seinauftrag>
+-- started_at, completed_at und status frei setzen. Da der Stundenzettel
+-- die offizielle Dauer als completed_at - started_at berechnet, ist das
+-- ein direkter Manipulationspfad auf die Lohnabrechnung (T4 oben).
+--
+-- ENTZOGEN STATT EINGESCHRAENKT — Begruendung:
+--
+--   a) Spaltenweise Einschraenkung ginge nur ueber column-level REVOKE auf
+--      der Rolle `authenticated`. Admins nutzen DIESELBE Rolle, ihre
+--      Schreibpfade wuerden mitbrechen. Keine Option.
+--   b) Ein BEFORE-UPDATE-Trigger koennte den Akteur nicht unterscheiden:
+--      auth.uid() liefert innerhalb der SECURITY-DEFINER-RPCs weiterhin
+--      den Mitarbeiter, der Trigger wuerde also start_own_job/
+--      complete_own_job mit abwuergen. Keine Option.
+--   c) Es gibt keinen Aufrufer. Verifiziert im gesamten Client:
+--      - services/jobs/jobs.service.ts kennt genau drei jobs-Schreibpfade
+--        (createJob/updateJob/deleteJob), alle mit
+--        `if (profile.role !== "admin") throw` davor;
+--      - setRecurringRuleActive laeuft laut eigenem Kommentar unter der
+--        Admin-Policy;
+--      - jede Employee-Aktion laeuft ueber rpc("start_own_job") /
+--        rpc("complete_own_job").
+--      Kein einziger .update() auf jobs haengt an dieser Policy.
+--
+-- Die beiden RPCs sind NACHWEISLICH SECURITY DEFINER (pg_proc.prosecdef =
+-- true, ebenso set_job_assignments, update_job_occurrences,
+-- generate_job_occurrences, inherit_occurrence_assignments). Sie umgehen
+-- RLS vollstaendig und sind von diesem DROP nicht betroffen — die
+-- Statusuebergaenge bleiben exakt wie sie sind, inklusive geteilter
+-- Job-Uhr.
+--
+-- NACH DIESER MIGRATION ist der Statuswechsel fuer Mitarbeiter
+-- AUSSCHLIESSLICH ueber die beiden RPCs erreichbar. Genau so war es
+-- immer gemeint.
+--
+-- Admins bleiben unberuehrt: "admin update jobs in own company" wird
+-- nicht angefasst.
+drop policy if exists "employee update own assigned jobs" on public.jobs;
+
+
+-- =========================================================
+-- ROLLBACK (manuell, in dieser Reihenfolge)
+-- =========================================================
+-- Stellt exakt den Stand VOR dieser Migration wieder her — inklusive der
+-- beiden Lecks. Nur im Notfall und nur mit ausdruecklicher Freigabe:
+--
+--   create policy "job-photos storage: Lesen aus eigenem Firma-Ordner"
+--   on storage.objects for select to authenticated
+--   using (
+--     bucket_id = 'job-photos'
+--     and (storage.foldername(name))[1] = public.current_user_company_id()::text
+--   );
+--
+--   create policy "job-photos storage: Hochladen in eigenen Firma-Ordner"
+--   on storage.objects for insert to authenticated
+--   with check (
+--     bucket_id = 'job-photos'
+--     and (storage.foldername(name))[1] = public.current_user_company_id()::text
+--   );
+--
+--   create policy "employee update own assigned jobs"
+--   on public.jobs for update to authenticated
+--   using (
+--     public.current_user_role() = 'employee'
+--     and assigned_to = auth.uid()
+--     and company_id = public.current_user_company_id()
+--   )
+--   with check (
+--     public.current_user_role() = 'employee'
+--     and assigned_to = auth.uid()
+--     and company_id = public.current_user_company_id()
+--   );
+--
+-- Die drei in Abschnitt 2 neu angelegten Policies brauchen KEIN Rollback:
+-- ihr Wortlaut ist mit dem vorherigen Produktionsstand identisch.
+--
+-- =========================================================
+-- WAS DIESE MIGRATION NICHT TUT
+-- =========================================================
+--   * Sie aendert NICHTS an public.job_photos / public.job_comments /
+--     public.job_comment_reads. Deren Policies sind bereits korrekt.
+--   * Sie aendert NICHTS an den beiden RPCs.
+--   * Sie weitet den Foto-SCHREIBPFAD NICHT auf die volle
+--     Zuweisungsmenge aus (siehe Begruendung in Abschnitt 2).
+--   * Sie fasst die uebrige bekannte Produktions-Drift NICHT an: den
+--     Database-Webhook-Trigger "dispatch-admin-notifications" auf
+--     notification_outbox und die Mitgliedschaft in der Publication
+--     supabase_realtime. Beides gehoert in einen eigenen PR.

--- a/supabase/tests/job_photo_storage_isolation.test.sql
+++ b/supabase/tests/job_photo_storage_isolation.test.sql
@@ -1,0 +1,672 @@
+-- =========================================================
+-- TEST: Foto-Isolation im Storage + kein direktes Employee-UPDATE auf jobs
+-- (Migration 20260805000000_lock_down_job_photo_storage_and_job_updates)
+-- =========================================================
+-- Prueft die vier Aussagen, auf denen die Migration steht:
+--
+--   1. Ein Mitarbeiter kommt NICHT an Fotos von Auftraegen, die ihm nicht
+--      zugewiesen sind — weder lesend noch schreibend —, auch nicht
+--      innerhalb der EIGENEN Firma. Das war das Leck (T1/T2).
+--   2. Wer legitim zugreifen darf, kann es weiterhin: Admin der Firma auf
+--      alles, zugewiesener Mitarbeiter auf seinen Auftrag. Kein
+--      Overblocking.
+--   3. Ein Mitarbeiter kann status/started_at/completed_at NICHT mehr per
+--      direktem UPDATE setzen (T4) — die beiden RPCs bleiben der einzige
+--      Weg und funktionieren unveraendert, inklusive geteilter Job-Uhr.
+--   4. Die Firmen-Isolation war und bleibt intakt.
+--
+-- Alle Zugriffe laufen als ECHTE Rollen (SET ROLE authenticated +
+-- request.jwt.claims), also ueber denselben Pfad wie die App ueber
+-- PostgREST. An KEINER Stelle wird service_role verwendet und an keiner
+-- Stelle wird RLS umgangen. Die Fixture wird als Login-/Owner-Rolle
+-- aufgebaut (vor dem ersten SET ROLE) — das ist Testaufbau, nicht
+-- Testgegenstand.
+--
+-- HINWEIS ZU „VERWEIGERT"-PFADEN: der lokale Supabase-Container stuerzt
+-- bei permission-denied (FEHLENDES PRIVILEG) ab, siehe
+-- job_assignments_rls.test.sql. Dieser Test loest so etwas nicht aus:
+-- `authenticated` besitzt auf storage.objects und public.jobs volle
+-- DML-GRANTS (verifiziert), jede Ablehnung hier kommt also aus einer
+-- RLS-Policy — entweder als 0 betroffene Zeilen (SELECT/UPDATE) oder als
+-- sauberer 42501 „new row violates row-level security policy" (INSERT).
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende.
+-- Ausfuehren lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/job_photo_storage_isolation.test.sql
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = b1…1 | Firma B = b1…2
+-- Admin A = b2…1
+-- ANNA    = b2…2  Legacy-PRIMAER von J1        -> darf lesen + hochladen
+-- BERND   = b2…3  SEKUNDAER auf J1             -> darf lesen, NICHT hochladen
+-- CARLA   = b2…4  Firma A, J1 NICHT zugewiesen -> der Angreifer
+-- Admin B = b2…5 | DORA = b2…6 (Firma B)
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000001','authenticated','authenticated','p-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000002','authenticated','authenticated','p-anna@example.test','{"full_name":"Anna Primaer"}'),
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000003','authenticated','authenticated','p-bernd@example.test','{"full_name":"Bernd Sekundaer"}'),
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000004','authenticated','authenticated','p-carla@example.test','{"full_name":"Carla Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000005','authenticated','authenticated','p-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','b2000000-0000-0000-0000-000000000006','authenticated','authenticated','p-dora@example.test','{"full_name":"Dora Fremdfirma"}');
+end $$;
+
+-- Der auth-Trigger handle_new_user ist in der lokalen Baseline nicht
+-- enthalten — Profile werden deshalb explizit angelegt (auf Produktion
+-- legt der Trigger sie an, daher on conflict do nothing).
+insert into public.profiles (id, full_name) values
+  ('b2000000-0000-0000-0000-000000000001','Admin A'),
+  ('b2000000-0000-0000-0000-000000000002','Anna Primaer'),
+  ('b2000000-0000-0000-0000-000000000003','Bernd Sekundaer'),
+  ('b2000000-0000-0000-0000-000000000004','Carla Fremd'),
+  ('b2000000-0000-0000-0000-000000000005','Admin B'),
+  ('b2000000-0000-0000-0000-000000000006','Dora Fremdfirma')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('b1000000-0000-0000-0000-000000000001','Foto Firma A','foto-firma-a-test'),
+  ('b1000000-0000-0000-0000-000000000002','Foto Firma B','foto-firma-b-test');
+
+update public.profiles set company_id='b1000000-0000-0000-0000-000000000001', role='admin',    is_active=true where id='b2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='b1000000-0000-0000-0000-000000000001', role='employee', is_active=true where id in
+  ('b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000003','b2000000-0000-0000-0000-000000000004');
+update public.profiles set company_id='b1000000-0000-0000-0000-000000000002', role='admin',    is_active=true where id='b2000000-0000-0000-0000-000000000005';
+update public.profiles set company_id='b1000000-0000-0000-0000-000000000002', role='employee', is_active=true where id='b2000000-0000-0000-0000-000000000006';
+
+-- Auftraege:
+--   J1 = b4…1  Firma A, single, {ANNA primaer, BERND sekundaer}
+--   J2 = b4…2  Firma A, single, {CARLA}   -> Kontrollfall gegen Overblocking
+--   J5 = b4…5  Firma B, single, {DORA}
+insert into public.jobs
+  (id,company_id,assigned_to,created_by,customer_name,service_name,location_address,status,job_type,date,start_time,recurring_days,is_active,created_at,updated_at,scheduled_start) values
+  ('b4000000-0000-0000-0000-000000000001','b1000000-0000-0000-0000-000000000001',null,'b2000000-0000-0000-0000-000000000001','K1','S1','O1','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('b4000000-0000-0000-0000-000000000002','b1000000-0000-0000-0000-000000000001',null,'b2000000-0000-0000-0000-000000000001','K2','S2','O2','open','single',current_date,'09:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null),
+  ('b4000000-0000-0000-0000-000000000005','b1000000-0000-0000-0000-000000000002',null,'b2000000-0000-0000-0000-000000000005','K5','S5','O5','open','single',current_date,'08:00',null,true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00',null);
+
+create temporary table _r (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+-- Pfad-Helfer: <company_id>/<job_id>/<datei>
+create or replace function pg_temp.p(co uuid, job uuid, datei text) returns text language sql immutable as $f$
+  select co::text||'/'||job::text||'/'||datei;
+$f$;
+
+-- Der Bucket wird von KEINER Migration angelegt (nur in lib/schema.sql
+-- beschrieben) — weitere Drift. Fuer den Test defensiv sicherstellen.
+insert into storage.buckets (id, name, public)
+values ('job-photos','job-photos',false)
+on conflict (id) do nothing;
+
+
+-- =========================================================
+-- Ausgangslage: Zuweisungen deterministisch setzen
+-- =========================================================
+-- Der Legacy-Zeiger muss deterministisch stehen, sonst ist „sekundaer"
+-- nicht nachweisbar: erst den gewuenschten Primaer ALLEIN setzen, dann den
+-- Zweiten ergaenzen (Regel 1 von compat_primary_assignee, vgl.
+-- shared_job_time_multi_assignment.test.sql).
+do $$
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+
+  perform public.set_job_assignments('b4000000-0000-0000-0000-000000000001',
+    array['b2000000-0000-0000-0000-000000000002']::uuid[]);
+  perform public.set_job_assignments('b4000000-0000-0000-0000-000000000001',
+    array['b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000003']::uuid[]);
+
+  perform public.set_job_assignments('b4000000-0000-0000-0000-000000000002',
+    array['b2000000-0000-0000-0000-000000000004']::uuid[]);
+
+  execute 'reset role';
+end $$;
+
+-- Fremdfirmen-Zuweisung direkt verdrahten (ein zweiter Rollenwechsel als
+-- Admin B braechte keinen Erkenntnisgewinn).
+insert into public.job_assignments (job_id, employee_id, employee_name_snapshot)
+values ('b4000000-0000-0000-0000-000000000005','b2000000-0000-0000-0000-000000000006','Dora Fremdfirma');
+update public.jobs set assigned_to='b2000000-0000-0000-0000-000000000006'
+where id='b4000000-0000-0000-0000-000000000005';
+
+-- Bestandsobjekte im Bucket (als Owner-Rolle angelegt = Testaufbau):
+--   OBJ_J1 gehoert ANNA und liegt in Firma A / J1
+--   OBJ_J5 gehoert DORA und liegt in Firma B / J5
+insert into storage.objects (id, bucket_id, name, owner, owner_id) values
+  ('b5000000-0000-0000-0000-000000000001','job-photos',
+   pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg'),
+   'b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000002'),
+  ('b5000000-0000-0000-0000-000000000005','job-photos',
+   pg_temp.p('b1000000-0000-0000-0000-000000000002','b4000000-0000-0000-0000-000000000005','dora.jpg'),
+   'b2000000-0000-0000-0000-000000000006','b2000000-0000-0000-0000-000000000006');
+
+-- Sanity: die Ausgangslage ist die, die wir glauben.
+do $$
+declare v text;
+begin
+  select assigned_to::text into v from public.jobs where id='b4000000-0000-0000-0000-000000000001';
+  if v <> 'b2000000-0000-0000-0000-000000000002' then
+    raise exception 'FIXTURE KAPUTT: Legacy-Primaer von J1 ist % statt ANNA', v;
+  end if;
+  if (select count(*) from public.job_assignments where job_id='b4000000-0000-0000-0000-000000000001') <> 2 then
+    raise exception 'FIXTURE KAPUTT: J1 hat nicht genau 2 Zuweisungen';
+  end if;
+end $$;
+
+
+-- =========================================================
+-- TEIL A — STORAGE: das Leck ist zu (P0-1)
+-- =========================================================
+
+-- CASE 1: CARLA (Firma A, J1 NICHT zugewiesen) liest das Foto von J1.
+-- Das ist der Kernfall des Lecks — vor der Migration lieferte er 1.
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and name = pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg');
+  execute 'reset role';
+  insert into _r values (1,'Nicht zugewiesener Mitarbeiter liest FREMDES Auftragsfoto','0',n::text);
+  raise notice 'CASE 1 -> %', n;
+end $$;
+
+-- CASE 2: CARLA laedt in den Auftragsordner von J1 hoch.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','carla-hack.jpg'),
+       'b2000000-0000-0000-0000-000000000004','b2000000-0000-0000-0000-000000000004');
+    v := 'ERLAUBT';
+  exception when insufficient_privilege then v := 'ABGELEHNT';
+            when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (2,'Nicht zugewiesener Mitarbeiter laedt in FREMDEN Auftragsordner','ABGELEHNT',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: ANNA (Primaer, zugewiesen) liest ihr Auftragsfoto -> muss gehen.
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and name = pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg');
+  execute 'reset role';
+  insert into _r values (3,'Zugewiesener Mitarbeiter (Primaer) liest sein Auftragsfoto','1',n::text);
+  raise notice 'CASE 3 -> %', n;
+end $$;
+
+-- CASE 4: ANNA laedt in ihren eigenen Auftragsordner hoch -> muss gehen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna-neu.jpg'),
+       'b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000002');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (4,'Zugewiesener Mitarbeiter (Primaer) laedt in EIGENEN Auftragsordner','ERLAUBT',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- CASE 5: BERND (SEKUNDAER zugewiesen) liest das Foto -> muss gehen.
+-- Die Zuweisungsmenge zaehlt beim LESEN (Stand seit 20260730000000).
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and name = pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg');
+  execute 'reset role';
+  insert into _r values (5,'SEKUNDAER Zugewiesener liest Auftragsfoto (Zuweisungsmenge)','1',n::text);
+  raise notice 'CASE 5 -> %', n;
+end $$;
+
+-- CASE 6: BERND laedt hoch -> ABGELEHNT.
+-- BEWUSSTE, DOKUMENTIERTE ASYMMETRIE: der Foto-/Kommentar-SCHREIBPFAD
+-- haengt projektweit am Legacy-Primaer (assigned_to), nicht an der
+-- Zuweisungsmenge — siehe CLAUDE.md und Abschnitt 2 der Migration. Die App
+-- bietet Bernd den Upload gar nicht erst an (isPrimaryAssignee). Dieser
+-- Fall haelt den Status quo fest, damit eine spaetere Angleichung eine
+-- BEWUSSTE Aenderung ist und kein Versehen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','bernd.jpg'),
+       'b2000000-0000-0000-0000-000000000003','b2000000-0000-0000-0000-000000000003');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (6,'SEKUNDAER Zugewiesener laedt hoch (Schreibpfad bleibt am Primaer)','ABGELEHNT',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: Admin A liest das Foto -> muss gehen (Admin sieht alles der Firma).
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and name = pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg');
+  execute 'reset role';
+  insert into _r values (7,'Admin liest Foto eines Auftrags seiner Firma','1',n::text);
+  raise notice 'CASE 7 -> %', n;
+end $$;
+
+-- CASE 8: Admin A laedt in einen Auftragsordner hoch, dem er selbst nicht
+-- zugewiesen ist -> muss gehen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','admin.jpg'),
+       'b2000000-0000-0000-0000-000000000001','b2000000-0000-0000-0000-000000000001');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (8,'Admin laedt in beliebigen Auftragsordner seiner Firma hoch','ERLAUBT',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- CASE 9: Admin A sieht ALLE Fotos seiner Firma (nach CASE 4 + 8 sind es 3).
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and (storage.foldername(name))[1] = 'b1000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (9,'Admin verwaltet saemtliche Firmenfotos (anna+anna-neu+admin)','3',n::text);
+  raise notice 'CASE 9 -> %', n;
+end $$;
+
+-- CASE 10: CARLA liest ihren EIGENEN Auftragsordner -> kein Overblocking.
+-- (Sie hat auf J2 noch kein Foto; entscheidend ist, dass der Upload geht.)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000002','carla-eigen.jpg'),
+       'b2000000-0000-0000-0000-000000000004','b2000000-0000-0000-0000-000000000004');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (10,'Kein Overblocking: Mitarbeiter laedt in EIGENEN Auftragsordner','ERLAUBT',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- CASE 11: DORA (Firma B) liest das Foto aus Firma A -> Firmen-Isolation.
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000006');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and name = pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','anna.jpg');
+  execute 'reset role';
+  insert into _r values (11,'Mitarbeiter FREMDER Firma liest Foto','0',n::text);
+  raise notice 'CASE 11 -> %', n;
+end $$;
+
+-- CASE 12: Admin B liest das Foto aus Firma A -> Firmen-Isolation.
+do $$
+declare n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000005');
+  execute 'set local role authenticated';
+  select count(*) into n from storage.objects
+   where bucket_id='job-photos'
+     and (storage.foldername(name))[1] = 'b1000000-0000-0000-0000-000000000001';
+  execute 'reset role';
+  insert into _r values (12,'Admin FREMDER Firma liest Fotos','0',n::text);
+  raise notice 'CASE 12 -> %', n;
+end $$;
+
+-- CASE 13: DORA laedt in einen Ordner von Firma A hoch -> ABGELEHNT.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000006');
+  execute 'set local role authenticated';
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','dora-hack.jpg'),
+       'b2000000-0000-0000-0000-000000000006','b2000000-0000-0000-0000-000000000006');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (13,'Mitarbeiter FREMDER Firma laedt in Firma-A-Ordner','ABGELEHNT',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+-- CASE 14: Pfad-Manipulation. ANNA schreibt ihre EIGENE company_id, haengt
+-- aber ein zweites Segment an, das auf keinen Auftrag zeigt — einmal als
+-- syntaktisch gueltiges, aber nicht existierendes UUID, einmal als
+-- voelliger Unsinn ("not-a-uuid"). BEIDE muessen abgelehnt werden, und der
+-- zweite Fall darf KEINEN Cast-Fehler (22P02) ausloesen, sondern ein
+-- schlichtes „Policy trifft nicht zu".
+do $$
+declare v1 text; v2 text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-0000000000ff','ghost.jpg'),
+       'b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000002');
+    v1 := 'ERLAUBT';
+  exception when others then v1 := 'ABGELEHNT';
+  end;
+
+  begin
+    insert into storage.objects (bucket_id, name, owner, owner_id) values
+      ('job-photos', 'b1000000-0000-0000-0000-000000000001/not-a-uuid/kaputt.jpg',
+       'b2000000-0000-0000-0000-000000000002','b2000000-0000-0000-0000-000000000002');
+    v2 := 'ERLAUBT';
+  exception when invalid_text_representation then v2 := 'CAST-FEHLER(22P02)';
+            when others then v2 := 'ABGELEHNT';
+  end;
+
+  execute 'reset role';
+  insert into _r values (14,'Upload unter ungueltigem 2. Pfadsegment (nicht existierend / kein UUID)',
+    'ghost=ABGELEHNT/muell=ABGELEHNT','ghost='||v1||'/muell='||v2);
+  raise notice 'CASE 14 -> ghost=% muell=%', v1, v2;
+end $$;
+
+-- CASE 15: DER EIGENTLICHE GRUND FUER DEN TEXTVERGLEICH.
+-- Ein Objekt mit kaputtem Pfadsegment liegt bereits im Bucket (hier als
+-- Owner-Rolle eingeschleust, also am RLS vorbei — genau wie eine Altlast
+-- oder ein am Storage-API vorbei angelegtes Objekt). Danach listet ANNA
+-- ganz normal die Fotos ihrer Firma.
+--
+-- Mit `((storage.foldername(name))[2])::uuid` wuerde diese Abfrage mit
+-- 22P02 ABBRECHEN — ein einziges kaputtes Objekt legte die Fotoliste der
+-- gesamten Firma lahm. Mit dem Textvergleich wird die kaputte Zeile
+-- schlicht nicht sichtbar und alles andere funktioniert weiter.
+insert into storage.objects (bucket_id, name, owner, owner_id) values
+  ('job-photos','b1000000-0000-0000-0000-000000000001/nicht-mal-ansatzweise-uuid/altlast.jpg',
+   'b2000000-0000-0000-0000-000000000001','b2000000-0000-0000-0000-000000000001');
+
+do $$
+declare v text; n int;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    select count(*) into n from storage.objects
+     where bucket_id='job-photos'
+       and (storage.foldername(name))[1] = 'b1000000-0000-0000-0000-000000000001';
+    v := 'zeilen='||n::text;
+  exception when invalid_text_representation then v := 'CAST-FEHLER(22P02)';
+            when others then v := 'FEHLER('||sqlstate||')';
+  end;
+  execute 'reset role';
+  -- ANNA sieht genau die drei Objekte von J1 (anna.jpg + anna-neu.jpg aus
+  -- CASE 4 + admin.jpg aus CASE 8). Das Altlast-Objekt bleibt unsichtbar,
+  -- und carla-eigen.jpg aus CASE 10 gehoert zu J2.
+  insert into _r values (15,'Kaputt benanntes Bestandsobjekt bricht die Fotoliste NICHT',
+    'zeilen=3',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: Die beiden weiten Drift-Policies existieren nicht mehr, und auf
+-- storage.objects stehen genau die drei beabsichtigten job-photos-Policies.
+do $$
+declare weit int; gesamt int;
+begin
+  select count(*) into weit from pg_policies
+   where schemaname='storage' and tablename='objects'
+     and policyname in ('job-photos storage: Lesen aus eigenem Firma-Ordner',
+                        'job-photos storage: Hochladen in eigenen Firma-Ordner');
+  select count(*) into gesamt from pg_policies
+   where schemaname='storage' and tablename='objects' and policyname like 'job-photos%';
+  insert into _r values (16,'Policy-Inventar storage.objects (weit=0, job-photos gesamt=3)',
+    'weit=0/gesamt=3','weit='||weit::text||'/gesamt='||gesamt::text);
+  raise notice 'CASE 16 -> weit=% gesamt=%', weit, gesamt;
+end $$;
+
+
+-- =========================================================
+-- TEIL B — jobs: kein direktes UPDATE mehr (P0-2)
+-- =========================================================
+-- WICHTIG ZUR ABGRENZUNG: shared_job_time_multi_assignment.test.sql
+-- CASE 26 prueft dasselbe Thema, aber mit einem SEKUNDAER Zugewiesenen —
+-- der scheiterte schon immer an `assigned_to = auth.uid()`. Der Fall war
+-- damit falsche Sicherheit: der LEGACY-PRIMAER kam durch. Alle Faelle hier
+-- laufen deshalb bewusst als ANNA, dem Primaer von J1.
+
+-- CASE 17: ANNA faelscht started_at.
+do $$
+declare n int; v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set started_at = now() - interval '9 hours'
+     where id='b4000000-0000-0000-0000-000000000001';
+    get diagnostics n = row_count;
+    v := 'zeilen='||n::text;
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (17,'Primaer faelscht started_at per direktem UPDATE','zeilen=0',v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: ANNA faelscht completed_at + status in einem Rutsch.
+do $$
+declare n int; v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set completed_at = now(), status = 'completed'
+     where id='b4000000-0000-0000-0000-000000000001';
+    get diagnostics n = row_count;
+    v := 'zeilen='||n::text;
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (18,'Primaer faelscht completed_at + status per direktem UPDATE','zeilen=0',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: und auch sonst nichts (Gegenprobe auf ein Nicht-Zeit-Feld).
+do $$
+declare n int; v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set customer_name='Gekapert'
+     where id='b4000000-0000-0000-0000-000000000001';
+    get diagnostics n = row_count;
+    v := 'zeilen='||n::text;
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (19,'Primaer aendert customer_name per direktem UPDATE','zeilen=0',v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- CASE 20: der Auftrag ist nach 16–18 unveraendert.
+do $$
+declare v text;
+begin
+  select status::text||'/'||coalesce(started_at::text,'null')||'/'||coalesce(completed_at::text,'null')||'/'||customer_name
+    into v from public.jobs where id='b4000000-0000-0000-0000-000000000001';
+  insert into _r values (20,'Auftrag nach den UPDATE-Versuchen unveraendert','open/null/null/K1',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: die Policy existiert nicht mehr; Mitarbeiter haben auf jobs
+-- ausschliesslich SELECT.
+do $$
+declare v text;
+begin
+  select coalesce(string_agg(cmd,',' order by cmd),'(keine)') into v
+  from pg_policies where schemaname='public' and tablename='jobs' and policyname like 'employee%';
+  insert into _r values (21,'Verbleibende Employee-Policies auf jobs','SELECT',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- CASE 22: start_own_job funktioniert unveraendert (ANNA, Primaer).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.start_own_job('b4000000-0000-0000-0000-000000000001', timestamptz '2026-08-05 08:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER('||sqlstate||')';
+  end;
+  execute 'reset role';
+  select v||'/'||status::text into v from public.jobs where id='b4000000-0000-0000-0000-000000000001';
+  insert into _r values (22,'start_own_job weiterhin funktionsfaehig (RPC nicht gebrochen)','OK/in_progress',v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: complete_own_job durch den SEKUNDAEREN — geteilte Job-Uhr bleibt
+-- intakt (Anna startet, Bernd schliesst ab).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000003');
+  execute 'set local role authenticated';
+  begin
+    perform public.complete_own_job('b4000000-0000-0000-0000-000000000001', timestamptz '2026-08-05 10:00+00');
+    v := 'OK';
+  exception when others then v := 'FEHLER('||sqlstate||')';
+  end;
+  execute 'reset role';
+  select v||'/'||status::text||'/dauer='||(completed_at - started_at)::text
+    into v from public.jobs where id='b4000000-0000-0000-0000-000000000001';
+  insert into _r values (23,'complete_own_job durch Sekundaeren; geteilte Job-Uhr intakt','OK/completed/dauer=02:00:00',v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+-- CASE 24: der Admin kann Auftraege weiterhin direkt aendern.
+do $$
+declare n int; v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set customer_name='K1 neu'
+     where id='b4000000-0000-0000-0000-000000000001';
+    get diagnostics n = row_count;
+    v := 'zeilen='||n::text;
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  execute 'reset role';
+  insert into _r values (24,'Admin aendert Auftrag seiner Firma weiterhin','zeilen=1',v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: der Admin der FREMDEN Firma kann es nicht.
+do $$
+declare n int; v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000005');
+  execute 'set local role authenticated';
+  begin
+    update public.jobs set customer_name='Fremd gekapert'
+     where id='b4000000-0000-0000-0000-000000000001';
+    get diagnostics n = row_count;
+    v := 'zeilen='||n::text;
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (25,'Admin FREMDER Firma aendert Auftrag','zeilen=0',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+-- CASE 26: Gegenprobe zur Tabellen-Policy — CARLA kann auch keine
+-- job_photos-ZEILE zu einem fremden Auftrag anlegen. (Diese Policy wurde
+-- nicht geaendert; der Fall haelt fest, dass Storage und Tabelle nach der
+-- Migration dieselbe Grenze ziehen.)
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('b2000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    insert into public.job_photos (job_id, company_id, uploaded_by, storage_path, file_name)
+    values ('b4000000-0000-0000-0000-000000000001','b1000000-0000-0000-0000-000000000001',
+            'b2000000-0000-0000-0000-000000000004',
+            pg_temp.p('b1000000-0000-0000-0000-000000000001','b4000000-0000-0000-0000-000000000001','carla-hack.jpg'),
+            'carla-hack.jpg');
+    v := 'ERLAUBT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (26,'job_photos-ZEILE zu fremdem Auftrag (Tabellen-Policy, unveraendert)','ABGELEHNT',v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _r order by case_no;
+
+do $$
+declare fails int; gesamt int;
+begin
+  select count(*), count(*) filter (where ergebnis is distinct from erwartet)
+    into gesamt, fails from _r;
+  if fails > 0 then
+    raise exception 'FOTO-ISOLATION TEST: % von % Faellen FEHLGESCHLAGEN', fails, gesamt;
+  end if;
+  raise notice 'ALLE % FAELLE PASS', gesamt;
+end $$;
+
+rollback;


### PR DESCRIPTION
> ⚠️ **DO NOT DEPLOY WITHOUT EXPLICIT APPROVAL.** Production still carries both vulnerabilities described below and will keep carrying them until this migration is applied. Merging this PR changes nothing on Production by itself.

## Problem

Two isolation defects, both **proven empirically against Production** on 2026-08-05 using a synthetic fixture inside a guaranteed-rollback transaction (`BEGIN … RAISE EXCEPTION`, zero residue confirmed afterwards). Roles were set via `SET ROLE authenticated` + `request.jwt.claims`, i.e. exactly the PostgREST path the app uses.

| Probe | Result |
|---|---|
| T1 — employee **not** assigned to job J1 reads J1's photo object | **1 row — LEAK** |
| T2 — same employee uploads into `<company>/<J1>/` | **ALLOWED — LEAK** |
| T3 — same employee reads the J1 `jobs` row | 0 rows (correct) |
| T4 — legacy primary sets `started_at = now()-9h`, `completed_at`, `status='completed'` by direct UPDATE | **ALLOWED — LEAK** |

T3 shows cross-company isolation was never broken. What was broken is isolation **between employees of the same company**.

## Root cause

**Photos:** RLS policies for the same command are PERMISSIVE and OR together. Production carries two policies with no job predicate at all — `job-photos storage: Lesen aus eigenem Firma-Ordner` (SELECT) and `job-photos storage: Hochladen in eigenen Firma-Ordner` (INSERT) — checking only `bucket_id` and the company folder. Sitting alongside the strict policies, they made those strict policies **effectively dead**. Neither is created by any migration in this repo: pure Dashboard drift, described only in a comment in `20260730000000`.

**Job clock:** `employee update own assigned jobs` (from baseline `20260713000000`) let the legacy primary assignee `UPDATE` their own `jobs` row. RLS is row-level, not column-level, so it cannot distinguish "edit a note" from "forge `started_at`". Since the timesheet computes `completed_at - started_at`, that is a direct payroll-manipulation path.

## Change

1. Drop the two wide `storage.objects` policies.
2. Re-create the three correct ones (`read allowed`, `insert allowed`, `delete own upload`) with their **exact production wording**, capturing drift into a migration — only `read allowed` came from a migration before. No-op on Production, first-time parity everywhere else.
3. Drop `employee update own assigned jobs`.

**Revoked rather than restricted**, because: column-level `REVOKE` would hit admins too (same `authenticated` role); a BEFORE-UPDATE trigger couldn't identify the actor (`auth.uid()` still returns the employee inside the SECURITY DEFINER RPCs, so it would break `start_own_job`/`complete_own_job`); and there is no caller — every client write path is either `role === 'admin'`-gated or goes through the two RPCs. Both RPCs are `prosecdef = true` and bypass RLS, so they are unaffected. Employees keep `SELECT` only.

Storage policies compare `j.id::text = (storage.foldername(name))[2]` rather than casting the segment to `uuid`. A single malformed object name would otherwise abort the **entire** photo listing with `22P02` instead of rejecting just that row — reproduced locally as a negative control: cast → `ABBRUCH(22P02)`, text → `OK`. Isolation is identical; the trade-off is loss of index sargability on `jobs.id`, negligible at ~900 rows (a functional index is the fix if it ever matters — not a return to the cast).

## Test evidence

Against a database rebuilt from scratch from migrations (`supabase stop --no-backup` + `supabase start`, all 24 applied cleanly — which also validates the DDL syntax):

| Suite | Result |
|---|---|
| `job_photo_storage_isolation.test.sql` (new, 26 cases) | **26/26 PASS** |
| `shared_job_time_multi_assignment.test.sql` | **27/27 PASS** (no regression) |
| `job_assignments_rls.test.sql` | **30/30 PASS** (no regression) |

All access runs as real roles (`SET ROLE` + `request.jwt.claims`); **no `service_role` anywhere**. Covers: unassigned employee refused read and upload; assigned primary allowed both; secondary assignee may read but not write; admin unrestricted within their company; cross-company refused in both directions; malformed path segments refused; a broken existing object does not break the photo listing; primary cannot forge `started_at` / `completed_at` / `status`; both RPCs still work and the shared clock stays intact; admin writes unaffected.

Live re-verification on Staging after deployment there: secondary assignee reads both photos but is refused INSERT with `42501`; primary and admin may write.

### ⚠️ What the green suites do **not** prove

Local and Staging databases **never had the two wide policies**, so the `DROP`s ran into thin air there. A green run proves the three strict policies are correct and that nothing regressed — it does **not** prove the drop works. **Only Production has the vulnerable policies, so the drop can be verified only after Production deployment.** Re-run the T1/T2/T4 probes against Production immediately afterwards; that is the sole conclusive check.

## Native impact

**None** — no client code in this PR.

## Deployment notes (not part of merging)

- Order: this PR first, then the `20260805000001` bucket PR.
- `DROP POLICY` takes `ACCESS EXCLUSIVE` on `storage.objects`, a live table. Guard with `ALTER DATABASE postgres SET lock_timeout='5s'` immediately before and `RESET` after.
- Behaviour change to expect: a **secondary** assignee can no longer upload files. That right existed only via the drift policy; the client never offered it (`JobDetailScreen` gates on `isPrimaryAssignee`), and the corresponding `job_photos` row was always blocked anyway — so at most it produced orphan files. Aligning the write path to the full assignment set is a **functional** change and belongs in its own PR.
- Rollback SQL is documented in the migration header.

## Remaining known drift (not addressed here)

The `job-photos` bucket itself (follow-up PR), the `dispatch-admin-notifications` webhook trigger on `notification_outbox`, and `supabase_realtime` publication membership.

## QA note

The manual Staging test did **not** prove that Employee B can complete a job started by Employee A — `completed_by` was A in that run. That scenario is covered **only** by the automated SQL suite (case 23: secondary assignee completes, shared clock intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
