### PR TITLE
fix(jobs): feldkritische Auftrags-UX für Mitarbeitende (Audit Batch 1)

### DIFF
--- a/app/(employee-tabs)/_layout.tsx
+++ b/app/(employee-tabs)/_layout.tsx
@@ -9,10 +9,13 @@ import { Tabs } from "expo-router";
 
 export default function EmployeeTabsLayout() {
   const theme = useAppTheme();
-  const { jobs } = useJobs();
+  const { hasUnread } = useJobs();
 
   // Roter Punkt am Jobs-Tab, wenn irgendein Job ungelesene Kommentare hat.
-  const hasUnreadComments = jobs.some((job) => job.hasUnreadComments);
+  // Quelle ist die gebündelte Unread-Liste (RPC) — identisch zum Admin-Layout.
+  // Vorher: jobs.some(...), das nur Jobs im aktuell geladenen Fenster sah; ein
+  // ungelesener Kommentar außerhalb davon blieb ohne Punkt.
+  const hasUnreadComments = hasUnread;
 
   return (
     <Tabs

--- a/components/JobCard.tsx
+++ b/components/JobCard.tsx
@@ -23,9 +23,10 @@ import {
   formatAssigneesShort,
   getAssignees,
 } from "@/utils/jobAssignees";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import type { AppTheme } from "@/constants/theme";
+import { confirmCompleteJob } from "@/utils/jobDialogs";
 
 type Props = {
   job: Job;
@@ -34,12 +35,14 @@ type Props = {
   /**
    * Inline-Quick-Action "Start" — wird nur gezeigt, wenn übergeben UND job.status === "open".
    * Wer keine Inline-Action will (z.B. Admin), lässt das Prop einfach weg.
+   * Darf ein Promise zurückgeben; die Karte sperrt dann bis zum Abschluss.
    */
-  onStart?: () => void;
+  onStart?: () => void | Promise<void>;
   /**
    * Inline-Quick-Action "Fertig" — wird nur gezeigt, wenn übergeben UND job.status === "in_progress".
+   * Darf ein Promise zurückgeben; die Karte sperrt dann bis zum Abschluss.
    */
-  onComplete?: () => void;
+  onComplete?: () => void | Promise<void>;
   /** Soll der Name des zugewiesenen Mitarbeiters in der Card stehen? (Default: false) */
   showEmployeeName?: boolean;
   /**
@@ -134,6 +137,32 @@ export default function JobCard({
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const status = getStatusConfig(theme, job.status);
+
+  // Doppel-Tap-Schutz für die Quick-Actions. Der Ref sperrt SYNCHRON (setBusy
+  // wirkt erst beim nächsten Render, zwei schnelle Taps kämen sonst beide
+  // durch); der State steuert nur die sichtbare Deaktivierung.
+  const busyRef = useRef(false);
+  const [busy, setBusy] = useState(false);
+
+  const runAction = useCallback(
+    async (action: () => void | Promise<void>, confirm: boolean) => {
+      if (busyRef.current) return;
+      busyRef.current = true;
+      setBusy(true);
+      try {
+        // Abschließen ist unumkehrbar — vorher nachfragen. Start bleibt ohne
+        // Rückfrage (zeitkritisch und unschädlich).
+        if (confirm && !(await confirmCompleteJob())) {
+          return;
+        }
+        await action();
+      } finally {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    },
+    [],
+  );
 
   // Parent-Recurring-Regeln dürfen weder gestartet noch abgeschlossen werden.
   const isParentRule = isParentRecurringJob(job);
@@ -349,8 +378,13 @@ export default function JobCard({
 
           {showStartAction ? (
             <TouchableOpacity
-              style={styles.quickActionPrimary}
-              onPress={onStart}
+              style={[styles.quickActionPrimary, busy && styles.quickActionBusy]}
+              // Fehleranzeige liegt beim Aufrufer (er kennt seine Fehlerfläche);
+              // der catch verhindert hier nur eine unbehandelte Promise.
+              onPress={() => {
+                if (onStart) runAction(onStart, false).catch(() => {});
+              }}
+              disabled={busy}
               activeOpacity={0.85}
               hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
             >
@@ -365,8 +399,11 @@ export default function JobCard({
 
           {showCompleteAction ? (
             <TouchableOpacity
-              style={styles.quickActionSuccess}
-              onPress={onComplete}
+              style={[styles.quickActionSuccess, busy && styles.quickActionBusy]}
+              onPress={() => {
+                if (onComplete) runAction(onComplete, true).catch(() => {});
+              }}
+              disabled={busy}
               activeOpacity={0.85}
               hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
             >
@@ -539,6 +576,11 @@ function createStyles(theme: AppTheme) {
       flexDirection: "row",
       alignItems: "center",
       gap: 6,
+    },
+
+    // Läuft gerade (Bestätigung offen oder Aktion unterwegs) → sichtbar gesperrt.
+    quickActionBusy: {
+      opacity: 0.5,
     },
 
     // Quick-Action "Start" (primär)

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -10,6 +10,7 @@
 import {
   Card,
   EmptyState,
+  ErrorBanner,
   KPICard,
   LoadingScreen,
   OfflineBanner,
@@ -25,9 +26,10 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import type { Job, JobStatus } from "@/types/job";
 import { isJobToday } from "@/utils/jobSchedule";
+import { confirmCompleteJob } from "@/utils/jobDialogs";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 type Filter = "all" | JobStatus;
@@ -81,6 +83,64 @@ export default function EmployeeOverviewScreen() {
   const { jobs, startJob, completeJob, loading } = useJobs();
 
   const [filter, setFilter] = useState<Filter>("all");
+
+  // ── Aktions-State für Start/Abschluss ─────────────────────────────────────
+  // Vorher liefen diese Aufrufe als Fire-and-Forget: nicht awaited, kein
+  // try/catch, keine Sperre. Eine abgelehnte RPC (offline, fehlende Rechte)
+  // erzeugte eine unbehandelte Promise und NULL sichtbares Feedback — der
+  // Mitarbeiter tippte dann erneut. Gleiches Muster wie im Kalender-Screen.
+  const [actionError, setActionError] = useState("");
+  const [actionBusy, setActionBusy] = useState(false);
+  // Sperrt synchron; setActionBusy wirkt erst beim nächsten Render.
+  const actionBusyRef = useRef(false);
+
+  const runJobAction = useCallback(
+    async (action: () => Promise<void>, fallbackMessage: string) => {
+      if (actionBusyRef.current) return;
+      actionBusyRef.current = true;
+      setActionBusy(true);
+      setActionError("");
+      try {
+        await action();
+      } catch (err: unknown) {
+        setActionError(err instanceof Error ? err.message : fallbackMessage);
+      } finally {
+        actionBusyRef.current = false;
+        setActionBusy(false);
+      }
+    },
+    [],
+  );
+
+  // JobCard bringt Bestätigung und eigenen Doppel-Tap-Schutz mit — hier nur
+  // noch ausführen und Fehler anzeigen.
+  const handleStart = useCallback(
+    (jobId: string) =>
+      runJobAction(
+        () => startJob(jobId),
+        "Job konnte nicht gestartet werden.",
+      ),
+    [runJobAction, startJob],
+  );
+
+  const handleComplete = useCallback(
+    (jobId: string) =>
+      runJobAction(
+        () => completeJob(jobId),
+        "Job konnte nicht abgeschlossen werden.",
+      ),
+    [runJobAction, completeJob],
+  );
+
+  // Aktiver-Job-Karte: eigener Button ohne JobCard → Bestätigung hier.
+  const handleCompleteActiveJob = useCallback(
+    async (jobId: string) => {
+      if (actionBusyRef.current) return;
+      if (!(await confirmCompleteJob())) return;
+      await handleComplete(jobId);
+    },
+    [handleComplete],
+  );
 
   // Zeitpunkt beim Render. Header zeigt nur das Datum (keine Live-Uhrzeit).
   const now = new Date();
@@ -173,6 +233,14 @@ export default function EmployeeOverviewScreen() {
       {/* ── Save-Status ── */}
       <OfflineBanner />
 
+      {/* ── Fehler aus Start/Abschluss — oben, ohne Scrollen sichtbar ── */}
+      {actionError ? (
+        <ErrorBanner
+          message={actionError}
+          onDismiss={() => setActionError("")}
+        />
+      ) : null}
+
       {/* ── Header ── */}
       <View style={styles.header}>
         <View style={styles.headerTopRow}>
@@ -228,67 +296,77 @@ export default function EmployeeOverviewScreen() {
         </View>
       </View>
 
-      {/* ── Aktiver Job (nur wenn vorhanden) ── */}
+      {/* ── Aktiver Job (nur wenn vorhanden) ──
+          Karte ist ein View, KEIN TouchableOpacity: der Abschließen-Button lag
+          vorher INNERHALB der Karten-Touchable. Beide Press-Highlights
+          überlagerten sich und ein Tap knapp neben dem Button navigierte
+          stillschweigend, statt abzuschließen. Jetzt zwei klar getrennte
+          Geschwister: oben der Navigations-Bereich, unten die Aktion. */}
       {activeJob && (
         <View style={styles.section}>
           <SectionHeader title="Aktiver Job" />
-          <TouchableOpacity
-            activeOpacity={0.85}
-            onPress={() => router.push(`/jobs/${activeJob.id}`)}
-            style={styles.activeCard}
-          >
-            <View style={styles.activeTopRow}>
-              <View style={styles.activeBadge}>
-                <View style={styles.activePulse} />
-                <Text style={styles.activeBadgeText}>Läuft</Text>
+          <View style={styles.activeCard}>
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={() => router.push(`/jobs/${activeJob.id}`)}
+              style={styles.activeNavArea}
+            >
+              <View style={styles.activeTopRow}>
+                <View style={styles.activeBadge}>
+                  <View style={styles.activePulse} />
+                  <Text style={styles.activeBadgeText}>Läuft</Text>
+                </View>
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={theme.colors.onPrimaryContainer}
+                />
               </View>
-              <Ionicons
-                name="chevron-forward"
-                size={18}
-                color={theme.colors.onPrimaryContainer}
-              />
-            </View>
 
-            <Text style={styles.activeCustomer} numberOfLines={1}>
-              {activeJob.customerName}
-            </Text>
-            {activeJob.service ? (
-              <Text style={styles.activeService} numberOfLines={1}>
-                {activeJob.service}
+              <Text style={styles.activeCustomer} numberOfLines={1}>
+                {activeJob.customerName}
               </Text>
-            ) : null}
+              {activeJob.service ? (
+                <Text style={styles.activeService} numberOfLines={1}>
+                  {activeJob.service}
+                </Text>
+              ) : null}
 
-            <View style={styles.activeMetaRow}>
-              {activeJob.location ? (
-                <View style={styles.activeMetaItem}>
-                  <Ionicons
-                    name="location-outline"
-                    size={14}
-                    color={theme.colors.onPrimaryContainer}
-                  />
-                  <Text style={styles.activeMetaText} numberOfLines={1}>
-                    {activeJob.location}
-                  </Text>
-                </View>
-              ) : null}
-              {activeJob.startTime ?? formatTime(activeJob.scheduledStart) ? (
-                <View style={styles.activeMetaItem}>
-                  <Ionicons
-                    name="time-outline"
-                    size={14}
-                    color={theme.colors.onPrimaryContainer}
-                  />
-                  <Text style={styles.activeMetaText}>
-                    {activeJob.startTime ?? formatTime(activeJob.scheduledStart)}
-                  </Text>
-                </View>
-              ) : null}
-            </View>
+              <View style={styles.activeMetaRow}>
+                {activeJob.location ? (
+                  <View style={styles.activeMetaItem}>
+                    <Ionicons
+                      name="location-outline"
+                      size={14}
+                      color={theme.colors.onPrimaryContainer}
+                    />
+                    <Text style={styles.activeMetaText} numberOfLines={1}>
+                      {activeJob.location}
+                    </Text>
+                  </View>
+                ) : null}
+                {activeJob.startTime ?? formatTime(activeJob.scheduledStart) ? (
+                  <View style={styles.activeMetaItem}>
+                    <Ionicons
+                      name="time-outline"
+                      size={14}
+                      color={theme.colors.onPrimaryContainer}
+                    />
+                    <Text style={styles.activeMetaText}>
+                      {activeJob.startTime ?? formatTime(activeJob.scheduledStart)}
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            </TouchableOpacity>
 
             <TouchableOpacity
-              style={styles.completeBtn}
+              style={[styles.completeBtn, actionBusy && styles.completeBtnBusy]}
               activeOpacity={0.85}
-              onPress={() => completeJob(activeJob.id)}
+              disabled={actionBusy}
+              onPress={() => {
+                handleCompleteActiveJob(activeJob.id).catch(() => {});
+              }}
             >
               <Ionicons
                 name="checkmark"
@@ -297,7 +375,7 @@ export default function EmployeeOverviewScreen() {
               />
               <Text style={styles.completeBtnText}>Job abschließen</Text>
             </TouchableOpacity>
-          </TouchableOpacity>
+          </View>
         </View>
       )}
 
@@ -347,12 +425,12 @@ export default function EmployeeOverviewScreen() {
                 onPress={() => router.push(`/jobs/${job.id}`)}
                 onStart={
                   canRunJobActions(job, role, profile?.id)
-                    ? () => startJob(job.id)
+                    ? () => handleStart(job.id)
                     : undefined
                 }
                 onComplete={
                   canRunJobActions(job, role, profile?.id)
-                    ? () => completeJob(job.id)
+                    ? () => handleComplete(job.id)
                     : undefined
                 }
               />
@@ -456,12 +534,18 @@ function createStyles(theme: AppTheme) {
     },
 
     // ── Aktiver Job (hervorgehoben)
+    // Container ist nicht mehr tappbar — die beiden Interaktionen liegen als
+    // Geschwister darin (Navigations-Bereich oben, Abschließen-Button unten).
     activeCard: {
       backgroundColor: theme.colors.primaryContainer,
       borderRadius: theme.radius.lg,
       padding: theme.spacing.lg,
       gap: 6,
       ...theme.shadows.md,
+    },
+    // Tappbarer Bereich für die Detail-Navigation (alles außer dem Button).
+    activeNavArea: {
+      gap: 6,
     },
     activeTopRow: {
       flexDirection: "row",
@@ -534,6 +618,9 @@ function createStyles(theme: AppTheme) {
       borderRadius: theme.radius.md,
       paddingVertical: theme.spacing.md,
       minHeight: theme.spacing.tapTarget,
+    },
+    completeBtnBusy: {
+      opacity: 0.5,
     },
     completeBtnText: {
       fontSize: theme.typography.size.md,

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -470,10 +470,16 @@ export default function EditJobScreen() {
 
             <Divider style={styles.sectionDivider} />
 
+            {/* Mitarbeiter-Auswahl bewusst NICHT hier: dieser Screen zeigt sie
+                unten in einem eigenen Abschnitt — mit der Warnung zu inaktiven
+                Zuweisungen und der erweiterten Liste (aktive + bereits
+                zugewiesene). Ohne dieses Prop stand die Auswahl zweimal auf dem
+                Bildschirm, oben dauerhaft leer. */}
             <JobFormFields
               values={values}
               errors={errors}
               onChangeField={setField}
+              showEmployeePicker={false}
             />
           </Card>
 

--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -41,6 +41,7 @@ import { JobTimelineCard } from "@/features/jobs/components/JobTimelineCard";
 import { OccurrenceOriginLink } from "@/features/jobs/components/OccurrenceOriginLink";
 import { getJobById } from "@/services/jobs/jobs.service";
 import { canRunJobActions, isPrimaryAssignee } from "@/utils/jobAssignees";
+import { confirmCompleteJob } from "@/utils/jobDialogs";
 import type { Job } from "@/types/job";
 import { useFocusEffect } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
@@ -248,6 +249,14 @@ export default function JobDetailScreen() {
 
   const handleComplete = async () => {
     setActionError("");
+
+    // Abschließen ist unumkehrbar (setzt completed_at) — vorher nachfragen.
+    // Start bleibt bewusst ohne Rückfrage.
+    const bestaetigt = await confirmCompleteJob();
+    if (!bestaetigt) {
+      return;
+    }
+
     try {
       setSubmitting(true);
       await completeJob(job.id);
@@ -389,23 +398,26 @@ export default function JobDetailScreen() {
         />
 
         {/* 9 — Job-spezifischer Offline-Hinweis, direkt vor den Aktionen,
-            auf die er sich bezieht */}
+            auf die er sich bezieht (die Aktionsleiste liegt unmittelbar
+            darunter, jetzt fixiert am unteren Rand) */}
         <JobPendingActionHint jobId={job.id} pendingActions={pendingActions} />
-
-        {/* 10 — Aktionen */}
-        <JobActionFooter
-          canStart={canStart}
-          canComplete={canComplete}
-          isDone={isDone}
-          submitting={submitting}
-          onStart={handleStart}
-          onComplete={handleComplete}
-          showEdit={isAdmin}
-          onEdit={handleEdit}
-        />
-
-        <View style={{ height: theme.spacing.xl }} />
       </ScrollView>
+
+      {/* 10 — Aktionen: FIXIERT, außerhalb des Scroll-Flusses.
+          Als Geschwister der ScrollView innerhalb der KeyboardAvoidingView —
+          dadurch rutscht die Leiste bei geöffneter Tastatur mit nach oben und
+          liegt nie unter ihr. Der Scroll-Bereich wird entsprechend kürzer, die
+          Leiste überdeckt also auch keine Kommentare. */}
+      <JobActionFooter
+        canStart={canStart}
+        canComplete={canComplete}
+        isDone={isDone}
+        submitting={submitting}
+        onStart={handleStart}
+        onComplete={handleComplete}
+        showEdit={isAdmin}
+        onEdit={handleEdit}
+      />
       </KeyboardAvoidingView>
     </SafeAreaView>
   );

--- a/features/jobs/components/JobActionFooter.tsx
+++ b/features/jobs/components/JobActionFooter.tsx
@@ -4,6 +4,19 @@
 // Handler, Berechtigungs-Booleans (canStart/canComplete/isDone) und der
 // submitting-State kommen unverändert vom Screen — hier wird nichts davon
 // neu berechnet oder verändert.
+//
+// FIXIERTE LEISTE: Diese Komponente liegt NICHT mehr im Scroll-Fluss, sondern
+// als Geschwister der ScrollView am unteren Rand (siehe JobDetailScreen). Vorher
+// stand sie am Ende eines langen Inhalts — hinter Foto-Raster und Kommentar-
+// Verlauf. Bei einem Auftrag mit mehreren Fotos und Kommentaren musste ein
+// Mitarbeiter im Feld mehrere Bildschirmhöhen scrollen, um „Starten“ oder
+// „Abschließen“ überhaupt zu erreichen. Jetzt ist die wichtigste Aktion immer
+// ohne Scrollen erreichbar.
+//
+// Die Leiste bringt ihr eigenes Chrome mit (Hintergrund, obere Trennlinie,
+// Safe-Area-Abstand unten), damit der Screen selbst schlank bleibt. Gibt es
+// nichts zu tun UND nichts zu melden, rendert sie gar nichts — dann bleibt der
+// volle Bildschirm dem Inhalt.
 
 import { Button } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
@@ -11,6 +24,7 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type Props = {
   canStart: boolean;
@@ -35,9 +49,24 @@ export function JobActionFooter({
 }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+
+  // Nichts anzuzeigen (z. B. Mitarbeiter ohne Zuweisung auf einem offenen
+  // Auftrag) → keine leere Leiste am Bildschirmrand stehen lassen.
+  const hasContent = canStart || canComplete || isDone || showEdit;
+  if (!hasContent) {
+    return null;
+  }
 
   return (
-    <View style={styles.actions}>
+    <View
+      style={[
+        styles.bar,
+        // Home-Indikator / Gestennavigation freihalten. Der Screen selbst nutzt
+        // edges={["top"]}, der untere Inset ist hier also noch offen.
+        { paddingBottom: Math.max(insets.bottom, theme.spacing.md) },
+      ]}
+    >
       {canStart ? (
         <Button
           label="Job starten"
@@ -90,9 +119,14 @@ export function JobActionFooter({
 
 function createStyles(theme: AppTheme) {
   return StyleSheet.create({
-    actions: {
+    // Fixierte Leiste am unteren Rand — abgesetzt vom Inhalt darüber.
+    bar: {
       gap: theme.spacing.sm,
-      marginTop: theme.spacing.xs,
+      paddingHorizontal: theme.spacing.gutter,
+      paddingTop: theme.spacing.md,
+      backgroundColor: theme.colors.surface,
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.outlineVariant,
     },
     doneInfo: {
       flexDirection: "row",

--- a/features/jobs/components/JobFormFields.tsx
+++ b/features/jobs/components/JobFormFields.tsx
@@ -25,6 +25,18 @@ type JobFormFieldsProps = {
     value: JobFormValues[K],
   ) => void;
   employees?: EmployeeOption[];
+  /**
+   * Mitarbeiter-Auswahl hier mitrendern (Standard: true — so nutzt es der
+   * Erstellen-Screen).
+   *
+   * Der Bearbeiten-Screen setzt `false`: er zeigt die Zuweisung in einem
+   * eigenen Abschnitt, weil er dort zusätzlich inaktive-Zuweisungen warnt und
+   * eine andere Mitarbeiter-Liste braucht (aktive + bereits zugewiesene). Ohne
+   * dieses Prop rendert er die Auswahl zweimal — und weil er `employees` hier
+   * nie übergibt, stand in der ersten (leeren) Auswahl dauerhaft
+   * „Keine Mitarbeiter verfügbar.“
+   */
+  showEmployeePicker?: boolean;
 };
 
 const JOB_TYPE_OPTIONS: { key: JobType; label: string }[] = [
@@ -37,6 +49,7 @@ export function JobFormFields({
   errors,
   onChangeField,
   employees = [],
+  showEmployeePicker = true,
 }: JobFormFieldsProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -195,12 +208,16 @@ export function JobFormFields({
         </View>
       )}
 
-      <Text style={styles.sectionLabel}>Mitarbeiter</Text>
-      <EmployeeMultiSelector
-        employees={employees}
-        selectedEmployeeIds={values.employeeIds}
-        onChange={(ids) => onChangeField("employeeIds", ids)}
-      />
+      {showEmployeePicker ? (
+        <>
+          <Text style={styles.sectionLabel}>Mitarbeiter</Text>
+          <EmployeeMultiSelector
+            employees={employees}
+            selectedEmployeeIds={values.employeeIds}
+            onChange={(ids) => onChangeField("employeeIds", ids)}
+          />
+        </>
+      ) : null}
 
       <Input
         label="Notizen"

--- a/utils/jobDialogs.ts
+++ b/utils/jobDialogs.ts
@@ -1,0 +1,32 @@
+// utils/jobDialogs.ts
+// ─────────────────────────────────────────────────────────────────
+// Job-bezogene Bestätigungsdialoge mit EINER kanonischen Formulierung.
+//
+// Warum zentral: das Abschließen eines Auftrags ist unumkehrbar — der erste
+// erfolgreiche Übergang setzt completed_at, jeder weitere ist serverseitig ein
+// No-Op (siehe „Geteilte Job-Uhr" in CLAUDE.md). Es gibt drei Einstiegspunkte
+// (Job-Detail, JobCard-Quick-Action, Aktiver-Job-Karte der Employee-Übersicht),
+// die deshalb denselben Dialog mit demselben Wortlaut zeigen müssen.
+//
+// Bewusst KEIN Dialog beim Starten: Start ist zeitkritisch, unschädlich und
+// über das Abschließen ohnehin korrigierbar — eine Rückfrage würde dort nur
+// Zeit im Feld kosten.
+//
+// Läuft über confirmDialog (utils/dialogs.ts), nicht über Alert.alert:
+// Alert ist im Web eine leere Attrappe, der onPress-Callback liefe dort nie.
+// ─────────────────────────────────────────────────────────────────
+
+import { confirmDialog } from "@/utils/dialogs";
+
+/**
+ * Fragt vor dem Abschließen eines Auftrags nach.
+ * @returns true, wenn der Nutzer bestätigt hat.
+ */
+export function confirmCompleteJob(): Promise<boolean> {
+  return confirmDialog({
+    title: "Auftrag abschließen?",
+    message: "Der Auftrag wird als erledigt markiert.",
+    confirmLabel: "Abschließen",
+    cancelLabel: "Abbrechen",
+  });
+}


### PR DESCRIPTION
Batch 1 des UI/UX-Audits — strikt begrenzt auf die feldkritische Auftrags-UX.

**Nicht angefasst:** Supabase, Migrationen, RLS, RPCs, Edge Functions, Firebase, Notifications-Architektur, Offline-Queue-Internas. Keine neuen Abhängigkeiten, keine Native-Config. JS/TS only → über Metro im bestehenden Development Build testbar, kein neuer Native-Build nötig.

## Was sich ändert

**1. Job-Detail: fixierte Aktionsleiste**
`JobActionFooter` lag am Ende des Scroll-Inhalts — hinter Foto-Raster und Kommentar-Verlauf. Bei einem Auftrag mit mehreren Fotos und Kommentaren musste man mehrere Bildschirmhöhen scrollen, um „Starten"/„Abschließen" zu erreichen. Die Leiste ist jetzt Geschwister der `ScrollView` innerhalb der `KeyboardAvoidingView`: immer sichtbar, rutscht bei geöffneter Tastatur mit nach oben (überdeckt also weder Tastatur noch Kommentare), respektiert `insets.bottom`. Gibt es nichts zu tun, rendert sie `null`.

**2. Job bearbeiten: doppelte Mitarbeiter-Auswahl entfernt**
`JobFormFields` rendert die Auswahl unbedingt; der Bearbeiten-Screen übergibt dort aber nie `employees` → erste Auswahl stand dauerhaft auf „Keine Mitarbeiter verfügbar.", direkt darüber der echte Abschnitt. Neues Prop `showEmployeePicker` (Standard `true`), Bearbeiten setzt `false`. **Die Sperre für inaktive Zuweisungen bleibt unverändert.** Erstellen-Screen funktional unverändert.

**3. Employee-Übersicht: echter Async-Handler**
`onPress={() => completeJob(id)}` war nicht awaited, ohne `try/catch` und ohne Sperre — eine abgelehnte RPC erzeugte eine unbehandelte Promise und null sichtbares Feedback. Jetzt geführte Handler mit synchroner Doppel-Tap-Sperre (Ref) und sichtbarem `ErrorBanner`, analog zum Kalender-Screen.

**4. Aktiver-Job-Karte: verschachtelte Touchables aufgelöst**
Der Abschließen-Button lag *innerhalb* der Karten-Touchable; ein Tap knapp daneben navigierte stillschweigend. Jetzt `View`-Container mit zwei klar getrennten Geschwistern (Navigation oben, Aktion unten). Abstände unverändert.

**5. Bestätigung vor dem Abschließen**
Abschließen setzt `completed_at` und ist unumkehrbar. Neuer zentraler `confirmCompleteJob()` (`utils/jobDialogs.ts`) über die bestehende `confirmDialog`-Utility — an allen drei Einstiegspunkten: Job-Detail, JobCard-Quick-Action, Aktiver-Job-Karte. **Starten bleibt bewusst ohne Rückfrage** (zeitkritisch, unschädlich).

> Auftrag abschließen?
> Der Auftrag wird als erledigt markiert.
> [Abbrechen] [Abschließen]

**6. Ungelesen-Punkt im Employee-Tab**
Nutzt jetzt `hasUnread` (gebündelte RPC-Liste) statt `jobs.some(...)`, das nur das geladene Fenster sah — identisch zum Admin-Layout. Backend-Verhalten unverändert.

## Ausdrücklich NICHT in diesem PR

- Die dokumentierte Rechte-Asymmetrie (`canRunJobActions` vs. `isPrimaryAssignee`) — unberührt.
- Rohe Backend-Fehlermeldungen, Pull-to-Refresh, KPI-Filter, „Alle anzeigen" bei >5 Aufträgen, Header-Vereinheitlichung, Vokabular (Job/Auftrag/Termin), toter Code — eigene Batches.

## Prüfung

- `npx tsc --noEmit` ✅
- `npm run lint` ✅

## Manueller Test (Dev-Build via Metro)

**Als Mitarbeiter**
- [ ] Auftrag mit ≥5 Fotos und ≥5 Kommentaren öffnen → Aktionsleiste ohne Scrollen sichtbar
- [ ] Kommentarfeld fokussieren → Leiste sitzt über der Tastatur, verdeckt weder Eingabe noch Senden (iOS **und** Android)
- [ ] Gestennavigation: Leiste liegt nicht unter dem Home-Indikator
- [ ] „Abschließen" → Dialog erscheint; Abbrechen ändert nichts; Bestätigen schließt ab
- [ ] „Starten" → **kein** Dialog
- [ ] Flugmodus → Start/Abschluss: deutsche Fehlermeldung im Banner (kein stiller Fehlschlag)
- [ ] Doppel-Tap auf „Fertig"/„Abschließen" → nur ein Dialog, nur eine Aktion
- [ ] Übersicht: Aktiver-Job-Karte — Tap auf Fläche navigiert, Tap auf Button schließt ab, keine Fehlgriffe
- [ ] Kalender-Tab: „Start"/„Fertig" auf JobCard verhalten sich gleich
- [ ] Ungelesener Kommentar → roter Punkt am Jobs-Tab
- [ ] Abgeschlossener Auftrag → Leiste zeigt „Dieser Job ist abgeschlossen."
- [ ] Nicht zugewiesener Auftrag → gar keine Leiste

**Als Admin**
- [ ] Job bearbeiten → **genau ein** Mitarbeiter-Abschnitt, korrekt vorbelegt
- [ ] Auftrag mit inaktiver Zuweisung → Warnung + Speichern weiterhin gesperrt
- [ ] Neuer Job → Mitarbeiter-Auswahl wie bisher, Anlegen funktioniert
- [ ] Job-Detail als Admin → „Bearbeiten" in der fixierten Leiste

🤖 Generated with [Claude Code](https://claude.com/claude-code)