### PR TITLE
fix(jobs): remove obsolete Abmelden button from New Job screen

### DIFF
--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -10,7 +10,6 @@ import { useJobs } from "@/context/JobContext";
 import { JobFormFields } from "@/features/jobs/components/JobFormFields";
 import { useJobForm } from "@/features/jobs/hooks/useJobForm";
 import { formatDateISO, formatTimeHHmm, formatToISO } from "@/utils/date";
-import { alertDialog, confirmDialog } from "@/utils/dialogs";
 import type { CreateJobInput } from "@/types/job";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -100,7 +99,7 @@ export default function AdminScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const { createJob, employees, loading } = useJobs();
-  const { signOut, role, loading: authLoading } = useAuth();
+  const { role, loading: authLoading } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   // Synchrone Re-Entrancy-Sperre gegen Doppel-Absendung. setSubmitting(true)
   // wirkt erst beim nächsten Render — zwei sehr schnelle Taps könnten daher
@@ -133,36 +132,6 @@ export default function AdminScreen() {
       }),
     ]).start();
   }, [fadeAnim, slideAnim]);
-
-  // ── Logout
-  // Über confirmDialog/alertDialog statt Alert.alert — Alert ist im Web eine
-  // leere Attrappe, der onPress-Callback lief dort nie (siehe utils/dialogs.ts).
-  const handleLogout = async () => {
-    const bestaetigt = await confirmDialog({
-      title: "Abmelden",
-      message: "Möchtest du dich wirklich abmelden?",
-      confirmLabel: "Abmelden",
-      destructive: true,
-    });
-
-    if (!bestaetigt) {
-      return;
-    }
-
-    try {
-      await signOut();
-    } catch (err: unknown) {
-      const msg =
-        err instanceof Error && err.message ? err.message : "Abmeldung fehlgeschlagen.";
-      await alertDialog("Abmelden fehlgeschlagen", `${msg}\n\nDu bist weiterhin angemeldet.`);
-      return;
-    }
-
-    // Explizit zur Anmeldung navigieren, statt uns auf das Neu-Mounten der
-    // Auth-Gruppe durch die Auth-Gates zu verlassen (das konnte den zuletzt
-    // sichtbaren Auth-Screen — Register — wieder aufdecken).
-    router.replace("/login");
-  };
 
   // ── Job erstellen
   const handleCreateJob = async () => {
@@ -293,13 +262,8 @@ export default function AdminScreen() {
             ) : null}
           </View>
 
-          <TouchableOpacity
-            onPress={handleLogout}
-            style={styles.logoutBtn}
-            activeOpacity={0.7}
-          >
-            <Text style={styles.logoutText}>Abmelden</Text>
-          </TouchableOpacity>
+          {/* Gegengewicht zum Zurück-Button, damit der Titel mittig bleibt. */}
+          <View style={styles.headerSpacer} />
         </View>
 
         {/* ── Scroll-Inhalt ── */}
@@ -414,16 +378,8 @@ function createStyles(theme: AppTheme) {
       color: theme.colors.statusInProgress,
     },
 
-    // Logout-Button
-    logoutBtn: {
+    headerSpacer: {
       minWidth: 72,
-      alignItems: "flex-end",
-    },
-    logoutText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.error,
     },
 
     // Scroll-Container


### PR DESCRIPTION
## Problem

Der Neuer-Job-Screen zeigt oben rechts weiterhin einen **„Abmelden"**-Button — sichtbar in iOS TestFlight Build 1.0.0 (7), gebaut aus `5f7f7ef`.

## Ursache

PR #65 (`ca143d9`, merged 2026-07-31) hat den Button korrekt entfernt — aber **nur aus `EditJobScreen.tsx`**. Der Neuer-Job-Screen ist eine eigene Komponente (`features/admin/AdminScreen.tsx`, gerendert von `app/jobs/create.tsx`) und trug seine **eigene, unabhängige Kopie** desselben Überbleibsels.

Diese Kopie stammt aus `7342501` (2026-04-08) und wurde seitdem nie entfernt. `e7888d2` (PR #68) hat lediglich den Handler-Inhalt von `Alert.alert` auf `confirmDialog`/`alertDialog` umgestellt — keine Wiedereinführung. Kein Commit in irgendeinem Branch hat den Button je aus `AdminScreen.tsx` entfernt.

## Änderung

Zieht `ca143d9` auf den Neuer-Job-Screen nach, gleiches Idiom, eine Datei:

- Button-`TouchableOpacity` im Header → `<View style={styles.headerSpacer} />`
- `handleLogout` entfernt (dadurch toter Code)
- `signOut` aus dem `useAuth()`-Destructuring entfernt (nur dort genutzt)
- Import `alertDialog, confirmDialog` entfernt (nur in `handleLogout` genutzt)
- Styles `logoutBtn`/`logoutText` → `headerSpacer: { minWidth: 72 }`, passend zum `backBtn` (`minWidth: 72`), damit der Titel mittig bleibt

Das React-Native-`Alert` bleibt importiert — es wird weiterhin in `handleCreateJob` verwendet.

## Nicht angefasst

- `EditJobScreen.tsx` / `JobDetailScreen.tsx`
- Die bewussten Abmelden-Notausgänge in `app/index.tsx` (Profil-Ladefehler / Offline ohne Cache)
- Abmelden bleibt regulär über das Profil (`ProfileScreen`) erreichbar
- Formular, Validierung, Erstellen, Rechte, Navigation unverändert

## Verifikation

- `npx tsc --noEmit` → sauber (Exit 0)
- `npm run lint` (`expo lint`) → sauber
- `git diff --stat`: 1 Datei, `4 insertions(+), 48 deletions(-)`
- Keine Rest-Referenzen auf `Abmelden`/`logoutBtn`/`logoutText`/`handleLogout`/`signOut` in `AdminScreen.tsx`

Nach dem Merge ist ein **neuer iOS-/Android-Build** nötig — Build 7 kann die Änderung nicht enthalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)