### PR TITLE
feat(notifications): aussagekräftigere Push-Texte + Deep-Link für Zuweisung

### DIFF
--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -8,6 +8,7 @@ import {
 } from "@/types/job";
 import { normalizeTime } from "@/utils/date";
 import { buildLegacyAssignees } from "@/utils/jobAssignees";
+import { buildAssignedPushBody } from "@/utils/jobNotificationContent";
 
 // Wird von updateJob() geworfen, wenn set_job_assignments bereits
 // erfolgreich committed wurde, das nachfolgende jobs-UPDATE und/oder
@@ -732,11 +733,30 @@ export async function createJob(input: CreateJobInput): Promise<CreateJobResult>
 
       // Nur senden, wenn wirklich ein Push-Token vorhanden ist
       if (employee?.expo_push_token) {
-        await sendPushNotification(
-          employee.expo_push_token,
-          "Neuer Auftrag",
-          `Du hast einen neuen Job: ${payload.service_name}`
-        );
+        await sendPushNotification(employee.expo_push_token, {
+          title: "Neuer Auftrag",
+          body: buildAssignedPushBody({
+            serviceName,
+            customerName,
+            locationAddress,
+            schedule: {
+              jobType: schedule.job_type,
+              date: schedule.date,
+              startTime: schedule.start_time,
+              recurringDays: schedule.recurring_days,
+            },
+          }),
+          // Gleiche Payload-Form wie der Dispatcher (dispatch-notifications).
+          // `jobId` ist der Schlüssel, den useNotificationNavigation ausliest —
+          // ohne ihn öffnet der Tap nur die App, nicht den Auftrag.
+          data: {
+            type: "job_assigned",
+            jobId: data.id,
+            companyId: profile.company_id,
+            employeeId: primaryEmployeeId,
+            status: payload.status,
+          },
+        });
       }
     } catch (pushError) {
       console.error(
@@ -958,18 +978,40 @@ export async function completeJob(
   return typeof data === "string" && data ? data : timestamp;
 }
 
-// Schickt eine Expo Push Notification an ein Gerät
-async function sendPushNotification(token: string, title: string, body: string) {
+// Payload einer Job-Push. `data` folgt exakt der Form, die der Dispatcher
+// (supabase/functions/dispatch-notifications) für gestartet/abgeschlossen
+// verschickt — damit liest useNotificationNavigation alle drei Ereignisse
+// über denselben Pfad aus.
+type JobPushMessage = {
+  title: string;
+  body: string;
+  data: {
+    type: string;
+    jobId: string;
+    companyId: string;
+    employeeId: string | null;
+    status: string;
+  };
+};
+
+// Schickt eine Expo Push Notification an ein Gerät.
+// `channelId`/`priority` spiegeln den Dispatcher: "default" ist exakt der
+// Kanal, den registerForPushNotifications auf Android anlegt (Importance MAX).
+async function sendPushNotification(token: string, message: JobPushMessage) {
   await fetch("https://exp.host/--/api/v2/push/send", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
     body: JSON.stringify({
       to: token,
       sound: "default",
-      title,
-      body,
+      title: message.title,
+      body: message.body,
+      data: message.data,
+      channelId: "default",
+      priority: "high",
     }),
   });
 }

--- a/supabase/functions/dispatch-notifications/index.ts
+++ b/supabase/functions/dispatch-notifications/index.ts
@@ -78,13 +78,29 @@ function jobTitle(row: ClaimedDelivery): string {
   return row.service_name?.trim() || row.customer_name?.trim() || "Auftrag";
 }
 
+// Der Admin soll am Text erkennen, WELCHER Auftrag gemeint ist, ohne die App
+// zu öffnen: wer, was, bei wem. Mehr steht hier nicht zur Verfügung —
+// claim_notification_deliveries liefert bewusst nur employee_name /
+// customer_name / service_name (keine Adresse, keine Terminierung). Eine
+// Erweiterung bräuchte eine Migration und gehört nicht in diesen Änderungsschritt.
 function buildContent(row: ClaimedDelivery): { title: string; body: string } {
   const who = row.employee_name?.trim() || "Ein Mitarbeiter";
+  const service = row.service_name?.trim();
+  const customer = row.customer_name?.trim();
+
+  // `what` ist die in Anführungszeichen gesetzte Leistung. Fehlt sie, rückt
+  // der Kunde nach (jobTitle) — dann darf er NICHT zusätzlich als "bei …"
+  // erscheinen, sonst steht er doppelt in der Zeile.
   const what = jobTitle(row);
-  if (row.event_type === "job_completed") {
-    return { title: "Job abgeschlossen", body: `${who} hat „${what}" abgeschlossen.` };
-  }
-  return { title: "Job gestartet", body: `${who} hat „${what}" gestartet.` };
+  const at = service && customer ? ` bei ${customer}` : "";
+
+  const done = row.event_type === "job_completed";
+  const verb = done ? "abgeschlossen" : "gestartet";
+
+  return {
+    title: done ? "Auftrag abgeschlossen" : "Auftrag gestartet",
+    body: `${who} hat „${what}“${at} ${verb}.`,
+  };
 }
 
 Deno.serve(async (req) => {

--- a/utils/jobNotificationContent.ts
+++ b/utils/jobNotificationContent.ts
@@ -1,0 +1,134 @@
+// utils/jobNotificationContent.ts
+// ─────────────────────────────────────────────────────────────────
+// Textbausteine für Job-Push-Benachrichtigungen. Bewusst REINE
+// Formatierung ohne Seiteneffekte und ohne Supabase-Zugriff, damit die
+// Segment-Reihenfolge und die Kürzungsregeln ohne Netzwerk nachvollziehbar
+// (und später testbar) bleiben.
+//
+// Warum hier und nicht im Service: `jobs.service.ts` entscheidet WANN
+// gesendet wird, dieses Modul entscheidet WAS drinsteht. Gleiches Muster
+// wie utils/jobSchedule.ts (Terminierung) und utils/jobAssignees.ts
+// (Zuweisungs-Anzeige) — Anzeige-/Textlogik gehört nicht in den Service.
+//
+// Die Gegenstelle für „gestartet"/„abgeschlossen" liegt serverseitig in
+// supabase/functions/dispatch-notifications/index.ts (buildContent). Dort
+// stehen nur employee_name/customer_name/service_name zur Verfügung — die
+// Claim-RPC liefert bewusst keine Adresse und keine Terminierung.
+// ─────────────────────────────────────────────────────────────────
+
+import { formatDateISO, normalizeTime } from "@/utils/date";
+import { formatRecurringDays } from "@/utils/recurrence";
+import type { JobType } from "@/types/job";
+
+// Trennzeichen zwischen den Segmenten. Mittelpunkt statt Komma, damit
+// Kundennamen mit Komma ("Müller, Meier & Co.") nicht mit der Segment-
+// Grenze verschwimmen.
+const SEPARATOR = " · ";
+
+// Die Adresse ist das am NIEDRIGSTEN priorisierte Segment: sie kommt nur
+// dazu, wenn sie kurz ist UND der Gesamttext dadurch nicht ausufert.
+// Android zeigt eingeklappt nur ~40–50 Zeichen; alles danach sieht der
+// Mitarbeiter erst nach dem Aufklappen. Service/Kunde/Zeit sind wichtiger.
+const MAX_LOCATION_LENGTH = 30;
+const MAX_BODY_LENGTH = 100;
+
+// Fallback, falls ausnahmsweise gar kein Segment gefüllt ist. Kunde, Ort
+// und Service sind in createJob Pflichtfelder, das sollte also nie greifen —
+// eine leere Push-Nachricht wäre aber deutlich schlimmer als ein Allgemeinplatz.
+const FALLBACK_BODY = "Dir wurde ein neuer Auftrag zugewiesen.";
+
+export type AssignedPushSchedule = {
+  jobType: JobType;
+  /** "YYYY-MM-DD" — nur bei single gesetzt. */
+  date?: string | null;
+  /** "HH:mm" oder "HH:mm:ss" (DB-Format). */
+  startTime?: string | null;
+  /** Kurzcodes "mon"…"sun" — nur bei recurring gesetzt. */
+  recurringDays?: string[] | null;
+};
+
+export type AssignedPushInput = {
+  serviceName?: string | null;
+  customerName?: string | null;
+  locationAddress?: string | null;
+  schedule: AssignedPushSchedule;
+};
+
+/**
+ * Terminangabe für die Push-Zeile.
+ *
+ *   single    → "Heute 18:00" | "Morgen 18:00" | "12.08. 18:00"
+ *   recurring → "Mo, Do · 18:00"
+ *
+ * Gibt null zurück, wenn weder Datum/Wochentage noch Uhrzeit bekannt sind.
+ * `ref` ist injizierbar, damit "Heute"/"Morgen" deterministisch prüfbar ist.
+ */
+export function formatAssignedSchedule(
+  schedule: AssignedPushSchedule,
+  ref: Date = new Date(),
+): string | null {
+  const time = normalizeTime(schedule.startTime);
+
+  if (schedule.jobType === "recurring") {
+    const days = formatRecurringDays(schedule.recurringDays);
+    // formatRecurringDays liefert "—" wenn die Liste leer ist — das ist ein
+    // Anzeige-Platzhalter und gehört nicht in eine Push-Nachricht.
+    const hasDays = days !== "—";
+    if (!hasDays) return time;
+    return time ? `${days}${SEPARATOR}${time}` : days;
+  }
+
+  const dateKey = schedule.date?.slice(0, 10) || null;
+  if (!dateKey) return time;
+
+  const dayLabel = formatRelativeDayLabel(dateKey, ref);
+  return time ? `${dayLabel} ${time}` : dayLabel;
+}
+
+/** "Heute" | "Morgen" | "12.08." für ein "YYYY-MM-DD"-Datum. */
+function formatRelativeDayLabel(dateKey: string, ref: Date): string {
+  if (formatDateISO(ref) === dateKey) return "Heute";
+
+  const tomorrow = new Date(ref);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (formatDateISO(tomorrow) === dateKey) return "Morgen";
+
+  const [, month, day] = dateKey.split("-");
+  // Jahr bewusst weglassen: in der Push-Zeile zählt Kürze, und ein Auftrag
+  // liegt praktisch nie mehr als ein Jahr in der Zukunft.
+  return `${day}.${month}.`;
+}
+
+/**
+ * Body der "Neuer Auftrag"-Push.
+ *
+ *   "Büroreinigung · Müller GmbH · Heute 18:00"
+ *   "Büroreinigung · Müller GmbH · Heute 18:00 · Bahnhofstr. 10"
+ *
+ * Reihenfolge = Informationshierarchie: WAS, für WEN, WANN, erst dann WO.
+ * Die Adresse fällt automatisch weg, wenn sie lang ist (siehe Konstanten oben).
+ */
+export function buildAssignedPushBody(input: AssignedPushInput): string {
+  const segments: string[] = [];
+
+  const service = input.serviceName?.trim();
+  if (service) segments.push(service);
+
+  const customer = input.customerName?.trim();
+  if (customer) segments.push(customer);
+
+  const when = formatAssignedSchedule(input.schedule);
+  if (when) segments.push(when);
+
+  let body = segments.join(SEPARATOR);
+
+  const location = input.locationAddress?.trim();
+  if (location && location.length <= MAX_LOCATION_LENGTH) {
+    const withLocation = body ? `${body}${SEPARATOR}${location}` : location;
+    if (withLocation.length <= MAX_BODY_LENGTH) {
+      body = withLocation;
+    }
+  }
+
+  return body || FALLBACK_BODY;
+}


### PR DESCRIPTION
## Problem

Die Push-Texte waren zu generisch, um den Auftrag ohne Öffnen der App zu identifizieren — und die Zuweisungs-Push ließ sich nicht antippen.

| Ereignis | vorher |
|---|---|
| Zuweisung | `Neuer Auftrag` / `Du hast einen neuen Job: Büroreinigung` |
| Gestartet | `Job gestartet` / `Lena hat „Büroreinigung" gestartet.` |
| Abgeschlossen | `Job abgeschlossen` / `Lena hat „Büroreinigung" abgeschlossen.` |

Kein Kunde, kein Termin, kein Ort. Und: die Zuweisungs-Push trug **gar keine `data`-Payload**, weshalb `extractJobId()` in `useNotificationNavigation` `null` lieferte — der Tap öffnete nur die App. Auf echten Geräten bestätigt.

## Lösung

| Ereignis | nachher |
|---|---|
| Zuweisung | `Neuer Auftrag` / `Büroreinigung · Müller GmbH · Heute 18:00 · Bahnhofstr. 10` |
| Gestartet | `Auftrag gestartet` / `Lena hat „Büroreinigung“ bei Müller GmbH gestartet.` |
| Abgeschlossen | `Auftrag abgeschlossen` / `Lena hat „Büroreinigung“ bei Müller GmbH abgeschlossen.` |

Informationshierarchie der Zuweisung: **WAS · für WEN · WANN · (WO)**. Die Adresse ist das einzige optionale Segment und fällt automatisch weg, wenn sie länger als 30 Zeichen ist oder der Text 100 Zeichen überschreiten würde — Android zeigt eingeklappt nur ~40–50 Zeichen.

Termin-Format: `Heute 18:00` · `Morgen 07:30` · `02.09. 14:15` · bei wiederkehrenden Regeln `Mo, Do · 06:00`.

Beim Dispatcher erscheint der Kunde nur dann als `bei …`, wenn er nicht ohnehin schon als Leistung einspringt (`jobTitle` fällt auf den Kunden zurück, wenn `service_name` fehlt) — sonst stünde er doppelt. Nebenbei das schließende deutsche Anführungszeichen korrigiert (`"` → `“`).

## Deep-Link

Die Zuweisungs-Push trägt jetzt dieselbe Payload-Form wie der Dispatcher:

```jsonc
{ "type": "job_assigned", "jobId": "…", "companyId": "…", "employeeId": "…", "status": "open" }
```

Damit laufen alle drei Ereignisse durch denselben Navigationspfad in `useNotificationNavigation`. Zusätzlich setzt die Zuweisungs-Push nun `channelId: "default"` und `priority: "high"` — exakt der Kanal, den `registerForPushNotifications` auf Android mit Importance MAX anlegt.

## Bewusst NICHT Teil dieser Änderung

- Assignment bleibt ein Client-Push (**kein** `notification_outbox`)
- weiterhin nur an `employeeIds[0]`
- Empfänger-/Fanout-Architektur unverändert
- Zustellmechanik von gestartet/abgeschlossen unverändert
- **keine** Kommentar-Notifications

## Deploy-Hinweis

Die Dispatcher-Texte werden erst nach `supabase functions deploy dispatch-notifications` wirksam. Dieser PR deployt **nichts**.

## Test

`npx tsc --noEmit` und `npm run lint` lokal grün. Das Projekt hat keinen JS-Test-Runner (CI = Typecheck + Lint, SQL-Tests separat), daher keine Unit-Tests — dafür ist die Textlogik als reine, seiteneffektfreie Funktion in `utils/jobNotificationContent.ts` isoliert und gegen fünf realistische Fälle manuell verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)