### PR TITLE
chore(eas): pin build profiles to their EAS environments

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -6,14 +6,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "development"
     },
     "preview": {
       "distribution": "internal",
       "environment": "preview"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "environment": "production"
     }
   },
   "submit": {


### PR DESCRIPTION
## Warum

Android-Push war seit jeher tot, weil **kein Android-Gerät je einen Expo Push Token erzeugen konnte**:

- Die beiden Android-**Production**-Builds stammen vom **2026-07-23**.
- Das `expo-notifications`-Plugin **und** `googleServicesFile` kamen erst am **2026-07-24** dazu (`7a6d3c8`).
- Die ausgelieferten Builds enthalten also weder FCM-Verdrahtung noch `google-services.json`.

Belegt in Prod: **41 Profile, genau 1 Push-Token** (ein Admin, iOS). **0 von 28 Mitarbeitern** haben einen Token.

## Was hier passiert

`google-services.json` ist bewusst gitignored (öffentliches Repo) und wird über die EAS-Dateivariable `GOOGLE_SERVICES_JSON` eingespielt (siehe `app.config.js`). Diese Variable existierte **nur** in der Umgebung `development` — ein `preview`- oder `production`-Build hätte die Datei also weiterhin nicht gehabt.

- **EAS-seitig** (nicht im Repo): `GOOGLE_SERVICES_JSON` als Secret-File-Variable für `preview` + `production` ergänzt. Die `development`-Variable blieb unangetastet.
- **Hier im Repo:** die Umgebungszuordnung der Build-Profile wird explizit gemacht, statt sie aus dem Profilnamen abzuleiten. `preview` trug sie bereits.

## Verifiziert vor dem Build

| Prüfung | Ergebnis |
|---|---|
| `android.package` | `com.ferash.taskopsmanager` — deckungsgleich mit Firebase |
| Firebase-Projekt / Sender | `taskops-manager` / `930224884095` |
| `expo-notifications` im Plugin-Array | vorhanden |
| EAS `projectId` | `e746276f-fbd7-49bd-aab6-dc3176e7661a` |
| FCM-V1-Credential in EAS | vorhanden, Projekt `taskops-manager` |

## Nicht Teil dieses PRs

Keine Änderung an der Notification-Logik, an Assignment-/Kommentar-Notifications, an Migrationen oder an Prod-Daten. Reine Build-Infrastruktur, damit ein echtes Android-Gerät überhaupt erst einen Token registrieren kann.

🤖 Generated with [Claude Code](https://claude.com/claude-code)