### PR TITLE
fix(ui): nutzersichere Fehlermeldungen, Pull-to-Refresh und Dark-Mode-Fallbacks

### DIFF
--- a/app/(admin-tabs)/employees.tsx
+++ b/app/(admin-tabs)/employees.tsx
@@ -3,7 +3,7 @@
 // Vollständig theme-aware (Light + Dark Mode).
 // Business-Logik (createEmployee, JobContext) unverändert.
 
-import { EmptyState, LoadingScreen } from "@/components/ui";
+import { EmptyState, ErrorBanner, LoadingScreen } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useJobs } from "@/context/JobContext";
 import { createEmployee } from "@/services/employees/createEmployee";
@@ -27,6 +27,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
 import { getEmployeeStatus } from "@/utils/employeeStatus";
+import { toUserMessage } from "@/utils/userMessages";
 
 function roleLabel(role?: string | null): string {
   if (role === "admin") return "Admin";
@@ -104,10 +105,10 @@ export default function EmployeesScreen() {
 
       handleCloseModal();
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Einladung konnte nicht verschickt werden.";
+      const message = toUserMessage(
+        error,
+        "Einladung konnte nicht verschickt werden.",
+      );
 
       Alert.alert("Fehler", message);
     } finally {
@@ -167,7 +168,10 @@ export default function EmployeesScreen() {
               <Text style={styles.countLabel}>aktive Mitarbeiter</Text>
             </View>
 
-            {error && <Text style={styles.errorText}>{error}</Text>}
+            {/* Ladefehler der Mitarbeiterliste: einheitlich als ErrorBanner
+                statt als nackter roter Text (dieselbe Darstellung wie in den
+                Job-Screens). Text kam bisher zudem roh aus dem Backend. */}
+            {error ? <ErrorBanner message={error} /> : null}
           </View>
         }
         ListEmptyComponent={
@@ -387,13 +391,6 @@ function createStyles(theme: AppTheme) {
     },
 
     // ── Error-Text
-    errorText: {
-      marginTop: theme.spacing.md,
-      color: theme.colors.error,
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-    },
 
     // ── Mitarbeiter-Karten in der Liste
     employeeCard: {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { AnimatedSplash } from "@/components/ui";
 import { AuthProvider, useAuth } from "@/context/AuthContext";
 import { JobProvider } from "@/context/JobContext";
 import { AuthLinkUrlProvider } from "@/features/auth/AuthLinkUrlProvider";
+import { useAppTheme } from "@/hooks/useAppTheme";
 import { useNotificationNavigation } from "@/hooks/useNotificationNavigation";
 import { setupNotifications } from "@/services/notificationService";
 import { installNetworkErrorGuard } from "@/utils/networkError";
@@ -38,8 +39,52 @@ installNetworkErrorGuard();
 
 // Einfacher globaler Error-Boundary: fängt unerwartete Render-Fehler im
 // gesamten App-Baum ab, damit die App nicht komplett weiß/rot einfriert.
-// Bewusst minimal (kein Crash-Reporting, kein Theme) — nur ein deutscher
-// Fallback mit "Erneut versuchen".
+// Bewusst minimal (kein Crash-Reporting) — nur ein deutscher Fallback mit
+// "Erneut versuchen".
+//
+// Die Darstellung liegt in einer eigenen Funktionskomponente, weil die Klasse
+// selbst keine Hooks nutzen kann: der Fallback hing dadurch an festen
+// Light-Mode-Farben (#FFFFFF/#111827) und blitzte im Dark Mode als weiße
+// Seite auf. useAppTheme() braucht keinen Provider (nur useColorScheme) und
+// funktioniert deshalb auch hier oberhalb des Provider-Baums.
+function AppErrorFallback({ onReset }: { onReset: () => void }) {
+  const theme = useAppTheme();
+
+  return (
+    <View
+      style={[
+        styles.errorContainer,
+        { backgroundColor: theme.colors.background },
+      ]}
+    >
+      <Text style={[styles.errorTitle, { color: theme.colors.onSurface }]}>
+        Etwas ist schiefgelaufen
+      </Text>
+      <Text
+        style={[styles.errorMessage, { color: theme.colors.onSurfaceVariant }]}
+      >
+        Es ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut.
+      </Text>
+      <Pressable
+        style={[
+          styles.errorButton,
+          { backgroundColor: theme.colors.primaryContainer },
+        ]}
+        onPress={onReset}
+      >
+        <Text
+          style={[
+            styles.errorButtonText,
+            { color: theme.colors.onPrimaryContainer },
+          ]}
+        >
+          Erneut versuchen
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
 type AppErrorBoundaryState = { hasError: boolean };
 
 class AppErrorBoundary extends Component<
@@ -63,18 +108,7 @@ class AppErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
-      return (
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorTitle}>Etwas ist schiefgelaufen</Text>
-          <Text style={styles.errorMessage}>
-            Es ist ein unerwarteter Fehler aufgetreten. Bitte versuche es
-            erneut.
-          </Text>
-          <Pressable style={styles.errorButton} onPress={this.handleReset}>
-            <Text style={styles.errorButtonText}>Erneut versuchen</Text>
-          </Pressable>
-        </View>
-      );
+      return <AppErrorFallback onReset={this.handleReset} />;
     }
 
     return this.props.children;
@@ -82,34 +116,31 @@ class AppErrorBoundary extends Component<
 }
 
 const styles = StyleSheet.create({
+  // Farben werden zur Laufzeit aus dem Theme ergänzt (siehe AppErrorFallback) —
+  // hier stehen nur Maße/Typo, damit der Fallback Dark Mode respektiert.
   errorContainer: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
     padding: 24,
-    backgroundColor: "#FFFFFF",
   },
   errorTitle: {
     fontSize: 20,
     fontWeight: "700",
-    color: "#111827",
     marginBottom: 8,
     textAlign: "center",
   },
   errorMessage: {
     fontSize: 15,
-    color: "#4B5563",
     textAlign: "center",
     marginBottom: 24,
   },
   errorButton: {
-    backgroundColor: "#2563EB",
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 8,
   },
   errorButtonText: {
-    color: "#FFFFFF",
     fontSize: 15,
     fontWeight: "600",
   },

--- a/components/ui/ErrorBanner.tsx
+++ b/components/ui/ErrorBanner.tsx
@@ -20,12 +20,23 @@ interface ErrorBannerProps {
   onDismiss?: () => void;
   /** Banner-Typ: error (rot) oder warning (orange) */
   type?: "error" | "warning";
+  /**
+   * Optionale Wiederholen-Aktion. Nur zusammen mit `actionLabel` sichtbar.
+   * Gedacht für Teil-Fehler, bei denen der Rest des Screens nutzbar bleibt
+   * (z. B. fehlgeschlagene KPI-Abfrage im Admin-Dashboard) — dort wäre ein
+   * Vollbild-Fehlerscreen falsch, aber ohne Retry säße der Nutzer fest.
+   */
+  onAction?: () => void;
+  /** Beschriftung der Aktion, z. B. "Erneut versuchen". */
+  actionLabel?: string;
 }
 
 export function ErrorBanner({
   message,
   onDismiss,
   type = "error",
+  onAction,
+  actionLabel,
 }: ErrorBannerProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme, type), [theme, type]);
@@ -38,9 +49,22 @@ export function ErrorBanner({
   return (
     <View style={styles.banner}>
       <Ionicons name={iconName} size={16} color={iconColor} style={styles.icon} />
-      <Text style={styles.message} numberOfLines={3}>
-        {message}
-      </Text>
+      <View style={styles.body}>
+        <Text style={styles.message} numberOfLines={3}>
+          {message}
+        </Text>
+        {onAction && actionLabel ? (
+          <TouchableOpacity
+            onPress={onAction}
+            activeOpacity={0.7}
+            style={styles.action}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="refresh" size={14} color={iconColor} />
+            <Text style={styles.actionText}>{actionLabel}</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
       {onDismiss && (
         <TouchableOpacity
           onPress={onDismiss}
@@ -77,8 +101,24 @@ function createStyles(
     icon: {
       marginTop: 1,
     },
-    message: {
+    body: {
       flex: 1,
+      gap: 6,
+    },
+    action: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+      alignSelf: "flex-start",
+    },
+    actionText: {
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.semibold,
+      fontFamily: theme.typography.family.semibold,
+      color: textColor,
+      textDecorationLine: "underline",
+    },
+    message: {
       fontSize: theme.typography.size.sm,
       fontWeight: theme.typography.weight.medium,
       fontFamily: theme.typography.family.medium,

--- a/components/ui/ScreenContainer.tsx
+++ b/components/ui/ScreenContainer.tsx
@@ -10,6 +10,7 @@ import React, { useMemo } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
+  RefreshControl,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -28,6 +29,17 @@ interface ScreenContainerProps {
   style?: ViewStyle;
   /** Tastatur-Ausweich-Verhalten aktivieren (Standard: false) */
   avoidKeyboard?: boolean;
+  /**
+   * Pull-to-Refresh: läuft gerade eine Aktualisierung? Steuert den nativen
+   * Spinner. Nur wirksam zusammen mit `onRefresh` und `scrollable`.
+   */
+  refreshing?: boolean;
+  /**
+   * Pull-to-Refresh-Handler. Ist er gesetzt, bekommt die ScrollView einen
+   * RefreshControl — so muss ihn kein Screen selbst verdrahten (die ScrollView
+   * gehört ScreenContainer, nicht dem Screen).
+   */
+  onRefresh?: () => void;
 }
 
 export function ScreenContainer({
@@ -36,6 +48,8 @@ export function ScreenContainer({
   noPadding = false,
   style,
   avoidKeyboard = false,
+  refreshing = false,
+  onRefresh,
 }: ScreenContainerProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -45,6 +59,18 @@ export function ScreenContainer({
       contentContainerStyle={[styles.scrollContent, noPadding && styles.noPadding, style]}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
+      refreshControl={
+        onRefresh ? (
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            // Theme-aware, damit der Spinner auch im Dark Mode sichtbar ist.
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+            progressBackgroundColor={theme.colors.surface}
+          />
+        ) : undefined
+      }
     >
       {children}
     </ScrollView>

--- a/context/JobContext.tsx
+++ b/context/JobContext.tsx
@@ -27,6 +27,7 @@ import { getCachedJobs, saveCachedJobs } from "@/services/offline/jobs.storage";
 import { syncPendingJobActions } from "@/services/offline/jobs.sync";
 import { CreateJobInput, EmployeeOption, Job, JobType } from "@/types/job";
 import { isNetworkError } from "@/utils/networkError";
+import { toUserMessage } from "@/utils/userMessages";
 import NetInfo from "@react-native-community/netinfo";
 import React, {
   createContext,
@@ -300,7 +301,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       // Bei Netzwerkfehler keinen Fehler-State setzen — Offline ist erwartbar
       // und der Cache wurde bereits geladen. Nur echte Fehler sichtbar machen.
       if (!networkError) {
-        setError(err?.message ?? "Jobs konnten nicht geladen werden.");
+        setError(toUserMessage(err, "Jobs konnten nicht geladen werden."));
       }
     } finally {
       refreshJobsInProgressRef.current = false;
@@ -333,7 +334,9 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         return;
       }
       console.error("Failed to load employees:", err);
-      setError(err?.message ?? "Mitarbeiter konnten nicht geladen werden.");
+      setError(
+        toUserMessage(err, "Mitarbeiter konnten nicht geladen werden."),
+      );
     }
   }, []);
 

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -11,6 +11,7 @@
 import {
   Card,
   EmptyState,
+  ErrorBanner,
   InitialsAvatar,
   KPICard,
   LoadingScreen,
@@ -29,9 +30,10 @@ import {
 } from "@/services/jobs/jobs.service";
 import { formatDateISO } from "@/utils/date";
 import { isAssignedTo } from "@/utils/jobAssignees";
+import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 const COMPANY_NAME = "Dashboard";
@@ -80,7 +82,14 @@ export default function AdminDashboardScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const { profile } = useAuth();
-  const { jobs, employees, loading } = useJobs();
+  const {
+    jobs,
+    employees,
+    loading,
+    error: dataError,
+    refreshJobs,
+    refreshEmployees,
+  } = useJobs();
 
   // Zeitpunkt beim Render. Header zeigt nur das Datum (keine Live-Uhrzeit).
   const now = new Date();
@@ -104,22 +113,53 @@ export default function AdminDashboardScreen() {
   // getScheduleKpis reine Zähler (count/head) über job_type='single'.
   const todayKey = useMemo(() => formatDateISO(now) ?? "", [now]);
   const [kpis, setKpis] = useState<ScheduleKpis | null>(null);
+  // Schlägt die KPI-Abfrage fehl, blieben die vier Kacheln früher stumm auf
+  // „—" stehen — für den Admin nicht von „es gibt heute nichts" zu
+  // unterscheiden. Jetzt: sichtbares Banner + Retry, restliches Dashboard
+  // bleibt nutzbar (ein fehlgeschlagener Zähler ist kein Screen-Fehler).
+  const [kpiError, setKpiError] = useState("");
+  const kpiLoadingRef = useRef(false);
+
+  const loadKpis = useCallback(async () => {
+    if (!todayKey || kpiLoadingRef.current) return;
+    kpiLoadingRef.current = true;
+    try {
+      const fresh = await getScheduleKpis(todayKey);
+      setKpis(fresh);
+      setKpiError("");
+    } catch (err: unknown) {
+      // Zuvor geladene Werte NICHT verwerfen — veraltete Zahlen sind
+      // brauchbarer als leere Kacheln, das Banner ordnet sie ein.
+      setKpiError(
+        toUserMessage(err, "Die Kennzahlen konnten nicht geladen werden."),
+      );
+    } finally {
+      kpiLoadingRef.current = false;
+    }
+  }, [todayKey]);
 
   useEffect(() => {
-    let cancelled = false;
-    if (!todayKey) return;
-    getScheduleKpis(todayKey)
-      .then((k) => {
-        if (!cancelled) setKpis(k);
-      })
-      .catch(() => {
-        // Fehler still: KPIs zeigen dann „—".
-        if (!cancelled) setKpis(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [todayKey]);
+    void loadKpis();
+  }, [loadKpis]);
+
+  // ── Pull-to-Refresh ──────────────────────────────────────────────────────
+  // Aktualisiert Jobs, Mitarbeiter und KPIs gemeinsam. Bewusst KEIN
+  // loading-Gate: der LoadingScreen darf den Screen dabei nicht ersetzen,
+  // sichtbare (auch veraltete) Inhalte bleiben stehen.
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshingRef = useRef(false);
+
+  const handleRefresh = useCallback(async () => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    try {
+      await Promise.all([refreshJobs(), refreshEmployees(), loadKpis()]);
+    } finally {
+      refreshingRef.current = false;
+      setRefreshing(false);
+    }
+  }, [refreshJobs, refreshEmployees, loadKpis]);
 
   const openCount = kpis?.offen ?? null;
   const inProgressCount = kpis?.inArbeit ?? null;
@@ -164,7 +204,12 @@ export default function AdminDashboardScreen() {
   if (loading) return <LoadingScreen />;
 
   return (
-    <ScreenContainer>
+    <ScreenContainer
+      refreshing={refreshing}
+      onRefresh={() => {
+        void handleRefresh();
+      }}
+    >
       {/* ── Header ── */}
       <View style={styles.header}>
         {/* Marken-Zeile. Rechts saß hier ein Save-Status-Badge, der nur im
@@ -189,6 +234,37 @@ export default function AdminDashboardScreen() {
 
       {/* ── Save-Status ── */}
       <OfflineBanner />
+
+      {/* ── Lade-/Aktualisierungsfehler der Job-/Mitarbeiterdaten ──
+          Sichtbar, aber nicht destruktiv: die zuletzt geladenen (ggf.
+          veralteten) Inhalte bleiben stehen. Offline setzt JobContext
+          bewusst KEINEN Fehler — dafür ist das OfflineBanner zuständig. */}
+      {dataError ? (
+        <View style={styles.kpiErrorWrap}>
+          <ErrorBanner
+            message={dataError}
+            actionLabel="Erneut versuchen"
+            onAction={() => {
+              void handleRefresh();
+            }}
+          />
+        </View>
+      ) : null}
+
+      {/* ── KPI-Fehler: nur die Kacheln betroffen, Rest bleibt bedienbar ── */}
+      {kpiError ? (
+        <View style={styles.kpiErrorWrap}>
+          <ErrorBanner
+            message={kpiError}
+            type="warning"
+            actionLabel="Erneut versuchen"
+            onAction={() => {
+              void loadKpis();
+            }}
+            onDismiss={() => setKpiError("")}
+          />
+        </View>
+      ) : null}
 
       {/* ── KPI-Karten (2×2) → tippen öffnet die Jobliste ── */}
       <View style={styles.kpiGrid}>
@@ -450,6 +526,9 @@ function createStyles(theme: AppTheme) {
     },
 
     // ── KPI Grid
+    kpiErrorWrap: {
+      marginBottom: theme.spacing.md,
+    },
     kpiGrid: {
       flexDirection: "row",
       flexWrap: "wrap",

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toUserMessage } from "@/utils/userMessages";
 
 // ─────────────────────────────────────────────
 // Section-Block (theme-aware Karte mit Header)
@@ -205,10 +206,7 @@ export default function AdminScreen() {
       }
     } catch (err: unknown) {
       // Bei einem Fehler wird NICHT navigiert — der Admin bleibt im Formular.
-      const msg =
-        err instanceof Error
-          ? err.message
-          : "Job konnte nicht erstellt werden.";
+      const msg = toUserMessage(err, "Job konnte nicht erstellt werden.");
       Alert.alert("Fehler", msg);
     } finally {
       // Sperre in beiden Fällen wieder freigeben (Erfolg wie Fehler).

--- a/features/auth/RegisterScreen.tsx
+++ b/features/auth/RegisterScreen.tsx
@@ -22,6 +22,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 
 export default function RegisterScreen() {
   const theme      = useAppTheme();
@@ -106,7 +107,7 @@ export default function RegisterScreen() {
       router.replace("/");
     } catch (err) {
       setFormError(
-        err instanceof Error ? err.message : "Registrierung fehlgeschlagen."
+        toFriendlyAuthErrorMessage(err, "Registrierung fehlgeschlagen.")
       );
     } finally {
       setLoading(false);

--- a/features/auth/SetupCompanyScreen.tsx
+++ b/features/auth/SetupCompanyScreen.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 
 export function SetupCompanyScreen() {
   const theme  = useAppTheme();
@@ -50,9 +51,7 @@ export function SetupCompanyScreen() {
       router.replace("/");
     } catch (err) {
       setFormError(
-        err instanceof Error
-          ? err.message
-          : "Firma konnte nicht erstellt werden."
+        toFriendlyAuthErrorMessage(err, "Firma konnte nicht erstellt werden.")
       );
     } finally {
       setLoading(false);

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -31,6 +31,7 @@ import { router, useLocalSearchParams } from "expo-router";
 import React, { useMemo, useState } from "react";
 import { Alert, ScrollView, StatusBar, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { toUserMessage } from "@/utils/userMessages";
 
 // Reihenfolge für die Job-Liste: laufend → offen → erledigt
 const STATUS_ORDER: Record<JobStatus, number> = {
@@ -196,10 +197,10 @@ export default function EmployeeDetailScreen() {
         `${employee.fullName} hat eine neue Einladungs-E-Mail erhalten.`,
       );
     } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : "Einladung konnte nicht erneut verschickt werden.";
+      const message = toUserMessage(
+        err,
+        "Einladung konnte nicht erneut verschickt werden.",
+      );
       Alert.alert("Fehler", message);
     } finally {
       setResendingInvite(false);
@@ -220,10 +221,10 @@ export default function EmployeeDetailScreen() {
           : "Mitarbeiter wurde deaktiviert.",
       );
     } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : "Status konnte nicht geändert werden.";
+      const message = toUserMessage(
+        err,
+        "Status konnte nicht geändert werden.",
+      );
       Alert.alert("Fehler", message);
     } finally {
       setUpdatingActive(false);

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -26,6 +26,7 @@ import type { AppTheme } from "@/constants/theme";
 import type { Job, JobStatus } from "@/types/job";
 import { isJobToday } from "@/utils/jobSchedule";
 import { confirmCompleteJob } from "@/utils/jobDialogs";
+import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useCallback, useMemo, useRef, useState } from "react";
@@ -79,9 +80,35 @@ export default function EmployeeOverviewScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const { profile, role } = useAuth();
-  const { jobs, startJob, completeJob, loading } = useJobs();
+  const {
+    jobs,
+    startJob,
+    completeJob,
+    loading,
+    error: dataError,
+    refreshJobs,
+  } = useJobs();
 
   const [filter, setFilter] = useState<Filter>("all");
+
+  // ── Pull-to-Refresh ──────────────────────────────────────────────────────
+  // Lädt die Jobs neu; alles Heute-Abgeleitete (KPIs, aktiver Job, "Heute
+  // anstehend", Monatsaktivität) hängt an `jobs` und aktualisiert sich damit
+  // mit. Bewusst kein loading-Gate → kein Vollbild-Spinner beim Ziehen.
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshingRef = useRef(false);
+
+  const handleRefresh = useCallback(async () => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    try {
+      await refreshJobs();
+    } finally {
+      refreshingRef.current = false;
+      setRefreshing(false);
+    }
+  }, [refreshJobs]);
 
   // ── Aktions-State für Start/Abschluss ─────────────────────────────────────
   // Vorher liefen diese Aufrufe als Fire-and-Forget: nicht awaited, kein
@@ -102,7 +129,7 @@ export default function EmployeeOverviewScreen() {
       try {
         await action();
       } catch (err: unknown) {
-        setActionError(err instanceof Error ? err.message : fallbackMessage);
+        setActionError(toUserMessage(err, fallbackMessage));
       } finally {
         actionBusyRef.current = false;
         setActionBusy(false);
@@ -228,9 +255,30 @@ export default function EmployeeOverviewScreen() {
   if (loading) return <LoadingScreen />;
 
   return (
-    <ScreenContainer>
+    <ScreenContainer
+      refreshing={refreshing}
+      onRefresh={() => {
+        void handleRefresh();
+      }}
+    >
       {/* ── Save-Status ── */}
       <OfflineBanner />
+
+      {/* ── Lade-/Aktualisierungsfehler der Jobs ──
+          Bleibt sichtbar, ohne die bereits angezeigten (ggf. veralteten)
+          Jobs zu verwerfen. Offline erzeugt hier bewusst keinen Fehler —
+          das übernimmt das OfflineBanner darüber. */}
+      {dataError ? (
+        <View style={styles.loadErrorWrap}>
+          <ErrorBanner
+            message={dataError}
+            actionLabel="Erneut versuchen"
+            onAction={() => {
+              void handleRefresh();
+            }}
+          />
+        </View>
+      ) : null}
 
       {/* ── Fehler aus Start/Abschluss — oben, ohne Scrollen sichtbar ── */}
       {actionError ? (
@@ -512,6 +560,9 @@ function createStyles(theme: AppTheme) {
       textTransform: "capitalize",
     },
     // ── Sections
+    loadErrorWrap: {
+      marginBottom: theme.spacing.md,
+    },
     section: {
       marginBottom: theme.spacing.xl,
     },

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toUserMessage } from "@/utils/userMessages";
 
 // Vergleicht zwei Mitarbeiter-ID-Mengen ordnungsunabhängig (normalisiert:
 // dedupliziert + sortiert). Reine Umsortierung darf hasChanges NICHT
@@ -321,10 +322,7 @@ export default function EditJobScreen() {
       Alert.alert("Erfolgreich", "Job wurde aktualisiert.");
       router.back();
     } catch (err: unknown) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : "Job konnte nicht gespeichert werden.";
+      const msg = toUserMessage(err, "Job konnte nicht gespeichert werden.");
 
       // Teilerfolg: die Mitarbeiterzuweisung wurde bereits gespeichert, auch
       // wenn der Rest fehlgeschlagen ist (siehe PartialUpdateError in
@@ -361,10 +359,10 @@ export default function EditJobScreen() {
             Alert.alert("Erfolgreich", "Job wurde gelöscht.");
             router.back();
           } catch (err: unknown) {
-            const msg =
-              err instanceof Error
-                ? err.message
-                : "Job konnte nicht gelöscht werden.";
+            const msg = toUserMessage(
+              err,
+              "Job konnte nicht gelöscht werden.",
+            );
             Alert.alert("Fehler", msg);
           } finally {
             setSubmitting(false);

--- a/features/jobs/EmployeeJobsCalendarScreen.tsx
+++ b/features/jobs/EmployeeJobsCalendarScreen.tsx
@@ -29,6 +29,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toUserMessage } from "@/utils/userMessages";
 
 // Datums-Key "YYYY-MM-DD" eines Jobs.
 // single hat date; Fallback scheduledStart (Alt-Daten / single ohne date).
@@ -157,7 +158,7 @@ export default function EmployeeJobsCalendarScreen() {
         await startJob(jobId);
       } catch (err: unknown) {
         setActionError(
-          err instanceof Error ? err.message : "Job konnte nicht gestartet werden.",
+          toUserMessage(err, "Job konnte nicht gestartet werden."),
         );
       }
     },
@@ -171,7 +172,7 @@ export default function EmployeeJobsCalendarScreen() {
         await completeJob(jobId);
       } catch (err: unknown) {
         setActionError(
-          err instanceof Error ? err.message : "Job konnte nicht abgeschlossen werden.",
+          toUserMessage(err, "Job konnte nicht abgeschlossen werden."),
         );
       }
     },

--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -60,6 +60,7 @@ import {
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
+import { toUserMessage } from "@/utils/userMessages";
 
 // ─────────────────────────────────────────────
 // JobDetailScreen
@@ -240,7 +241,7 @@ export default function JobDetailScreen() {
       await startJob(job.id);
     } catch (err: unknown) {
       setActionError(
-        err instanceof Error ? err.message : "Job konnte nicht gestartet werden."
+        toUserMessage(err, "Job konnte nicht gestartet werden.")
       );
     } finally {
       setSubmitting(false);
@@ -262,9 +263,7 @@ export default function JobDetailScreen() {
       await completeJob(job.id);
     } catch (err: unknown) {
       setActionError(
-        err instanceof Error
-          ? err.message
-          : "Job konnte nicht abgeschlossen werden."
+        toUserMessage(err, "Job konnte nicht abgeschlossen werden.")
       );
     } finally {
       setSubmitting(false);

--- a/features/jobs/RecurringRuleDetailScreen.tsx
+++ b/features/jobs/RecurringRuleDetailScreen.tsx
@@ -57,6 +57,7 @@ import { router } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
 import { Alert, ScrollView, StatusBar, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { toUserMessage } from "@/utils/userMessages";
 
 type Props = {
   /** Die Parent-Regel. Der Aufrufer hat bereits geprüft, dass es eine ist. */
@@ -204,7 +205,7 @@ export default function RecurringRuleDetailScreen({
       await loadOccurrences();
     } catch (err: unknown) {
       setActionError(
-        err instanceof Error ? err.message : "Aktion fehlgeschlagen.",
+        toUserMessage(err, "Aktion fehlgeschlagen."),
       );
     } finally {
       setRuleBusy(false);
@@ -230,9 +231,10 @@ export default function RecurringRuleDetailScreen({
               // Der DB-Guard lehnt Löschungen mit geschützter Historie ab —
               // Meldung sichtbar machen statt still zu scheitern.
               setActionError(
-                err instanceof Error
-                  ? err.message
-                  : "Löschen nicht möglich (geschützte Historie).",
+                toUserMessage(
+                  err,
+                  "Löschen nicht möglich (geschützte Historie).",
+                ),
               );
             } finally {
               setRuleBusy(false);

--- a/features/jobs/components/JobComments.tsx
+++ b/features/jobs/components/JobComments.tsx
@@ -11,7 +11,7 @@
 // setzen; ohne dieses Prop hätte der Nutzer ein aktives Senden-Feld, das
 // serverseitig mit einem RLS-Fehler endet.
 
-import { Button, Card, ErrorBanner, Input } from "@/components/ui";
+import { Button, Card, EmptyState, ErrorBanner, Input } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useJobComments } from "@/features/jobs/hooks/useJobComments";
 import { formatDateISO, isSameLocalDate } from "@/utils/date";
@@ -20,6 +20,7 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { toUserMessage } from "@/utils/userMessages";
 
 // ─────────────────────────────────────────────
 // Datums-/Zeit-Formatierung (analog JobDetailScreen)
@@ -94,9 +95,7 @@ export function JobComments({
         );
       } else {
         setSubmitError(
-          err instanceof Error
-            ? err.message
-            : "Kommentar konnte nicht gesendet werden.",
+          toUserMessage(err, "Kommentar konnte nicht gesendet werden."),
         );
       }
     } finally {
@@ -122,9 +121,16 @@ export function JobComments({
           <ActivityIndicator size="small" color={theme.colors.primary} />
         </View>
       ) : error ? (
-        <Text style={styles.errorText}>{error}</Text>
+        /* Einheitliche Fehlerdarstellung statt nacktem rotem Text — gleiche
+           Optik wie Sende-Fehler direkt darunter und in den Job-Screens. */
+        <ErrorBanner message={error} />
       ) : comments.length === 0 ? (
-        <Text style={styles.emptyText}>Noch keine Kommentare</Text>
+        <EmptyState
+          title="Noch keine Kommentare"
+          message="Schreibe die erste Nachricht zu diesem Auftrag."
+          icon="chatbubble-outline"
+          compact
+        />
       ) : (
         <View style={styles.list}>
           {comments.map((comment) => (
@@ -209,16 +215,6 @@ function createStyles(theme: AppTheme) {
     loadingWrap: {
       paddingVertical: theme.spacing.md,
       alignItems: "center",
-    },
-    errorText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.regular,
-      color: theme.colors.error,
-    },
-    emptyText: {
-      fontSize: theme.typography.size.sm,
-      fontFamily: theme.typography.family.regular,
-      color: theme.colors.onSurfaceVariant,
     },
 
     // Liste

--- a/features/jobs/components/JobPhotos.tsx
+++ b/features/jobs/components/JobPhotos.tsx
@@ -23,6 +23,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { toUserMessage } from "@/utils/userMessages";
 
 // ─────────────────────────────────────────────
 // Konstanten
@@ -207,7 +208,7 @@ export function JobPhotos({ jobId, canUpload, isOnline }: JobPhotosProps) {
       // Fehler wurde im Hook bereits in error-State gesetzt;
       // hier als lokalen uploadError spiegeln für direktes Feedback.
       setUploadError(
-        err instanceof Error ? err.message : "Upload fehlgeschlagen.",
+        toUserMessage(err, "Upload fehlgeschlagen."),
       );
     }
   }

--- a/features/jobs/hooks/useJobPhotos.ts
+++ b/features/jobs/hooks/useJobPhotos.ts
@@ -11,6 +11,7 @@ import {
 import type { JobPhoto, UploadPhotoInput } from "@/types/photo";
 import { isNetworkError } from "@/utils/networkError";
 import { useCallback, useEffect, useState } from "react";
+import { toUserMessage } from "@/utils/userMessages";
 
 type UploadArgs = Omit<UploadPhotoInput, "jobId" | "companyId">;
 
@@ -49,9 +50,7 @@ export function useJobPhotos(jobId: string, isOnline: boolean) {
         setError(null);
       } else {
         setError(
-          err instanceof Error
-            ? err.message
-            : "Fotos konnten nicht geladen werden.",
+          toUserMessage(err, "Fotos konnten nicht geladen werden."),
         );
       }
     } finally {
@@ -87,8 +86,7 @@ export function useJobPhotos(jobId: string, isOnline: boolean) {
         // Neues Foto vorne einfügen (neueste zuerst, analog Service-Sortierung)
         setPhotos((prev) => [newPhoto, ...prev]);
       } catch (err: unknown) {
-        const message =
-          err instanceof Error ? err.message : "Upload fehlgeschlagen.";
+        const message = toUserMessage(err, "Upload fehlgeschlagen.");
         setError(message);
         throw err;
       } finally {

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -27,6 +27,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
 
 const APP_VERSION =
   Constants.expoConfig?.version ??
@@ -78,8 +79,7 @@ export default function ProfileScreen({
       // im Web nichts anzeigte — ein fehlgeschlagener Logout sah damit aus wie
       // gar keine Reaktion. Der Nutzer bleibt bewusst angemeldet, statt in
       // einen halb abgemeldeten Zustand zu geraten.
-      const grund =
-        error instanceof Error && error.message ? error.message : "Unbekannter Fehler.";
+      const grund = toFriendlyAuthErrorMessage(error, "Unbekannter Fehler.");
       await alertDialog("Abmelden fehlgeschlagen", `${grund}\n\nDu bist weiterhin angemeldet.`);
       return;
     }

--- a/features/timesheets/TimesheetScreen.tsx
+++ b/features/timesheets/TimesheetScreen.tsx
@@ -76,7 +76,12 @@ export default function TimesheetScreen() {
         />
         {employees.length === 0 ? (
           <Card>
-            <Text style={styles.muted}>Keine Mitarbeiter vorhanden.</Text>
+            <EmptyState
+              title="Keine Mitarbeiter"
+              message="Lege zuerst Mitarbeiter an, um einen Nachweis zu erstellen."
+              icon="people-outline"
+              compact
+            />
           </Card>
         ) : (
           <Card padding={0}>

--- a/features/timesheets/hooks/useTimesheet.ts
+++ b/features/timesheets/hooks/useTimesheet.ts
@@ -10,6 +10,7 @@ import {
 import type { TimesheetData } from "@/types/timesheet";
 import type { EmployeeOption } from "@/types/job";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toUserMessage } from "@/utils/userMessages";
 
 // In Version 1 neutraler, fest hinterlegter Firmenname (kein company.name-Fetch).
 const COMPANY_NAME = "Cleaning Ops";
@@ -114,9 +115,10 @@ export function useTimesheet(): UseTimesheetResult {
       .catch((err) => {
         if (!cancelled) {
           setError(
-            err instanceof Error
-              ? err.message
-              : "Stundenzettel konnte nicht geladen werden.",
+            toUserMessage(
+              err,
+              "Stundenzettel konnte nicht geladen werden.",
+            ),
           );
           setData(null);
         }
@@ -138,7 +140,7 @@ export function useTimesheet(): UseTimesheetResult {
       await exportTimesheetPdf(data);
     } catch (err) {
       setExportError(
-        err instanceof Error ? err.message : "PDF-Export fehlgeschlagen.",
+        toUserMessage(err, "PDF-Export fehlgeschlagen."),
       );
     } finally {
       setExporting(false);

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -659,20 +659,26 @@ export async function createJob(input: CreateJobInput): Promise<CreateJobResult>
           compensationError,
         );
       }
+      // Interne Details (Job-ID, Supabase-Hinweis) gehören ins Log, nicht in
+      // die UI — der Nutzer braucht nur zu wissen, dass er nachsehen muss.
+      if (__DEV__) {
+        console.error(
+          `[createJob] Kompensation fehlgeschlagen für Job-ID ${data.id} — ` +
+            `Auftrag existiert möglicherweise ohne Zuweisungen.`,
+        );
+      }
       throw new Error(
-        `Job wurde angelegt, aber die Mitarbeiterzuweisung ist fehlgeschlagen UND ` +
-          `der Job konnte danach nicht automatisch wieder gelöscht werden ` +
-          `(Job-ID ${data.id}). Der Auftrag existiert möglicherweise ohne ` +
-          `Zuweisungen — bitte manuell in Supabase prüfen.`,
+        "Der Auftrag wurde angelegt, aber die Mitarbeiterzuweisung ist " +
+          "fehlgeschlagen. Bitte prüfe den Auftrag in der Jobliste.",
       );
     }
 
-    const assignMsg =
-      assignError instanceof Error ? assignError.message : String(assignError);
+    if (__DEV__) {
+      console.error("[createJob] Zuweisung fehlgeschlagen:", assignError);
+    }
     throw new Error(
-      `Job konnte nicht mit den gewählten Mitarbeitern angelegt werden ` +
-        `(${assignMsg}). Der unvollständig angelegte Job wurde automatisch ` +
-        `wieder entfernt.`,
+      "Der Auftrag konnte nicht mit den gewählten Mitarbeitern angelegt " +
+        "werden. Es wurde nichts gespeichert — bitte erneut versuchen.",
     );
   }
 

--- a/services/photos/photos.service.ts
+++ b/services/photos/photos.service.ts
@@ -144,9 +144,12 @@ export async function uploadJobPhoto(input: UploadPhotoInput): Promise<JobPhoto>
     });
 
   if (storageError) {
-    throw new Error(
-      `Foto konnte nicht hochgeladen werden: ${storageError.message}`,
-    );
+    // Rohtext NICHT anhängen: er enthält Bucket-/Pfad-/Policy-Namen und landete
+    // bisher unverändert im UI. Details bleiben im Dev-Log nachvollziehbar.
+    if (__DEV__) {
+      console.error("[photos] Upload fehlgeschlagen:", storageError);
+    }
+    throw new Error("Das Foto konnte nicht hochgeladen werden.");
   }
 
   // 3. Metadaten in Tabelle speichern
@@ -167,8 +170,11 @@ export async function uploadJobPhoto(input: UploadPhotoInput): Promise<JobPhoto>
   if (dbError) {
     // 4. Best-effort Rollback: Datei aus Storage entfernen
     await supabase.storage.from(BUCKET).remove([storagePath]);
+    if (__DEV__) {
+      console.error("[photos] Speichern der Metadaten fehlgeschlagen:", dbError);
+    }
     throw new Error(
-      `Foto wurde hochgeladen, aber konnte nicht gespeichert werden: ${dbError.message}`,
+      "Das Foto konnte nicht gespeichert werden. Bitte versuche es erneut.",
     );
   }
 
@@ -200,9 +206,10 @@ export async function getJobPhotos(jobId: string): Promise<JobPhoto[]> {
     .order("created_at", { ascending: false });
 
   if (error) {
-    throw new Error(
-      `Fotos konnten nicht geladen werden: ${error.message}`,
-    );
+    if (__DEV__) {
+      console.error("[photos] Laden fehlgeschlagen:", error);
+    }
+    throw new Error("Die Fotos konnten nicht geladen werden.");
   }
 
   if (!data || data.length === 0) {

--- a/utils/userMessages.ts
+++ b/utils/userMessages.ts
@@ -1,0 +1,190 @@
+// utils/userMessages.ts
+// Zentrale Übersetzung beliebiger Fehler in nutzerfreundliche, deutsche
+// Meldungen — für ALLE nicht-Auth-Fehlerpfade (Jobs, Kommentare, Fotos,
+// Mitarbeiter, Stundenzettel, Firma).
+//
+// Warum: Die Services reichen Supabase-/PostgREST-Fehler an vielen Stellen roh
+// weiter (`if (error) throw error;`). Das UI zeigte sie bisher mit dem Muster
+//   err instanceof Error ? err.message : fallback
+// direkt an — Nutzer sahen dadurch Texte wie
+//   "new row violates row-level security policy for table \"job_comments\""
+//   "duplicate key value violates unique constraint \"...\""
+//   "JSON object requested, multiple (or no) rows returned"
+//   "Network request failed"
+// also Tabellen-, Policy- und Constraint-Namen aus dem Backend.
+//
+// `toUserMessage(err, fallback)` ist die eine Anlaufstelle dafür:
+//   1. Netzwerk/Offline    → feste Offline-Meldung
+//   2. Bekannter Fehlercode/-text → passende deutsche Meldung
+//   3. Bereits vom Server/Service auf Deutsch formulierte Meldung
+//      (z. B. "Nur Admins dürfen Jobs erstellen.") → unverändert durchreichen
+//   4. Alles andere        → screen-spezifischer `fallback` des Aufrufers
+//
+// Für Auth-/Edge-Function-Fehler bleibt utils/authErrorMessages.ts zuständig
+// (kennt GoTrue-Texte und liest Edge-Function-Bodys); toUserMessage ersetzt
+// sie NICHT, sondern deckt den Rest der App ab.
+
+import { isNetworkError } from "@/utils/networkError";
+
+// ── Standard-Meldungen ──────────────────────────────────────────────────────
+export const GENERIC_ERROR_MESSAGE =
+  "Die Aktion konnte nicht ausgeführt werden.";
+export const OFFLINE_MESSAGE =
+  "Keine Internetverbindung. Bitte versuche es erneut.";
+export const PERMISSION_MESSAGE =
+  "Du hast keine Berechtigung für diese Aktion.";
+export const NOT_FOUND_MESSAGE =
+  "Der Eintrag wurde nicht gefunden oder ist nicht mehr verfügbar.";
+export const CONFLICT_MESSAGE =
+  "Dieser Eintrag existiert bereits.";
+export const IN_USE_MESSAGE =
+  "Der Eintrag wird noch verwendet und kann nicht gelöscht werden.";
+export const INVALID_INPUT_MESSAGE =
+  "Die Eingaben sind unvollständig oder ungültig.";
+export const SESSION_EXPIRED_MESSAGE =
+  "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.";
+export const SERVER_UNAVAILABLE_MESSAGE =
+  "Der Server ist momentan nicht erreichbar. Bitte versuche es später erneut.";
+export const TIMEOUT_MESSAGE =
+  "Die Anfrage hat zu lange gedauert. Bitte versuche es erneut.";
+export const LOAD_FAILED_MESSAGE = "Die Daten konnten nicht geladen werden.";
+export const SAVE_FAILED_MESSAGE =
+  "Die Änderungen konnten nicht gespeichert werden.";
+
+// ── Fehlercodes ─────────────────────────────────────────────────────────────
+// Postgres-SQLSTATE und PostgREST-Codes, die Supabase im `code`-Feld liefert.
+// P0001 (raise_exception) fehlt bewusst: RPCs formulieren dort eigene, meist
+// schon deutsche Texte — die laufen unten durch die Durchreiche-Prüfung.
+const CODE_MESSAGES: Readonly<Record<string, string>> = {
+  // Postgres
+  "42501": PERMISSION_MESSAGE, // insufficient_privilege / RLS
+  "23505": CONFLICT_MESSAGE, // unique_violation
+  "23503": IN_USE_MESSAGE, // foreign_key_violation
+  "23502": INVALID_INPUT_MESSAGE, // not_null_violation
+  "23514": INVALID_INPUT_MESSAGE, // check_violation
+  "22P02": INVALID_INPUT_MESSAGE, // invalid_text_representation
+  "57014": TIMEOUT_MESSAGE, // query_canceled
+  // PostgREST
+  PGRST116: NOT_FOUND_MESSAGE, // 0 oder >1 Zeilen bei .single()
+  PGRST301: SESSION_EXPIRED_MESSAGE, // JWT ungültig/abgelaufen
+  PGRST204: INVALID_INPUT_MESSAGE, // Spalte im Payload unbekannt
+  PGRST202: GENERIC_ERROR_MESSAGE, // RPC nicht gefunden
+};
+
+// ── Textmuster ──────────────────────────────────────────────────────────────
+// Greifen, wenn kein `code` mitgeliefert wird (z. B. weil der Service den
+// Fehler in ein `new Error(...)` umverpackt hat). Reihenfolge: spezifisch → grob.
+const MESSAGE_PATTERNS: readonly { pattern: RegExp; message: string }[] = [
+  // Vor der Berechtigungs-Regel: die Job-RPCs melden gelöschte UND gesperrte
+  // Jobs mit demselben Text ("Job not found or not allowed"). Der mit Abstand
+  // häufigere Fall ist ein zwischenzeitlich gelöschter/umverteilter Auftrag —
+  // "nicht mehr verfügbar" passt dort, während "keine Berechtigung" unnötig
+  // alarmiert (und im RLS-Fall inhaltlich ebenfalls zutrifft).
+  {
+    pattern:
+      /job not found|not found or not allowed|no rows returned|results contain 0 rows/i,
+    message: NOT_FOUND_MESSAGE,
+  },
+  {
+    pattern:
+      /row-level security|violates row-level|permission denied|insufficient privilege|not allowed|nicht erlaubt|nur admins/i,
+    message: PERMISSION_MESSAGE,
+  },
+  {
+    pattern: /duplicate key|already exists|unique constraint/i,
+    message: CONFLICT_MESSAGE,
+  },
+  {
+    pattern: /foreign key constraint|still referenced/i,
+    message: IN_USE_MESSAGE,
+  },
+  {
+    pattern: /violates (check|not-null)|invalid input syntax/i,
+    message: INVALID_INPUT_MESSAGE,
+  },
+  {
+    pattern: /invalid jwt|jwt expired|not authenticated|session.{0,15}(missing|not found)/i,
+    message: SESSION_EXPIRED_MESSAGE,
+  },
+  {
+    pattern: /timed? ?out|timeout|deadline exceeded|aborted/i,
+    message: TIMEOUT_MESSAGE,
+  },
+  {
+    pattern:
+      /^5\d{2}\b|internal server error|service unavailable|bad gateway|upstream/i,
+    message: SERVER_UNAVAILABLE_MESSAGE,
+  },
+];
+
+// Sichtbare Spuren von Backend-Internas. Eine Meldung, auf die eines dieser
+// Muster passt, wird NIE durchgereicht — auch dann nicht, wenn sie sonst
+// deutsch aussieht (z. B. eine deutsche RPC-Meldung mit angehängtem
+// Constraint-Namen). Sicherheitsnetz hinter der Muster-Zuordnung oben.
+const TECHNICAL_MARKER_PATTERN =
+  /\b(select|insert|update|delete|from|where|join|relation|column|table|constraint|policy|schema|function|rpc|sqlstate|pgrst\w*|postgres|supabase|storage|bucket|auth\.uid|null value|stack|typeerror|referenceerror|syntaxerror|econnrefused|enotfound|fetch|http|https?:\/\/|\{|\}|\[object|=>|at [A-Z]\w+\.)\b|_id\b|"[a-z_]+"|`|\bjwt\b/i;
+
+// Positive Prüfung: sieht der Text wie bewusst formulierte deutsche
+// Nutzer-Kopie aus? Ohne diese Hürde würde jede unbekannte englische
+// Backend-Meldung durchrutschen (Denylist allein ist zu löchrig).
+const GERMAN_MARKER_PATTERN =
+  /[äöüßÄÖÜ]|\b(bitte|nicht|kein|keine|keinen|konnte|konnten|wurde|wurden|darf|dürfen|muss|müssen|fehlt|ist|sind|du|dein|deine|der|die|das|ein|eine|noch|mehr|erneut|wähle|gib)\b/i;
+
+function extractParts(err: unknown): { message: string; code: string } {
+  if (!err) return { message: "", code: "" };
+  if (typeof err === "string") return { message: err, code: "" };
+
+  const raw = err as { message?: unknown; code?: unknown; status?: unknown };
+  const message =
+    typeof raw.message === "string"
+      ? raw.message
+      : err instanceof Error
+        ? err.message
+        : "";
+  const code =
+    typeof raw.code === "string"
+      ? raw.code
+      : typeof raw.code === "number"
+        ? String(raw.code)
+        : typeof raw.status === "number"
+          ? String(raw.status)
+          : "";
+
+  return { message, code };
+}
+
+// Darf diese Meldung dem Nutzer unverändert gezeigt werden? Nur wenn sie
+// deutsch formuliert ist UND keinerlei technische Marker enthält.
+function isUserSafeMessage(message: string): boolean {
+  if (!message || message.length > 200) return false;
+  if (TECHNICAL_MARKER_PATTERN.test(message)) return false;
+  return GERMAN_MARKER_PATTERN.test(message);
+}
+
+/**
+ * Übersetzt einen beliebigen Fehler in eine anzeigbare deutsche Meldung.
+ *
+ * `fallback` ist der screen-spezifische Kontext des Aufrufers (z. B. "Job
+ * konnte nicht gestartet werden.") und wird immer dann verwendet, wenn der
+ * Fehler nicht zugeordnet werden kann — bewusst statt einer einzigen vagen
+ * Meldung überall.
+ */
+export function toUserMessage(
+  err: unknown,
+  fallback: string = GENERIC_ERROR_MESSAGE,
+): string {
+  if (isNetworkError(err)) return OFFLINE_MESSAGE;
+
+  const { message, code } = extractParts(err);
+
+  const byCode = CODE_MESSAGES[code];
+  if (byCode) return byCode;
+
+  for (const { pattern, message: friendly } of MESSAGE_PATTERNS) {
+    if (pattern.test(message)) return friendly;
+  }
+
+  if (isUserSafeMessage(message)) return message;
+
+  return fallback;
+}


### PR DESCRIPTION
Audit **Batch 5 — Empty / Loading / Error States**. Reine Präsentations-/UX-Arbeit: kein Schema, keine Migration, keine RLS/RPC/Edge Function, keine Änderung an Offline-Queue, Firebase/Notifications oder nativer Expo-Config. Keine neuen Dependencies.

## 1 — Nutzersichere Fehlermeldungen

Neu: `utils/userMessages.ts` mit `toUserMessage(error, fallback)`.

Reihenfolge der Zuordnung:
1. Netzwerk/Offline (`isNetworkError`) → "Keine Internetverbindung. Bitte versuche es erneut."
2. Fehlercode → Postgres `42501` / `23505` / `23503` / `23502` / `23514` / `22P02` / `57014`, PostgREST `PGRST116` / `PGRST301` / `PGRST204` / `PGRST202`
3. Textmuster → RLS/permission, not-found, duplicate, FK, invalid input, JWT/Session, Timeout, 5xx
4. Bereits deutsch formulierte Server-/Service-Meldung → unverändert durchreichen
5. sonst → screen-spezifischer `fallback` des Aufrufers

Gegen Leaks gibt es ein **doppeltes Gate**: eine Denylist technischer Marker (SQL-Keywords, Tabellen-/Policy-/Constraint-Namen, `PGRST*`, Stacktraces, `_id`, gequotete Identifier) blockiert die Durchreiche, und der Text muss zusätzlich **positiv deutsch** aussehen. Eine unbekannte englische Backend-Meldung kann damit nicht durchrutschen.

`utils/authErrorMessages.ts` bleibt für Auth/Edge Functions zuständig (kennt GoTrue-Texte und liest Function-Bodys); die drei Auth-nahen Stellen nutzen jetzt konsequent `toFriendlyAuthErrorMessage`.

Zusätzlich komponieren die Services keine rohen Backend-Texte mehr in ihre eigenen Meldungen (`photos.service.ts`, `jobs.service.ts` — vorher z. B. `Fotos konnten nicht geladen werden: ${error.message}`). Details landen im Dev-Log.

## 2 — Pull-to-Refresh

`ScreenContainer` bekommt optionale `refreshing` / `onRefresh`-Props und hängt einen theme-aware `RefreshControl` in seine ScrollView — die Screens müssen nichts duplizieren.

- **Admin-Dashboard**: `refreshJobs()` + `refreshEmployees()` + KPI-Reload parallel
- **Employee-Übersicht**: `refreshJobs()`; alles Heute-Abgeleitete hängt an `jobs`

Kein `loading`-Gate beim Ziehen (kein LoadingScreen-Ersatz), Ref-Guard gegen parallele Refreshes, vorhandene Daten bleiben stehen.

## 3 — KPI-Fehler + Retry

`getScheduleKpis` schlug bisher still fehl und ließ vier Kacheln auf "—" stehen — ununterscheidbar von "heute ist nichts". Jetzt: inline `ErrorBanner` (warning) mit "Erneut versuchen", zuvor geladene Werte bleiben erhalten, das restliche Dashboard bleibt bedienbar. Pull-to-Refresh löst denselben Reload mit aus.

## 4 — Empty/Loading/Error-Konsistenz

- `ErrorBanner` kann optional eine Aktion rendern (`onAction` / `actionLabel`)
- `JobComments`: nackter roter Fehlertext → `ErrorBanner`; "Noch keine Kommentare" → `EmptyState compact`
- `TimesheetScreen`: "Keine Mitarbeiter vorhanden." → `EmptyState compact`
- Mitarbeiterliste: roher Context-Fehler als nackter Text → `ErrorBanner`
- Lade-/Aktualisierungsfehler der Job-Daten sind jetzt auf beiden Landing-Screens sichtbar, ohne Daten zu verwerfen

**`SkeletonCard`: bewusst NICHT adoptiert (Option B).** Die einzigen sinnvollen Stellen wären die initialen Vollbild-Ladezustände der beiden Landing-Screens — die sollen laut Scope unverändert bleiben. Eine Adoption hier wäre reine Rechtfertigung der Komponente.

## 5 — Dark-Mode-Fallbacks

`AppErrorBoundary` in `app/_layout.tsx` hing an festen Light-Farben (`#FFFFFF` / `#111827` / `#2563EB`) und blitzte im Dark Mode als weiße Seite auf. Die Darstellung liegt jetzt in `AppErrorFallback`, einer Funktionskomponente mit `useAppTheme()` (braucht nur `useColorScheme`, also keinen Provider — funktioniert oberhalb des Provider-Baums). Klasse, Reset-Logik und Boundary-Position unverändert.

**`app/index.tsx` war bereits theme-aware** — der Audit-Befund ist dort veraltet. Beide Fallbacks (Profil-Fehler, Offline) nutzen schon `theme.colors.*`. Der Boot-Platzhalter `#0B1220` bleibt bewusst fix (Marken-Splash, dunkel — kein weißer Frame). SplashGate/AuthGate/`<Redirect>`-Choreografie und Protected-Routes sind unangetastet.

## 6 — Save-Status: keine Regression

`SaveStatusBadge`, permanentes "Online" und der "Alles gespeichert"-Flash sind **nicht** reintroduziert (Treffer nur noch in erklärenden Kommentaren in `OfflineBanner.tsx`). `OfflineBanner` selbst ist in diesem PR **unverändert** und zeigt weiterhin offline / pending / saving / error.

## Verifikation

- `npx tsc --noEmit` → sauber
- `npm run lint` → sauber (exit 0)
- `toUserMessage` gegen 23 reale Fehlerformen laufen lassen (RLS-Violation mit Tabellenname, `duplicate key ... constraint`, `PGRST116`, FK-Violation, `Network request failed`, `column jobs.job_type does not exist`, TypeError, `{}`, `null` sowie die deutschen Service-Texte): kein einziger Backend-Text erreicht die UI, alle bewusst formulierten deutschen Meldungen bleiben erhalten.

**Noch nicht manuell auf dem Gerät getestet** — Checkliste im Follow-up-Kommentar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)