### PR TITLE
chore(eas): pin ASC App ID im iOS-Submit-Profil

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -19,6 +19,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6792585395"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem

`eas submit --platform ios --non-interactive` brach ab, **bevor überhaupt eine Submission entstand**:

```
Set ascAppId in the submit profile (eas.json) or re-run this command in interactive mode.
```

`submit.production` war leer. Ohne die ASC App ID kann EAS die App in App Store Connect nicht auflösen und verlangt stattdessen einen interaktiven Apple-Login mit 2FA — das blockiert jeden automatisierten Upload.

## Stolperfalle: das Feld ist plattform-gescopt

Auf Profil-Ebene lehnt die CLI es ab:

```
eas.json is not valid.
- "submit.production.ascAppId" is not allowed
```

Es gehört unter den `ios`-Schlüssel — genau das macht dieser PR.

## Kein Geheimnis im Repo

Hier steht nur die öffentliche App-Store-Connect-App-ID. Die eigentliche Authentifizierung läuft unverändert über den auf den EAS-Servern hinterlegten App-Store-Connect-API-Key (`CTG3RHKP4X`, *[Expo] EAS Submit*), der nicht im Repository liegt.

## Verifiziert

Mit dieser Änderung lud `eas submit --platform ios --id 89f9366e… --non-interactive` **1.0.0 (7)** ohne jede Rückfrage nach App Store Connect hoch (Submission `77e67c7f-cbed-424d-968c-c0a9b28584e2`, von Apple angenommen).

## Kontext

Ohne diesen Fix kostete der iOS-Upload bereits eine Buildnummer: Build 6 erreichte App Store Connect, scheiterte danach, und war damit verbraucht (`Build number 6 for app version 1.0.0 has already been used`) — Build 7 musste neu gebaut werden.

Reine Build-/Submit-Konfiguration. Kein App-Code, keine Notification-Logik, keine Migrationen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)