### PR TITLE
fix(ui): Save-Status nur bei echten Meldungen — kein Layout-Sprung

### DIFF
--- a/components/ui/OfflineBanner.tsx
+++ b/components/ui/OfflineBanner.tsx
@@ -5,6 +5,23 @@
 // Liest nur vorhandene Offline-/Queue-Werte aus dem JobContext —
 // keine eigene Sync-Logik. Sichtbare Texte bewusst ohne
 // Fachbegriffe (kein "Sync", "Queue", "pending").
+//
+// NUR AUSSAGEKRÄFTIGE ZUSTÄNDE: Das Banner erscheint ausschließlich bei
+// offline / wartenden Änderungen / Speichern / Fehler. Der Normalfall
+// ("saved") zeigt NICHTS.
+//
+// Vorher lief nach JEDER erfolgreichen Speicherung ein „Alles gespeichert"-
+// Banner an: es montierte sich in den Layout-Fluss (Inhalt darunter sprang
+// ~46 px nach unten), blieb 1500 ms stehen und demontierte sich dann wieder
+// (Inhalt sprang zurück). Zwei Layout-Sprünge pro Aktion für eine Information,
+// die niemand braucht — der Normalzustand ist genau das, was der Nutzer
+// ohnehin erwartet. Es gab zusätzlich einen dauerhaften „Online"-Badge im
+// Header (SaveStatusBadge), der dasselbe „saved" anders benannte und beim
+// Statuswechsel die Begrüßung neu umbrach; er ist ersatzlos entfallen.
+//
+// Beim Übergang zurück nach "saved" blendet das Banner den ZULETZT
+// aussagekräftigen Zustand sauber aus (displayState), statt vorher noch auf
+// Grün umzuspringen.
 // ─────────────────────────────────────────────────────────────────
 
 import { useJobs } from "@/context/JobContext";
