### PR TITLE
fix(zeitplan): Realtime-Status nur noch im Dev loggen, kein Redbox mehr

### DIFF
--- a/features/jobs/AdminScheduleScreen.tsx
+++ b/features/jobs/AdminScheduleScreen.tsx
@@ -38,6 +38,7 @@ import {
   matchesSearch,
   type ScheduleFilter,
 } from "@/utils/scheduleView";
+import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, {
@@ -158,8 +159,11 @@ export default function AdminScheduleScreen({
         }
         setRuleMap(map);
         setJobs(items);
-      } catch (err: any) {
-        setError(err?.message ?? "Zeitplan konnte nicht geladen werden.");
+      } catch (err: unknown) {
+        // Letzte verbliebene Roh-Fehlerstelle dieses Screens: err.message kam
+        // direkt aus Supabase/PostgREST und konnte Tabellen-/Policy-Namen
+        // anzeigen. Jetzt über den zentralen Mapper (siehe utils/userMessages).
+        setError(toUserMessage(err, "Zeitplan konnte nicht geladen werden."));
       } finally {
         loadInProgress.current = false;
         setLoading(false);
@@ -198,13 +202,24 @@ export default function AdminScheduleScreen({
           }, 300);
         },
       )
+      // Status NUR im Development protokollieren — analog zum Kanal in
+      // context/JobContext.tsx ("Jobs realtime status:").
+      //
+      // Warum kein console.error mehr: CHANNEL_ERROR ist hier ein erwartbarer,
+      // sich selbst heilender Zustand. supabase-js setzt den Realtime-JWT erst
+      // bei SIGNED_IN/TOKEN_REFRESHED — beim Kaltstart mit gespeicherter
+      // Session feuert aber INITIAL_SESSION, sodass der erste Join ohne Token
+      // (also als anon) gegen die RLS auf `jobs` läuft und abgelehnt wird.
+      // realtime-js rejoint daraufhin selbstständig mit Backoff (1/2/5/10 s)
+      // und übernimmt den Token, sobald er gesetzt ist. console.error erzeugte
+      // dafür ein rotes LogBox-Overlay im Dev-Build, obwohl nichts kaputt ist
+      // und der Zeitplan sich danach normal weiter aktualisiert.
+      //
+      // Bewusst NICHT geändert: Kanal-Topic, Events, Filter, Cleanup sowie
+      // jegliche Auth-/Reconnect-Logik. Reine Logging-Änderung.
       .subscribe((status, error) => {
-        if (error) {
-          console.error("Admin schedule realtime error:", error);
-        }
-
-        if (status === "CHANNEL_ERROR") {
-          console.error("Admin schedule realtime channel failed");
+        if (__DEV__) {
+          console.log("Admin schedule realtime status:", status, error ?? "");
         }
       });
 


### PR DESCRIPTION
Kleiner Folge-PR zu #78 (bereits gemergt). **Reine Logging-/Präsentationsänderung in einer Datei.**

## Problem

Im iOS-Development-Build erschien im roten LogBox-Overlay:

```
Admin schedule realtime channel failed
```

Der Zustand ist **erwartbar und heilt sich selbst** — es war nur die Meldungs-Schwere falsch. `features/jobs/AdminScheduleScreen.tsx` war der einzige der drei Realtime-Kanäle der App, der `console.error` benutzt; die anderen beiden loggen still bzw. gar nicht:

| Kanal | Datei | Logging |
|---|---|---|
| `jobs-realtime` | `context/JobContext.tsx:496` | `console.log` unter `__DEV__` |
| `profile-active-<uid>` | `context/AuthContext.tsx:566` | kein Callback |
| `admin-schedule-realtime-<ts>` | `AdminScheduleScreen.tsx:201` | **`console.error`** ← Ursache des Overlays |

## Ursache (nur zur Einordnung — in diesem PR NICHT behoben)

Nachvollzogen in den installierten Paketen:

1. `lib/supabase.ts` erzeugt den Client ohne `accessToken`-Callback → supabase-js nutzt `_listenForAuthEvents()`.
2. `_handleTokenChanged` reicht den Token nur bei `TOKEN_REFRESHED` oder `SIGNED_IN` an Realtime weiter (`supabase-js/dist/index.cjs:557`).
3. Beim Kaltstart mit gespeicherter Session feuert auth-js aber `INITIAL_SESSION` (`auth-js/GoTrueClient.js:3388`) — dieser Event trifft **keinen** Zweig, `realtime.setAuth()` wird nie aufgerufen.
4. `RealtimeChannel.subscribe()` hängt den JWT nur an, wenn er existiert (`RealtimeChannel.js:122`) → der Join läuft als `anon`.
5. Die RLS auf `jobs` lehnt ab → Server antwortet `error` → `CHANNEL_ERROR` (`RealtimeChannel.js:146`).

**Selbstheilung:** `joinPush.receive("error")` plant über `rejoinTimer.scheduleTimeout()` einen Rejoin mit Backoff `[1000, 2000, 5000, 10000]` ms (`phoenix.cjs.js:277-283`); sobald `setAuth(token)` läuft, bekommen alle Kanäle den Token und rejoinen (`RealtimeClient.js:428-440`). Der Zeitplan aktualisiert sich danach normal weiter.

## Änderung

`.subscribe()`-Callback loggt Status inkl. Fehlerdetails jetzt nur noch unter `__DEV__` per `console.log` — dieselbe Konvention wie `JobContext`.

Zusätzlich die **letzte verbliebene Roh-Fehlerstelle dieses Screens** migriert: `setError(err?.message ?? …)` konnte Supabase-/PostgREST-Text mit Tabellen- und Policy-Namen anzeigen (der Screen war nicht Teil des Batch-5-Dateisatzes in #78). Jetzt `toUserMessage(err, "Zeitplan konnte nicht geladen werden.")`.

## Bewusst NICHT geändert

- Supabase-Client-/Auth-Konfiguration und `lib/supabase.ts`
- Kanal-Topic, Events, Filter, Debounce, Cleanup
- Reconnect-/Retry-Verhalten (kein eigener Reconnect-Code)
- RLS, Replication, Realtime-Settings, Migrationen, RPCs, Edge Functions
- Keine neuen Dependencies, kein Build

Echte Anwendungsfehler werden **nicht** unterdrückt: die Änderung betrifft ausschließlich diesen einen Status-Callback. `TIMED_OUT`/`CLOSED` waren vorher schon unbehandelt und werden jetzt sogar erstmals sichtbar (im Dev-Log).

**Hinweis:** Wer die *Ursache* statt des Symptoms beheben will, bräuchte einen `accessToken`-Callback am Supabase-Client — das ändert App-weites Auth-Plumbing und gehört in einen eigenen PR mit eigenem Test.

## Verifikation

- `npx tsc --noEmit` → sauber
- `npm run lint` → sauber (exit 0)
- Diff: 1 Datei, +21/−7

🤖 Generated with [Claude Code](https://claude.com/claude-code)