### PR TITLE
chore(eas): separate iOS development app variant

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,7 +1,57 @@
+// app.config.js
+// ─────────────────────────────────────────────────────────────────
+// Dynamische Expo-Konfiguration. Zwei Aufgaben:
+//
+//  1. Firebase-Datei für Android aus der EAS-Dateivariable ziehen
+//     (google-services.json ist gitignored, öffentliches Repo).
+//
+//  2. App-Variante: Der Development-Build bekommt eine EIGENE iOS-Bundle-ID
+//     und einen eigenen Namen, damit er PARALLEL zur TestFlight-App auf
+//     demselben iPhone leben kann. Vorher teilten sich beide
+//     com.ferash.taskopsmanager — die Installation des TestFlight-Builds hat
+//     den Development-Client also schlicht überschrieben. Danach öffnete die
+//     Metro-URL (exp+cleaning-employee-app-2://expo-development-client/?url=…)
+//     die Produktions-App, die keinen Dev-Launcher enthält: expo-router
+//     interpretierte den Pfad als Route -> „Unmatched Route".
+//
+// Die Variante wird AUSSCHLIESSLICH über APP_VARIANT gesteuert, gesetzt im
+// EAS-Build-Profil "development" (eas.json). Ohne die Variable bleibt alles
+// exakt wie bisher — preview und production sind damit unverändert.
+// ─────────────────────────────────────────────────────────────────
+
+const IS_DEV = process.env.APP_VARIANT === "development";
+
 module.exports = ({ config }) => ({
   ...config,
+
+  // Klar unterscheidbar im Homescreen und im App-Switcher.
+  name: IS_DEV ? "TaskOps Manager Dev" : config.name,
+
+  // Eigenes URL-Schema, damit taskopsmanager://-Links (z. B. aus der
+  // Produktions-App) nicht versehentlich im Dev-Build landen, wenn beide
+  // Apps installiert sind.
+  //
+  // ACHTUNG: Das Dev-Client-Schema exp+<slug> wird vom expo-dev-client-Plugin
+  // aus dem SLUG abgeleitet, nicht aus Bundle-ID oder scheme — es bleibt
+  // deshalb bei beiden Apps identisch. Siehe Hinweis im PR: zum Verbinden
+  // notfalls die Dev-Client-App direkt öffnen statt den QR-Code zu scannen.
+  scheme: IS_DEV ? "taskopsmanagerdev" : config.scheme,
+
+  ios: {
+    ...config.ios,
+    bundleIdentifier: IS_DEV
+      ? "com.ferash.taskopsmanager.dev"
+      : config.ios.bundleIdentifier,
+  },
+
   android: {
     ...config.android,
+    // Der Android-PACKAGE-NAME bleibt bewusst unverändert — auch für die
+    // Dev-Variante. google-services.json enthält genau einen Client für
+    // com.ferash.taskopsmanager; ein abweichendes Package ließe den
+    // Google-Services-Schritt im Build scheitern („No matching client found")
+    // und FCM-Push wäre tot. Eine getrennte Android-Variante bräuchte einen
+    // zweiten Firebase-Client — bewusst nicht Teil dieser Änderung.
     googleServicesFile:
       process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
   },

--- a/eas.json
+++ b/eas.json
@@ -7,7 +7,10 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      "environment": "development"
+      "environment": "development",
+      "env": {
+        "APP_VARIANT": "development"
+      }
     },
     "preview": {
       "distribution": "internal",


### PR DESCRIPTION
## Problem

Der Development-Client ließ sich nicht mit Metro verbinden. Die Metro-URL öffnete zwar die App, landete aber in **„Unmatched Route"** statt im Dev-Launcher.

**Ursache:** Development- und Produktions-Build teilten sich die Bundle-ID `com.ferash.taskopsmanager`. Die Installation von TestFlight `1.0.0 (7)` hat den Development-Client damit schlicht **überschrieben**.

Da `expo-dev-client` als reguläre `dependency` geführt wird, registriert **auch der Produktions-Build** das Schema `exp+cleaning-employee-app-2://` — nachweisbar in der `Info.plist`, die zwei URL-Types trägt:

```
CFBundleURLSchemes = [ taskopsmanager, cleaningemployeeapp2, com.ferash.cleaningemployeeapp2 ]
CFBundleURLSchemes = [ exp+cleaning-employee-app-2 ]
```

Die Metro-URL öffnete also die Produktions-App, die keinen Dev-Launcher enthält, und expo-router interpretierte `expo-development-client/?url=…` als Route.

## Lösung

Der Dev-Build bekommt eine eigene Identität, gesteuert allein über `APP_VARIANT` (gesetzt im EAS-Profil `development`):

| Profil | name | bundleIdentifier | scheme |
|---|---|---|---|
| **development** | **TaskOps Manager Dev** | **com.ferash.taskopsmanager.dev** | **taskopsmanagerdev** |
| preview | TaskOps Manager | com.ferash.taskopsmanager | taskopsmanager |
| production | TaskOps Manager | com.ferash.taskopsmanager | taskopsmanager |

Ohne die Variable ist die Auflösung unverändert — `preview` und `production` sind nicht betroffen. Verifiziert mit `eas config` für alle drei Profile.

`app.config.js` war bereits dynamisch (für `GOOGLE_SERVICES_JSON`) und wurde nur erweitert — kein neuer Mechanismus, kein Refactor.

## Bewusst NICHT geändert

- **Android-Package** bleibt `com.ferash.taskopsmanager`, auch für die Dev-Variante. `google-services.json` trägt genau einen Client dafür; ein abweichendes Package würde den Google-Services-Schritt brechen (`No matching client found`) und FCM-Push töten. Eine getrennte Android-Variante bräuchte einen zweiten Firebase-Client.
- Keine Firebase-/FCM-Konfiguration, keine Supabase-Daten, Migrationen oder Edge Functions.
- Keine Änderung an der Produktions-/TestFlight-Identität.

## Verifiziert auf echtem Gerät

- `TaskOps Manager Dev` installiert **parallel** zur TestFlight-App
- Metro verbindet sich erfolgreich (`npx expo start --dev-client --clear`)
- aktuelle JS/TS-Änderungen laden korrekt (der entfernte „Abmelden"-Button auf New Job fehlt in der Dev-App)
- Produktions-App bleibt unberührt

`npx tsc --noEmit` → exit 0 · `npm run lint` → exit 0

## Bekannte Einschränkung

Das Dev-Client-Schema `exp+<slug>` leitet sich aus dem **slug** ab, nicht aus Bundle-ID oder `scheme` (`getDefaultScheme` → `exp+${slug}`). Beide Apps registrieren es also weiterhin; welche iOS bei einem Scan wählt, ist nicht definiert. Zum Verbinden notfalls **die Dev-App direkt öffnen** und den Server aus der Launcher-Liste wählen — dieser Weg hängt nicht am Schema. Sauber beheben ließe sich das nur, indem `expo-dev-client` in die `devDependencies` wandert; das wäre eine Änderung an der Produktions-Konfiguration und gehört nicht in diesen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)