@@ -27,8 +44,13 @@ import {
 
 type SaveState = "offline" | "saving" | "error" | "pending" | "saved";
 
+// Zustände, die dem Nutzer tatsächlich etwas sagen. "saved" ist der stille
+// Normalfall und wird bewusst NICHT dargestellt.
+type InformativeSaveState = Exclude<SaveState, "saved">;
+
 // Leitet den Speicher-/Verbindungszustand aus den Offline-/Queue-Werten ab.
-// Zentral, damit Banner (volle Anzeige) und Badge (kompakt) dieselbe Logik teilen.
+// Unverändert — die Queue-/Sync-Logik selbst liegt im JobContext, hier wird
+// sie nur gelesen und in eine Darstellung übersetzt.
 function deriveSaveState(args: {
   online: boolean;
   isSyncing: boolean;
@@ -41,12 +63,6 @@ function deriveSaveState(args: {
   if (syncFailed) return "error";
   if (pendingCount > 0) return "pending";
   return "saved";
-}
-
-// Hook-Variante für Komponenten, die nur den Zustand brauchen (z. B. Badge).
-export function useSaveState(): SaveState {
-  const { online, isSyncing, syncFailed, pendingCount } = useJobs();
-  return deriveSaveState({ online, isSyncing, syncFailed, pendingCount });
 }
 
 function pendingLabel(count: number): string {
@@ -68,7 +84,10 @@ function actionLabel(action: PendingJobAction): string {
 // `config.title` unten) — als eigene Funktion, damit die Animations-Effect
 // den Text kennt, ohne `config` (das von der aktuellen Theme-Farbe abhängt)
 // vorziehen zu müssen.
-function stateAnnouncement(state: SaveState, pendingCount: number): string {
+function stateAnnouncement(
+  state: InformativeSaveState,
+  pendingCount: number,
+): string {
   switch (state) {
     case "offline":
       return "Kein Internet. Änderungen gehen nicht verloren.";
@@ -78,17 +97,12 @@ function stateAnnouncement(state: SaveState, pendingCount: number): string {
       return "Änderungen konnten nicht gespeichert werden.";
     case "pending":
       return pendingLabel(pendingCount);
-    case "saved":
-      return "Alles gespeichert.";
   }
 }
 
 // ── Animation: Timing für das Ein-/Ausblenden des Banners ─────────────────
 const ENTER_DURATION_MS = 220;
 const EXIT_DURATION_MS = 250;
-// Wie lange die "Alles gespeichert"-Bestätigung stehen bleibt, bevor sie
-// ausblendet — sonst verschwindet sie, bevor man sie lesen kann.
-const SAVED_HOLD_MS = 1500;
 
 export function OfflineBanner() {
   const theme = useAppTheme();
@@ -107,38 +121,42 @@ export function OfflineBanner() {
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const state = deriveSaveState({ online, isSyncing, syncFailed, pendingCount });
+  const informativeState: InformativeSaveState | null =
+    state === "saved" ? null : state;
 
   // ── Animation: sanftes Ein-/Ausblenden bei Statuswechsel ──────────────
-  // Banner bleibt gemountet, solange state !== "saved" ODER die
-  // Ausblend-Animation noch läuft. Beim Wechsel zu "saved" zeigt es kurz
-  // die Bestätigung (SAVED_HOLD_MS), bevor es animiert ausblendet, statt
-  // abrupt zu verschwinden (frühere Version: `if (state === "saved")
-  // return null;` sofort beim Statuswechsel).
-  const [mounted, setMounted] = useState(state !== "saved");
+  // Banner ist gemountet, solange es einen aussagekräftigen Zustand gibt ODER
+  // die Ausblend-Animation noch läuft. Erreicht der Zustand "saved", blendet
+  // es SOFORT aus (kein Halten, keine Erfolgsmeldung) und demontiert sich.
+  const [mounted, setMounted] = useState(informativeState !== null);
+  // Zuletzt dargestellter aussagekräftiger Zustand. Bleibt während der
+  // Ausblend-Animation stehen, damit z. B. „Änderungen werden gespeichert…"
+  // ruhig ausblendet, statt vorher noch auf einen Erfolgszustand umzuspringen.
+  const [displayState, setDisplayState] = useState<InformativeSaveState | null>(
+    informativeState,
+  );
   const animProgress = useRef(
-    new Animated.Value(state !== "saved" ? 1 : 0),
+    new Animated.Value(informativeState !== null ? 1 : 0),
   ).current;
-  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const runningAnim = useRef<Animated.CompositeAnimation | null>(null);
 
   useEffect(() => {
-    if (hideTimer.current) {
-      clearTimeout(hideTimer.current);
-      hideTimer.current = null;
-    }
     runningAnim.current?.stop();
 
-    // iOS: VoiceOver bekommt Statuswechsel nicht zuverlässig über
-    // accessibilityRole="alert" bei Prop-Updates mit — explizit ansagen.
-    // Android: übernimmt accessibilityLiveRegion="polite" auf dem Banner
-    // selbst (siehe unten), daher hier nicht doppelt ansagen.
-    if (Platform.OS === "ios") {
-      AccessibilityInfo.announceForAccessibility(
-        stateAnnouncement(state, pendingCount),
-      );
-    }
+    if (informativeState !== null) {
+      // iOS: VoiceOver bekommt Statuswechsel nicht zuverlässig über
+      // accessibilityRole="alert" bei Prop-Updates mit — explizit ansagen.
+      // Android: übernimmt accessibilityLiveRegion="polite" auf dem Banner
+      // selbst (siehe unten), daher hier nicht doppelt ansagen.
+      // Der Normalfall ("saved") wird bewusst NICHT angesagt — es gibt nichts
+      // zu melden, und eine Ansage bei jedem gespeicherten Job wäre Lärm.
+      if (Platform.OS === "ios") {
+        AccessibilityInfo.announceForAccessibility(
+          stateAnnouncement(informativeState, pendingCount),
+        );
+      }
 
-    if (state !== "saved") {
+      setDisplayState(informativeState);
       setMounted(true);
       runningAnim.current = Animated.timing(animProgress, {
         toValue: 1,
@@ -147,27 +165,18 @@ export function OfflineBanner() {
       });
       runningAnim.current.start();
     } else {
-      hideTimer.current = setTimeout(() => {
-        runningAnim.current = Animated.timing(animProgress, {
-          toValue: 0,
-          duration: EXIT_DURATION_MS,
-          useNativeDriver: true,
-        });
-        runningAnim.current.start(({ finished }) => {
-          if (finished) setMounted(false);
-        });
-      }, SAVED_HOLD_MS);
+      runningAnim.current = Animated.timing(animProgress, {
+        toValue: 0,
+        duration: EXIT_DURATION_MS,
+        useNativeDriver: true,
+      });
+      runningAnim.current.start(({ finished }) => {
+        if (finished) setMounted(false);
+      });
     }
-
-    return () => {
-      if (hideTimer.current) {
-        clearTimeout(hideTimer.current);
-        hideTimer.current = null;
-      }
-    };
     // animProgress ist ein stabiler Ref-Wert, absichtlich nicht in den Deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state, pendingCount]);
+  }, [informativeState, pendingCount]);
 
   // Läuft eine Animation noch, wenn die Komponente verschwindet (z. B. Navi-
   // gation weg vom Screen mitten im Ausblenden) — sauber stoppen.
@@ -177,7 +186,8 @@ export function OfflineBanner() {
     };
   }, []);
 
-  if (!mounted) return null;
+  // Nichts zu melden → nichts rendern. Kein Platzhalter, keine Erfolgsmeldung.
+  if (!mounted || !displayState) return null;
 
   const animatedStyle = {
     opacity: animProgress,
@@ -221,21 +231,16 @@ export function OfflineBanner() {
       border: theme.colors.statusOpenBorder,
       title: pendingLabel(pendingCount),
     },
-    saved: {
-      icon: "checkmark-circle-outline" as const,
-      fg: theme.colors.statusCompleted,
-      bg: theme.colors.statusCompletedBg,
-      border: theme.colors.statusCompletedBorder,
-      title: "Alles gespeichert",
-    },
-  }[state];
+  }[displayState];
 
   // Zweite Zeile: offline + wartende Änderungen → Anzahl zeigen
   const subtitle =
-    state === "offline" && pendingCount > 0 ? pendingLabel(pendingCount) : null;
+    displayState === "offline" && pendingCount > 0
+      ? pendingLabel(pendingCount)
+      : null;
 
   const showDetails = pendingCount > 0;
-  const showRetry = state === "error";
+  const showRetry = displayState === "error";
 
   return (
     <>
@@ -300,10 +305,13 @@ export function OfflineBanner() {
           <Pressable style={styles.sheet} onPress={() => {}}>
             <View style={styles.sheetHandle} />
 
+            {/* Das Sheet ist nur bei wartenden Änderungen erreichbar. Fällt der
+                Zähler auf 0, während es offen ist, bleibt eine sachliche
+                Angabe stehen — keine Erfolgsmeldung. */}
             <Text style={styles.sheetTitle}>
               {pendingCount > 0
                 ? pendingLabel(pendingCount)
-                : "Alles gespeichert"}
+                : "Keine wartenden Änderungen"}
             </Text>
             <Text style={styles.sheetHint}>
               {online
@@ -348,55 +356,6 @@ export function OfflineBanner() {
       </Modal>
     </>
   );
-}
-
-// ─────────────────────────────────────────────────────────────────
-// Kompakter Status-Badge für den Header (oben rechts).
-// Zeigt im Online-/Alles-gespeichert-Zustand dezent "Online".
-// Wichtige Zustände (offline/pending/saving/error) übernimmt das volle
-// <OfflineBanner/> — der Badge rendert dann nichts.
-// ─────────────────────────────────────────────────────────────────
-export function SaveStatusBadge() {
-  const theme = useAppTheme();
-  const styles = useMemo(() => createBadgeStyles(theme), [theme]);
-  const state = useSaveState();
-
-  if (state !== "saved") return null;
-
-  return (
-    <View style={styles.badge}>
-      <View style={styles.dot} />
-      <Text style={styles.label}>Online</Text>
-    </View>
-  );
-}
-
-function createBadgeStyles(theme: ReturnType<typeof useAppTheme>) {
-  return StyleSheet.create({
-    badge: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 6,
-      paddingHorizontal: 10,
-      paddingVertical: 4,
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.statusCompletedBg,
-      borderWidth: 1,
-      borderColor: theme.colors.statusCompletedBorder,
-    },
-    dot: {
-      width: 6,
-      height: 6,
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.statusCompleted,
-    },
-    label: {
-      fontSize: theme.typography.size.xs,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.statusCompleted,
-    },
-  });
 }
 
 function createStyles(theme: ReturnType<typeof useAppTheme>) {

--- a/components/ui/index.tsx
+++ b/components/ui/index.tsx
@@ -33,7 +33,7 @@ export { AppHeader } from "./AppHeader";
 export { StatusBadge } from "./StatusBadge";
 export { WeekdayDots } from "./WeekdayDots";
 export { SkeletonCard } from "./SkeletonCard";
-export { OfflineBanner, SaveStatusBadge } from "./OfflineBanner";
+export { OfflineBanner } from "./OfflineBanner";
 export { ErrorBanner } from "./ErrorBanner";
 export { InitialsAvatar } from "./InitialsAvatar";
 export { InfoRow } from "./InfoRow";

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -15,7 +15,6 @@ import {
   KPICard,
   LoadingScreen,
   OfflineBanner,
-  SaveStatusBadge,
   ScreenContainer,
   SectionHeader,
 } from "@/components/ui";
@@ -168,20 +167,18 @@ export default function AdminDashboardScreen() {
     <ScreenContainer>
       {/* ── Header ── */}
       <View style={styles.header}>
+        {/* Marken-Zeile. Rechts saß hier ein Save-Status-Badge, der nur im
+            Normalfall gerendert wurde und bei jedem Speichern verschwand —
+            aussagekräftige Zustände zeigt jetzt ausschließlich das Banner. */}
         <View style={styles.brandRow}>
-          <View style={styles.brandLeft}>
-            <View style={styles.logoBadge}>
-              <Ionicons
-                name="business"
-                size={18}
-                color={theme.colors.onPrimaryContainer}
-              />
-            </View>
-            <Text style={styles.companyName}>{COMPANY_NAME}</Text>
+          <View style={styles.logoBadge}>
+            <Ionicons
+              name="business"
+              size={18}
+              color={theme.colors.onPrimaryContainer}
+            />
           </View>
-
-          {/* Dezenter Online-Status oben rechts */}
-          <SaveStatusBadge />
+          <Text style={styles.companyName}>{COMPANY_NAME}</Text>
         </View>
 
         <Text style={styles.greeting}>
@@ -420,13 +417,8 @@ function createStyles(theme: AppTheme) {
     brandRow: {
       flexDirection: "row",
       alignItems: "center",
-      justifyContent: "space-between",
-      marginBottom: theme.spacing.md,
-    },
-    brandLeft: {
-      flexDirection: "row",
-      alignItems: "center",
       gap: theme.spacing.sm,
+      marginBottom: theme.spacing.md,
     },
     logoBadge: {
       width: 34,

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -13,7 +13,6 @@ import {
   KPICard,
   LoadingScreen,
   OfflineBanner,
-  SaveStatusBadge,
   ScreenContainer,
   SectionHeader,
 } from "@/components/ui";
@@ -173,15 +172,16 @@ export default function EmployeeOverviewScreen() {
       {/* ── Save-Status ── */}
       <OfflineBanner />
 
-      {/* ── Header ── */}
+      {/* ── Header ──
+          Die Begrüßung nimmt immer die volle Breite ein. Vorher saß rechts
+          daneben ein Save-Status-Badge, der nur im Normalfall gerendert wurde:
+          bei jedem Speichern verschwand er und die Begrüßung wurde breiter
+          (anderer Zeilenumbruch/Abschnitt) — sichtbares Zappeln im Kopfbereich.
+          Der Badge ist entfallen; aussagekräftige Zustände zeigt das Banner. */}
       <View style={styles.header}>
-        <View style={styles.headerTopRow}>
-          <Text style={styles.greeting} numberOfLines={1}>
-            {getGreeting(now)}, {firstName}
-          </Text>
-          {/* Dezenter Online-Status oben rechts */}
-          <SaveStatusBadge />
-        </View>
+        <Text style={styles.greeting} numberOfLines={1}>
+          {getGreeting(now)}, {firstName}
+        </Text>
         <Text style={styles.dateText}>{dateLabel}</Text>
       </View>
 
@@ -419,14 +419,7 @@ function createStyles(theme: AppTheme) {
       paddingTop: theme.spacing.md,
       marginBottom: theme.spacing.xl,
     },
-    headerTopRow: {
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-      gap: theme.spacing.sm,
-    },
     greeting: {
-      flex: 1,
       fontSize: theme.typography.size.xxl,
       fontFamily: theme.typography.family.bold,
       fontWeight: theme.typography.weight.bold,


### PR DESCRIPTION
Behebt den vorbestehenden Layout-Sprung durch die Save-Status-Anzeige. **Unabhängig von #76** (anderer Branch, andere Dateien, von `main` abgezweigt) — #76 bleibt offen.

Rein präsentationell. **Keine** Änderungen an `deriveSaveState`, JobContext, Offline-Queue, `pendingActions`, `retrySync`, Supabase, Migrationen, RPCs oder Edge Functions.

## Problem

Der Normalzustand wurde doppelt angezeigt und kostete bei jedem Speichern Layout-Stabilität:

- **`OfflineBanner`** montierte sich nach *jeder* erfolgreichen Speicherung neu in den Layout-Fluss („Alles gespeichert", grün), hielt 1500 ms, blendete 250 ms aus und demontierte sich. Da die Animation `useNativeDriver` auf `opacity`/`translateY` nutzt, gibt sie ihre Höhe erst beim Unmount frei → **zwei vertikale Sprünge (~46 px) pro Aktion**.
- **`SaveStatusBadge`** zeigte dauerhaft „Online" im Header — aber **nur** im Normalzustand. Beim Speichern verschwand er; da die Begrüßung `flex: 1` in einer `space-between`-Zeile hatte, wurde sie breiter und brach neu um.
- Beide beschrieben denselben `saved`-Zustand mit zwei verschiedenen Wörtern.

## Lösung

| Zustand | Vorher | Nachher |
|---|---|---|
| `saved` (Normalfall) | Banner „Alles gespeichert" 1500 ms + Badge „Online" dauerhaft | **nichts** |
| `offline` | Banner | Banner (unverändert) |
| `pending` | Banner + Details-Sheet | unverändert |
| `saving` | Banner | unverändert |
| `error` | Banner + „Erneut versuchen" | unverändert |

Beim Übergang zurück in den Normalfall blendet der **zuletzt aussagekräftige** Zustand ruhig aus (neuer `displayState`), statt vorher noch auf Grün umzuspringen. Kein Halten, keine Erfolgsmeldung.

Entfernt, weil danach ungenutzt: `SaveStatusBadge`, `createBadgeStyles`, `useSaveState`, `SAVED_HOLD_MS` und die `saved`-Farbkonfiguration.

Header beider Screens kommen ohne rechtes Statuselement aus — **kein unsichtbarer Platzhalter**: die Begrüßung hat immer die volle Breite, `brandRow` trägt die Marken-Zeile direkt.

Zusätzlich: der Sheet-Titel fällt auf „Keine wartenden Änderungen" statt „Alles gespeichert" (nur erreichbar, wenn der Zähler bei offenem Sheet auf 0 fällt).

## Verbleibende Vorkommen

- `SaveStatusBadge`, „Alles gespeichert" → **nur noch in erklärenden Code-Kommentaren**, keine UI.
- „Online" als sichtbarer Text → **keine** Vorkommen mehr.
- `useSaveState` → vollständig entfernt.

## Andere OfflineBanner-Konsumenten

Alle 7 Render-Stellen nutzen `<OfflineBanner />` ohne Props und ohne Abhängigkeit vom `saved`-Verhalten: Employee-Übersicht, Admin-Dashboard, Job-Detail, Employee-Kalender, Admin-Jobs, Dauerauftrags-Detail, JobsList. Offline-/Pending-/Saving-/Error-Darstellung, Retry-Aktion und Details-Sheet unverändert.

## Prüfung

- `npx tsc --noEmit` ✅
- `npm run lint` ✅

## Manueller Test (Dev-Build via Metro)

**A. Normaler Online-Leerlauf**
- [ ] Kein Status-Badge im Header
- [ ] Kein „Online", kein „Alles gespeichert"
- [ ] Header optisch stabil, keine Bewegung

**B. Auftrag starten/abschließen**
- [ ] Pending/Saving darf kurz erscheinen
- [ ] Nach Erfolg verschwindet es
- [ ] **Kein grüner Erfolgs-Blitz**, kein Zurückspringen des Inhalts danach

**C. Flugmodus**
- [ ] Offline-Banner erscheint klar; bei wartenden Änderungen zusätzlich die Anzahl

**D. Reconnect**
- [ ] Saving erscheint ggf. kurz, verschwindet nach Erfolg
- [ ] Kein „Alles gespeichert"-Flash

**E. Sync-Fehler**
- [ ] Fehler-Banner + „Erneut versuchen" erscheinen weiterhin und bleiben stehen

**F. Admin-Dashboard + Employee-Übersicht**
- [ ] Begrüßung/Titel-Breite bleibt über alle Statuswechsel konstant
- [ ] Details-Sheet (bei wartenden Änderungen) öffnet und listet korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)