### PR TITLE
chore(db): define the job-photos storage bucket as a migration

### DIFF
--- a/supabase/migrations/20260805000001_job_photos_bucket.sql
+++ b/supabase/migrations/20260805000001_job_photos_bucket.sql
@@ -1,0 +1,77 @@
+-- =========================================================
+-- MIGRATION: Storage-Bucket "job-photos" versioniert anlegen
+-- Datum: 2026-08-05
+-- =========================================================
+-- ZWECK
+--   Schliesst die letzte bekannte Storage-Drift. Bisher wurde der Bucket
+--   NUR in lib/schema.sql beschrieben — und die Datei ist ausdrueckliche
+--   REFERENZ, keine ausgefuehrte Quelle. Folge: jede aus Migrationen
+--   gebaute Umgebung (lokal, CI, Staging) hatte GAR KEINEN Bucket, waehrend
+--   Produktion einen hat. Auf Staging ist das am 2026-08-05 konkret
+--   aufgefallen: die drei "job-photos"-Policies auf storage.objects waren
+--   vorhanden (Migration 20260805000000), aber jeder Foto-Upload lief ins
+--   Leere, weil das Ziel schlicht nicht existierte.
+--
+--   20260805000000 hat die POLICIES ins Repository geholt und den Bucket
+--   selbst ausdruecklich noch offen gelassen. Das wird hier nachgeholt.
+--
+-- WERTE NICHT GERATEN, SONDERN AUS PRODUKTION UEBERNOMMEN
+--   Ausgelesen am 2026-08-05 per GET /storage/v1/bucket/job-photos gegen
+--   Produktion (rein lesend, nichts veraendert). Drei Quellen stimmen exakt
+--   ueberein — deshalb sind die Werte hier belastbar und keine Annahme:
+--
+--     Produktion (live)          public=false  10485760  jpeg,png,webp
+--     lib/schema.sql             public=false  10485760  jpeg,png,webp
+--     services/photos/photos.service.ts
+--       MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  = 10485760
+--       ALLOWED_MIME_TYPES  = image/jpeg | image/png | image/webp
+--
+--   Der Bucket ist PRIVAT (public=false). Der Zugriff laeuft ausschliesslich
+--   ueber Signed URLs aus services/photos/photos.service.ts; wer eine Datei
+--   sehen oder anlegen darf, entscheiden allein die drei RLS-Policies auf
+--   storage.objects aus 20260805000000. Diese Migration vergibt KEINE
+--   Rechte — sie legt nur das Ziel an.
+--
+--   Serverseitiges file_size_limit/allowed_mime_types ist bewusst die
+--   ZWEITE Verteidigungslinie: die clientseitige Pruefung im Service ist
+--   Komfort (fruehe, verstaendliche Fehlermeldung), erzwungen wird sie hier.
+--
+-- WIRKUNG JE UMGEBUNG
+--   Produktion : reiner No-Op. Der Bucket existiert seit 2026-06-11 mit
+--                exakt diesen Werten; das ON CONFLICT schreibt identische
+--                Werte zurueck. Es gehen KEINE Objekte verloren — die
+--                Dateien haengen an storage.objects, nicht an dieser Zeile.
+--   Staging/lokal/CI : legt den Bucket erstmals an und macht Foto-Tests
+--                ueberhaupt erst moeglich.
+--
+-- IDEMPOTENT: beliebig oft ausfuehrbar (ON CONFLICT DO UPDATE).
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'job-photos',
+  'job-photos',
+  false,
+  10485760, -- 10 MB = MAX_FILE_SIZE_BYTES in services/photos/photos.service.ts
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update
+  set name               = excluded.name,
+      public             = excluded.public,
+      file_size_limit    = excluded.file_size_limit,
+      allowed_mime_types = excluded.allowed_mime_types;
+
+
+-- =========================================================
+-- ROLLBACK (manuell)
+-- =========================================================
+-- NICHT einfach "delete from storage.buckets where id='job-photos'" —
+-- das schlaegt fehl, solange Objekte im Bucket liegen (FK von
+-- storage.objects.bucket_id), und waere dort, wo es durchginge, ein
+-- DATENVERLUST. Ein Rollback ist praktisch nur in einer frisch gebauten
+-- Umgebung sinnvoll:
+--
+--   delete from storage.objects where bucket_id = 'job-photos';  -- Datenverlust!
+--   delete from storage.buckets where id = 'job-photos';
+--
+-- In Produktion ist diese Migration ohnehin ein No-Op, dort gibt es nichts
+-- zurueckzurollen.


### PR DESCRIPTION
> Deploy **after** #69. No-op on Production. Do not deploy without explicit approval.

## Problem

The `job-photos` bucket existed only in `lib/schema.sql` — and that file is explicit **reference**, not an executed source. Every environment built from migrations (local, CI, Staging) therefore had **no bucket at all**, while Production has one.

This surfaced concretely on Staging on 2026-08-05: the three `job-photos` policies on `storage.objects` were present, but every upload went nowhere because the target simply did not exist. Combined with the dead web picker (#68) it produced a QA run that looked like it passed while nothing was persisted.

## Change

One idempotent `INSERT … ON CONFLICT DO UPDATE` creating the bucket.

**Values were not guessed.** Read on 2026-08-05 via `GET /storage/v1/bucket/job-photos` against Production (read-only) and identical in three independent places:

| Source | private | size limit | MIME types |
|---|---|---|---|
| Production (live) | `public=false` | `10485760` | jpeg, png, webp |
| `lib/schema.sql` | `public=false` | `10485760` | jpeg, png, webp |
| `services/photos/photos.service.ts` | — | `MAX_FILE_SIZE_BYTES` | `ALLOWED_MIME_TYPES` |

The bucket is **private**; access runs solely through signed URLs. Who may read or write is decided entirely by the RLS policies on `storage.objects` — this migration grants **no** rights, it only creates the target. The server-side limits are deliberately the second line of defence behind client-side validation.

## Effect per environment

- **Production:** pure no-op. The bucket has existed since 2026-06-11 with exactly these values; `ON CONFLICT` writes identical values back. **No objects are lost** — files hang off `storage.objects`, not off this row.
- **Staging / local / CI:** creates the bucket for the first time and makes photo tests possible at all.

## Test evidence

- Syntax validated inside `BEGIN … ROLLBACK` against a local container: bucket materialises in-transaction with `file_size_limit=10485760`, then discarded; the local database was confirmed unchanged afterwards.
- Verified on Staging after applying there: `public=false`, `10485760`, `image/jpeg,image/png,image/webp` — byte-identical to Production.
- Idempotency follows from `ON CONFLICT DO UPDATE`.

## Native impact

**None** — no client code.

## Limitations

- Ordering matters: apply **after** `20260805000000` (#69).
- Rollback is not a plain `DELETE` — the FK from `storage.objects` blocks it while files exist, and forcing it would mean data loss. Practical only in a freshly built environment; documented in the migration header. On Production there is nothing to roll back, since it is a no-op there.
- Remaining known drift stays out of scope: the `dispatch-admin-notifications` webhook trigger and `supabase_realtime` publication membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
