### PR TITLE
fix(formulare): Warnung bei ungespeicherten Änderungen, klarere Felder & Validierung

### DIFF
--- a/components/ui/DateTimeField.tsx
+++ b/components/ui/DateTimeField.tsx
@@ -40,6 +40,13 @@ export interface DateTimeFieldProps {
    * "date": nur Datum, keine Uhrzeit (Start-/Enddatum für Recurring-Regeln).
    */
   mode?: "datetime" | "time" | "date";
+  /**
+   * Validierungsfehler zu diesem Feld. Wird direkt unter dem Feld gerendert —
+   * genau wie beim Input, damit Datums-/Zeitfelder nicht anders aussehen als
+   * Textfelder. Vorher musste jede Aufrufstelle den Fehler selbst als <Text>
+   * nachbauen (5× dieselbe Zeile in JobFormFields).
+   */
+  error?: string;
 }
 
 export function DateTimeField({
@@ -48,6 +55,7 @@ export function DateTimeField({
   value,
   onChange,
   mode = "datetime",
+  error,
 }: DateTimeFieldProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -202,6 +210,11 @@ export function DateTimeField({
         )}
       </View>
 
+      {/* Fehler bewusst AUSSERHALB des positionierten Wrappers: der
+          Löschen-Button darin ist absolut am unteren Rand verankert und würde
+          sonst auf die Fehlerzeile rutschen. */}
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
       <Modal visible={showPickerModal} transparent animationType="fade">
         <View style={modalStyles.overlay}>
           <View style={modalStyles.container}>
@@ -283,6 +296,13 @@ function createStyles(theme: AppTheme) {
     },
     fieldArea: {
       width: "100%",
+    },
+    // Gleiche Optik wie die Fehlerzeile im Input (components/ui/index.tsx).
+    errorText: {
+      marginTop: 2,
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.error,
     },
     clearBtn: {
       position: "absolute",

--- a/components/ui/index.tsx
+++ b/components/ui/index.tsx
@@ -190,7 +190,7 @@ interface InputProps extends TextInputProps {
   error?: string;
 }
 
-export function Input({ label, error, style, onFocus, onBlur, ...props }: InputProps) {
+export function Input({ label, error, style, onFocus, onBlur, multiline, ...props }: InputProps) {
   const theme = useAppTheme();
   const [focused, setFocused] = useState(false);
   const styles = useMemo(() => createInputStyles(theme), [theme]);
@@ -199,8 +199,14 @@ export function Input({ label, error, style, onFocus, onBlur, ...props }: InputP
     <View style={styles.wrapper}>
       {label && <Text style={styles.label}>{label}</Text>}
       <TextInput
+        multiline={multiline}
+        // Mehrzeilige Felder sahen bisher aus wie einzeilige: minHeight war der
+        // Tap-Target-Wert und der Text stand vertikal zentriert. Jetzt sichtbar
+        // mehrzeilig (Platz für ~4 Zeilen) und Text startet oben.
+        textAlignVertical={multiline ? "top" : undefined}
         style={[
           styles.input,
+          multiline && styles.inputMultiline,
           focused && styles.inputFocused,
           error && styles.inputError,
           style as any,
@@ -301,6 +307,11 @@ function createInputStyles(theme: AppTheme) {
     },
     inputError: {
       borderColor: theme.colors.error,
+    },
+    inputMultiline: {
+      minHeight: 96,
+      paddingTop: 12,
+      paddingBottom: 12,
     },
     errorText: {
       fontSize: theme.typography.size.xs,

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -3,7 +3,7 @@
 // Vollständig auf useAppTheme() migriert — Light + Dark Mode.
 // Business-Logik (createJob, useJobForm, AuthContext, JobContext) unverändert.
 
-import { LoadingScreen } from "@/components/ui";
+import { Button, LoadingScreen } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
@@ -15,7 +15,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Alert,
   Animated,
   KeyboardAvoidingView,
   Platform,
@@ -28,6 +27,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
 import { toUserMessage } from "@/utils/userMessages";
+import { alertDialog } from "@/utils/dialogs";
+import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 
 // ─────────────────────────────────────────────
 // Section-Block (theme-aware Karte mit Header)
@@ -114,7 +115,12 @@ export default function AdminScreen() {
     [employees],
   );
 
-  const { values, errors, setField, validate, reset } = useJobForm();
+  const { values, errors, isDirty, setField, validate, reset } = useJobForm();
+
+  // Warnung vor dem Verlassen mit ungespeicherten Eingaben. Deckt eigenen
+  // Zurück-Button, Android-Hardware-Zurück und iOS-Swipe ab (siehe Hook).
+  // Während des Absendens bewusst aus: der Erfolgs-Pfad navigiert selbst.
+  const { leaveWithoutWarning } = useUnsavedChangesGuard(isDirty && !submitting);
 
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(20)).current;
@@ -180,34 +186,28 @@ export default function AdminScreen() {
 
       const { recurringOccurrencesFailed } = await createJob(input);
 
-      // Formular vor dem Erfolgshinweis zurücksetzen.
+      // Formular vor dem Erfolgshinweis zurücksetzen (setzt auch isDirty zurück).
       reset();
 
-      // Nach Bestätigung des Hinweises zur Jobs-Übersicht navigieren. Der Job
-      // ist bereits angelegt — deshalb navigieren wir auch bei fehlgeschlagener
-      // Occurrence-Generierung; wir zeigen dann aber KEINEN vollen Erfolg,
-      // sondern einen Teil-Erfolg-Hinweis (Termine bitte prüfen).
-      const goToJobs = () => router.replace("/(admin-tabs)/jobs");
-
+      // Erst den Hinweis abwarten, DANN navigieren — über alertDialog, weil
+      // Alert.alert im Web nichts anzeigt und der onPress-Callback dort nie
+      // liefe (die Navigation wäre unerreichbar). Der Job ist bereits angelegt,
+      // deshalb navigieren wir auch bei fehlgeschlagener Occurrence-Generierung
+      // — dann aber mit Teil-Erfolg-Hinweis statt vollem Erfolg.
       if (recurringOccurrencesFailed) {
-        Alert.alert(
+        await alertDialog(
           "Job angelegt",
           "Der Job wurde angelegt, aber die Termine konnten nicht vollständig erzeugt werden. Bitte prüfe die Terminierung.",
-          [{ text: "OK", onPress: goToJobs }],
-          { cancelable: false },
         );
       } else {
-        Alert.alert(
-          "✓ Erstellt",
-          "Der Job wurde erfolgreich angelegt.",
-          [{ text: "OK", onPress: goToJobs }],
-          { cancelable: false },
-        );
+        await alertDialog("Erstellt", "Der Job wurde erfolgreich angelegt.");
       }
+
+      leaveWithoutWarning(() => router.replace("/(admin-tabs)/jobs"));
     } catch (err: unknown) {
       // Bei einem Fehler wird NICHT navigiert — der Admin bleibt im Formular.
       const msg = toUserMessage(err, "Job konnte nicht erstellt werden.");
-      Alert.alert("Fehler", msg);
+      await alertDialog("Fehler", msg);
     } finally {
       // Sperre in beiden Fällen wieder freigeben (Erfolg wie Fehler).
       submittingRef.current = false;
@@ -283,19 +283,15 @@ export default function AdminScreen() {
             />
           </SectionBlock>
 
-          <TouchableOpacity
+          {/* Gemeinsamer Button statt eigener TouchableOpacity-Nachbau —
+              gleiche Optik, gleicher Lade-Spinner und gleiche Tap-Fläche wie
+              im Bearbeiten-Screen. */}
+          <Button
+            label="Job erstellen"
             onPress={handleCreateJob}
+            loading={submitting}
             disabled={loading || submitting}
-            activeOpacity={0.85}
-            style={[
-              styles.createBtn,
-              (loading || submitting) && styles.createBtnDisabled,
-            ]}
-          >
-            <Text style={styles.createBtnText}>
-              {submitting ? "Wird erstellt…" : "Job erstellen"}
-            </Text>
-          </TouchableOpacity>
+          />
 
           <View style={{ height: 40 }} />
         </Animated.ScrollView>
@@ -384,27 +380,6 @@ function createStyles(theme: AppTheme) {
     scroll: {
       padding: theme.spacing.lg,
       gap: theme.spacing.md,
-    },
-
-    // "Job erstellen"-Button
-    createBtn: {
-      backgroundColor: theme.colors.primaryContainer,
-      paddingVertical: 15,
-      borderRadius: theme.radius.md,
-      alignItems: "center",
-      minHeight: theme.spacing.tapTarget,
-      justifyContent: "center",
-      ...theme.shadows.md,
-    },
-    createBtnDisabled: {
-      opacity: 0.5,
-    },
-    createBtnText: {
-      fontSize: theme.typography.size.md,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onPrimaryContainer,
-      letterSpacing: theme.typography.letterSpacing.wide,
     },
   });
 }

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -24,7 +24,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -37,6 +36,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
 import { toUserMessage } from "@/utils/userMessages";
+import { alertDialog, confirmDialog } from "@/utils/dialogs";
+import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 
 // Vergleicht zwei Mitarbeiter-ID-Mengen ordnungsunabhängig (normalisiert:
 // dedupliziert + sortiert). Reine Umsortierung darf hasChanges NICHT
@@ -242,10 +243,17 @@ export default function EditJobScreen() {
     );
   }, [job, values, assignedEmployeeIds]);
 
-  // ── Speichern (unveränderte Logik)
+  // Warnung vor dem Verlassen mit ungespeicherten Änderungen. Nutzt dieselbe
+  // hasChanges-Berechnung wie der Speichern-Button — es warnt also exakt dann,
+  // wenn auch wirklich etwas zu speichern wäre. Während des Absendens aus.
+  const { leaveWithoutWarning } = useUnsavedChangesGuard(
+    hasChanges && !submitting,
+  );
+
+  // ── Speichern (Business-Logik unverändert)
   const handleSave = async () => {
     if (!job) {
-      Alert.alert("Fehler", "Job wurde nicht gefunden.");
+      await alertDialog("Fehler", "Job wurde nicht gefunden.");
       return;
     }
 
@@ -260,7 +268,7 @@ export default function EditJobScreen() {
     // diesem Zustand stattfinden — auch nicht, falls der Button je über
     // einen anderen Pfad als disabled=false erreichbar wäre.
     if (hasInactiveAssignedEmployees) {
-      Alert.alert(
+      await alertDialog(
         "Bearbeiten nicht möglich",
         "Dieser Auftrag ist mindestens einem inaktiven Mitarbeiter zugewiesen " +
           `(${inactiveAssignedEmployees.map((e) => e.fullName).join(", ")}). ` +
@@ -319,8 +327,12 @@ export default function EditJobScreen() {
             },
       );
 
-      Alert.alert("Erfolgreich", "Job wurde aktualisiert.");
-      router.back();
+      // Erst den Hinweis abwarten, DANN zurück. Vorher lief Alert.alert
+      // fire-and-forget und router.back() feuerte sofort — der Hinweis stand
+      // dann über dem VORHERIGEN Screen bzw. verschwand mit dem Wechsel. Im
+      // Web zeigte Alert.alert ohnehin nichts an.
+      await alertDialog("Gespeichert", "Der Job wurde aktualisiert.");
+      leaveWithoutWarning(() => router.back());
     } catch (err: unknown) {
       const msg = toUserMessage(err, "Job konnte nicht gespeichert werden.");
 
@@ -331,45 +343,45 @@ export default function EditJobScreen() {
       // Fehlschlag/Rollback darstellen, im Formular bleiben (kein
       // router.back()) und NICHT automatisch erneut speichern.
       if (err instanceof PartialUpdateError) {
-        Alert.alert("Teilweise gespeichert", msg);
+        await alertDialog("Teilweise gespeichert", msg);
       } else {
-        Alert.alert("Fehler", msg);
+        await alertDialog("Fehler", msg);
       }
     } finally {
       setSubmitting(false);
     }
   };
 
-  // ── Löschen (unveränderte Logik)
+  // ── Löschen (Business-Logik unverändert)
+  // Dialoge laufen jetzt über confirmDialog/alertDialog statt Alert.alert:
+  // dieselbe Erfolgs-Reihenfolge wie beim Speichern (Hinweis abwarten, dann
+  // navigieren) und im Web überhaupt sichtbar.
   const handleDelete = async () => {
     if (!job) {
-      Alert.alert("Fehler", "Job wurde nicht gefunden.");
+      await alertDialog("Fehler", "Job wurde nicht gefunden.");
       return;
     }
 
-    Alert.alert("Job löschen", "Möchtest du diesen Job wirklich löschen?", [
-      { text: "Abbrechen", style: "cancel" },
-      {
-        text: "Löschen",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            setSubmitting(true);
-            await deleteJob(job.id);
-            Alert.alert("Erfolgreich", "Job wurde gelöscht.");
-            router.back();
-          } catch (err: unknown) {
-            const msg = toUserMessage(
-              err,
-              "Job konnte nicht gelöscht werden.",
-            );
-            Alert.alert("Fehler", msg);
-          } finally {
-            setSubmitting(false);
-          }
-        },
-      },
-    ]);
+    const confirmed = await confirmDialog({
+      title: "Job löschen",
+      message: "Möchtest du diesen Job wirklich löschen?",
+      confirmLabel: "Löschen",
+      destructive: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      setSubmitting(true);
+      await deleteJob(job.id);
+      await alertDialog("Gelöscht", "Der Job wurde gelöscht.");
+      leaveWithoutWarning(() => router.back());
+    } catch (err: unknown) {
+      const msg = toUserMessage(err, "Job konnte nicht gelöscht werden.");
+      await alertDialog("Fehler", msg);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   if (authLoading || loading) {

--- a/features/jobs/components/JobFormFields.tsx
+++ b/features/jobs/components/JobFormFields.tsx
@@ -73,8 +73,8 @@ export function JobFormFields({
       />
 
       <Input
-        label="Ort *"
-        placeholder="z.B. Dortmund"
+        label="Adresse *"
+        placeholder="z. B. Bahnhofstraße 12, 58507 Lüdenscheid"
         value={values.location}
         onChangeText={(val) => onChangeField("location", val)}
         error={errors.location}
@@ -121,10 +121,8 @@ export function JobFormFields({
             placeholder="Datum und Uhrzeit auswählen..."
             value={values.singleDateTime}
             onChange={(val) => onChangeField("singleDateTime", val)}
+            error={errors.singleDateTime}
           />
-          {errors.singleDateTime ? (
-            <Text style={styles.errorText}>{errors.singleDateTime}</Text>
-          ) : null}
         </View>
       ) : (
         /* ── Wiederkehrend: Wochentage + Uhrzeit + aktiv ── */
@@ -162,10 +160,8 @@ export function JobFormFields({
             mode="time"
             value={values.startTime}
             onChange={(val) => onChangeField("startTime", val)}
+            error={errors.startTime}
           />
-          {errors.startTime ? (
-            <Text style={styles.errorText}>{errors.startTime}</Text>
-          ) : null}
 
           <DateTimeField
             label="Startdatum *"
@@ -173,10 +169,8 @@ export function JobFormFields({
             mode="date"
             value={values.recurrenceStartDate}
             onChange={(val) => onChangeField("recurrenceStartDate", val)}
+            error={errors.recurrenceStartDate}
           />
-          {errors.recurrenceStartDate ? (
-            <Text style={styles.errorText}>{errors.recurrenceStartDate}</Text>
-          ) : null}
 
           <DateTimeField
             label="Enddatum (optional)"
@@ -184,10 +178,8 @@ export function JobFormFields({
             mode="date"
             value={values.recurrenceEndDate}
             onChange={(val) => onChangeField("recurrenceEndDate", val)}
+            error={errors.recurrenceEndDate}
           />
-          {errors.recurrenceEndDate ? (
-            <Text style={styles.errorText}>{errors.recurrenceEndDate}</Text>
-          ) : null}
 
           <View style={styles.activeRow}>
             <View style={styles.activeTextWrap}>
@@ -196,6 +188,9 @@ export function JobFormFields({
                 Inaktive Aufträge werden Mitarbeitern nicht angezeigt.
               </Text>
             </View>
+            {/* Thumb/Track explizit setzen: Android zeichnete den Thumb
+                sonst in seiner hellen Standardfarbe, die im Dark Mode auf dem
+                dunklen Track kaum zu unterscheiden war. Verhalten unverändert. */}
             <Switch
               value={values.isActive}
               onValueChange={(val) => onChangeField("isActive", val)}
@@ -203,6 +198,12 @@ export function JobFormFields({
                 false: theme.colors.outlineVariant,
                 true: theme.colors.primary,
               }}
+              thumbColor={
+                values.isActive
+                  ? theme.colors.onPrimaryContainer
+                  : theme.colors.surfaceContainerHighest
+              }
+              ios_backgroundColor={theme.colors.outlineVariant}
             />
           </View>
         </View>
@@ -210,7 +211,7 @@ export function JobFormFields({
 
       {showEmployeePicker ? (
         <>
-          <Text style={styles.sectionLabel}>Mitarbeiter</Text>
+          <Text style={styles.sectionLabel}>Mitarbeiter (optional)</Text>
           <EmployeeMultiSelector
             employees={employees}
             selectedEmployeeIds={values.employeeIds}
@@ -220,11 +221,12 @@ export function JobFormFields({
       ) : null}
 
       <Input
-        label="Notizen"
-        placeholder="Interne Hinweise (optional)"
+        label="Notizen (optional)"
+        placeholder="Interne Hinweise für dein Team"
         value={values.notes}
         onChangeText={(val) => onChangeField("notes", val)}
         multiline
+        numberOfLines={4}
       />
     </>
   );

--- a/features/jobs/hooks/useJobForm.ts
+++ b/features/jobs/hooks/useJobForm.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { JobType } from "@/types/job";
 import type { WeekdayKey } from "@/utils/recurrence";
 
@@ -50,6 +50,40 @@ export function useJobForm(initialValues?: Partial<JobFormValues>) {
 
     const [errors, setErrors] = useState<JobFormErrors>({});
 
+    // Ausgangsstand beim Mount — Basis für isDirty (Warnung vor dem Verlassen
+    // mit ungespeicherten Änderungen).
+    //
+    // NUR für das ERSTELLEN-Formular gedacht: der Bearbeiten-Screen befüllt die
+    // Werte nach dem Laden per setValues und hätte hier eine veraltete Basis.
+    // Er hat dafür eine eigene, job-bezogene hasChanges-Berechnung, die
+    // zusätzlich Datums-/Zeit-Normalisierung berücksichtigt.
+    const baselineRef = useRef<JobFormValues>({
+        ...emptyValues,
+        ...initialValues,
+    });
+
+    const isDirty = useMemo(() => {
+        const base = baselineRef.current;
+        return (
+            values.customerName !== base.customerName ||
+            values.location !== base.location ||
+            values.service !== base.service ||
+            values.notes !== base.notes ||
+            values.jobType !== base.jobType ||
+            values.isActive !== base.isActive ||
+            values.employeeIds.length !== base.employeeIds.length ||
+            values.employeeIds.some((id) => !base.employeeIds.includes(id)) ||
+            values.recurringDays.length !== base.recurringDays.length ||
+            values.recurringDays.some((d) => !base.recurringDays.includes(d)) ||
+            values.singleDateTime?.getTime() !== base.singleDateTime?.getTime() ||
+            values.startTime?.getTime() !== base.startTime?.getTime() ||
+            values.recurrenceStartDate?.getTime() !==
+                base.recurrenceStartDate?.getTime() ||
+            values.recurrenceEndDate?.getTime() !==
+                base.recurrenceEndDate?.getTime()
+        );
+    }, [values]);
+
     const setField = <K extends keyof JobFormValues>(
         field: K,
         value: JobFormValues[K]
@@ -68,31 +102,31 @@ export function useJobForm(initialValues?: Partial<JobFormValues>) {
         const nextErrors: JobFormErrors = {};
 
         if (!values.customerName.trim()) {
-            nextErrors.customerName = "Bitte Kundennamen eingeben.";
+            nextErrors.customerName = "Kunde ist erforderlich.";
         }
 
         if (!values.location.trim()) {
-            nextErrors.location = "Bitte Ort eingeben.";
+            nextErrors.location = "Adresse ist erforderlich.";
         }
 
         if (!values.service.trim()) {
-            nextErrors.service = "Bitte Service eingeben.";
+            nextErrors.service = "Service ist erforderlich.";
         }
 
         // ── Terminierung je nach Auftragstyp ──
         if (values.jobType === "single") {
             if (!values.singleDateTime) {
-                nextErrors.singleDateTime = "Bitte Datum und Uhrzeit wählen.";
+                nextErrors.singleDateTime = "Bitte wähle Datum und Uhrzeit.";
             }
         } else {
             if (values.recurringDays.length === 0) {
-                nextErrors.recurringDays = "Bitte mindestens einen Wochentag wählen.";
+                nextErrors.recurringDays = "Bitte wähle mindestens einen Wochentag.";
             }
             if (!values.startTime) {
-                nextErrors.startTime = "Bitte Uhrzeit wählen.";
+                nextErrors.startTime = "Bitte wähle eine Uhrzeit.";
             }
             if (!values.recurrenceStartDate) {
-                nextErrors.recurrenceStartDate = "Bitte Startdatum wählen.";
+                nextErrors.recurrenceStartDate = "Bitte wähle ein Startdatum.";
             }
             if (
                 values.recurrenceStartDate &&
@@ -110,11 +144,14 @@ export function useJobForm(initialValues?: Partial<JobFormValues>) {
     const reset = () => {
         setValues(emptyValues);
         setErrors({});
+        // Basis mitziehen, sonst gilt das frisch geleerte Formular als geändert.
+        baselineRef.current = emptyValues;
     };
 
     return {
         values,
         errors,
+        isDirty,
         setField,
         validate,
         reset,

--- a/hooks/useUnsavedChangesGuard.ts
+++ b/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,72 @@
+// hooks/useUnsavedChangesGuard.ts
+// ─────────────────────────────────────────────────────────────────
+// Warnt vor dem Verlassen eines Formulars mit ungespeicherten Änderungen.
+//
+// Deckt ALLE Wege aus dem Screen mit EINEM Mechanismus ab, weil
+// `usePreventRemove` (react-navigation, bereits über expo-router vorhanden —
+// keine neue Dependency) am Navigations-Dispatch ansetzt und nicht an einem
+// einzelnen Button:
+//   * eigener Zurück-Button im Header (er ruft router.back() → GO_BACK)
+//   * Android-Hardware-Zurück
+//   * iOS-Swipe-Back / natives Zurück (der Hook meldet den Zustand zusätzlich
+//     an den Navigator, damit die Geste selbst abgefangen wird)
+//
+// Kein Endlos-Loop beim erneuten Dispatch: react-navigation markiert die Action
+// intern mit den bereits besuchten Route-Keys (VISITED_ROUTE_KEYS in
+// useOnPreventRemove.js) und überspringt das beforeRemove-Event beim zweiten
+// Durchlauf. Das ist das offiziell dokumentierte Muster.
+//
+// Dialog läuft über confirmDialog (utils/dialogs) — Alert.alert ist im Web
+// eine leere Attrappe und würde den Nutzer dort aussperren.
+// ─────────────────────────────────────────────────────────────────
+
+import { confirmDialog } from "@/utils/dialogs";
+import { useNavigation, usePreventRemove } from "@react-navigation/native";
+import { useCallback, useRef } from "react";
+
+export const DISCARD_TITLE = "Änderungen verwerfen?";
+export const DISCARD_MESSAGE = "Nicht gespeicherte Änderungen gehen verloren.";
+export const DISCARD_CONFIRM = "Verwerfen";
+export const DISCARD_CANCEL = "Weiter bearbeiten";
+
+export function useUnsavedChangesGuard(hasUnsavedChanges: boolean) {
+  const navigation = useNavigation();
+  // Synchron umlegbar — im Gegensatz zu State wirkt der Ref sofort. Genau das
+  // braucht der Pfad „erfolgreich gespeichert → zurück": dort darf die Warnung
+  // nicht mehr kommen, obwohl hasUnsavedChanges im selben Tick noch true ist.
+  const bypassRef = useRef(false);
+
+  usePreventRemove(hasUnsavedChanges, ({ data }) => {
+    if (bypassRef.current) {
+      navigation.dispatch(data.action);
+      return;
+    }
+
+    void (async () => {
+      const discard = await confirmDialog({
+        title: DISCARD_TITLE,
+        message: DISCARD_MESSAGE,
+        confirmLabel: DISCARD_CONFIRM,
+        cancelLabel: DISCARD_CANCEL,
+        destructive: true,
+      });
+
+      // Bei „Weiter bearbeiten" passiert bewusst nichts: das beforeRemove-Event
+      // wurde bereits verhindert, der Nutzer bleibt im Formular.
+      if (discard) {
+        navigation.dispatch(data.action);
+      }
+    })();
+  });
+
+  /**
+   * Navigiert ohne Rückfrage — für Wege, bei denen die Änderungen gerade
+   * gespeichert (oder der Datensatz gelöscht) wurden.
+   */
+  const leaveWithoutWarning = useCallback((navigate: () => void) => {
+    bypassRef.current = true;
+    navigate();
+  }, []);
+
+  return { leaveWithoutWarning };
+}


### PR DESCRIPTION
UI/UX-Audit **Batch 2 — Forms & Validation**. JS/TS only, über Metro testbar. Keine neuen Dependencies, keine Backend-/Supabase-Änderung, kein Header-/Navigations-Redesign.

## 1 — Warnung bei ungespeicherten Änderungen

Neu: `hooks/useUnsavedChangesGuard.ts`, aufgebaut auf `usePreventRemove` aus `@react-navigation/native` (**bereits direkte Dependency**, wird u. a. in `JobDetailScreen` schon importiert).

Der Hook setzt am **Navigations-Dispatch** an, nicht an einem einzelnen Button — damit sind mit einem Mechanismus abgedeckt:
- eigener Zurück-Button im Header (ruft `router.back()` → `GO_BACK`)
- Android-Hardware-Zurück
- iOS-Swipe-Back / natives Zurück (der Hook meldet den Zustand zusätzlich an den Navigator, der die Geste selbst abfängt)

Kein Endlos-Loop beim erneuten Dispatch: react-navigation markiert die Action intern mit den bereits besuchten Route-Keys (`VISITED_ROUTE_KEYS` in `useOnPreventRemove.js`) und überspringt `beforeRemove` beim zweiten Durchlauf — das ist das offiziell dokumentierte Muster, im installierten Paket verifiziert.

Dialog läuft über `confirmDialog` (`utils/dialogs`), nicht `Alert.alert` — letzteres ist im Web eine leere Attrappe.

| Screen | Dirty-Quelle |
|---|---|
| Neuer Job | `isDirty` aus `useJobForm` (Vergleich gegen den Ausgangsstand beim Mount) |
| Job bearbeiten | vorhandene `hasChanges`-Berechnung — warnt exakt dann, wenn auch der Speichern-Button aktiv wäre |

**Ohne Änderung erscheint keine Warnung.** Nach erfolgreichem Speichern/Löschen navigiert `leaveWithoutWarning()` ohne Rückfrage (Ref, wirkt synchron).

## 2 — Feldklarheit

- Label `Ort *` → **`Adresse *`**, Platzhalter jetzt adressorientiert: `z. B. Bahnhofstraße 12, 58507 Lüdenscheid`
- **Nur die Anzeige** — Feldname `location`, DB-Spalte und Payload-Semantik sind unverändert
- Notizen sind sichtbar mehrzeilig: `Input` unterstützt jetzt `multiline` (minHeight 96, `textAlignVertical: top`). Tastaturverhalten unverändert

## 3 — Pflicht vs. optional (einheitlich)

Pflicht mit `*`: Kunde, Adresse, Service, Auftragstyp, Datum & Uhrzeit, Wochentage, Uhrzeit, Startdatum.
Optional explizit benannt: `Mitarbeiter (optional)`, `Notizen (optional)`, `Enddatum (optional)`.

Keine impliziten Optional-Felder mehr — jedes Feld trägt genau einen Marker.

## 4 — Validierung

Meldungen vereinheitlicht und weiterhin **direkt am jeweiligen Feld** (keine zusätzlichen globalen Alerts):

| Feld | Meldung |
|---|---|
| Kunde | Kunde ist erforderlich. |
| Adresse | Adresse ist erforderlich. |
| Service | Service ist erforderlich. |
| Datum & Uhrzeit | Bitte wähle Datum und Uhrzeit. |
| Wochentage | Bitte wähle mindestens einen Wochentag. |
| Uhrzeit | Bitte wähle eine Uhrzeit. |
| Startdatum | Bitte wähle ein Startdatum. |
| Enddatum | Das Enddatum darf nicht vor dem Startdatum liegen. |

**Die Regeln selbst sind unverändert.** Zur letzten Zeile: die vorgeschlagene Formulierung „muss **nach** dem Startdatum liegen" hätte die geltende Regel falsch beschrieben — geprüft wird `endDate < startDate`, ein **gleiches** Datum ist also erlaubt (eintägige Regel). Da die Business-Regeln erhalten bleiben sollten, ist die Meldung bei „nicht vor" geblieben. Wenn die Regel selbst strenger werden soll, gehört das in einen eigenen PR (betrifft auch die Serverseite).

## 5 — Gemeinsame Darstellung

- `DateTimeField` bekommt eine `error`-Prop und rendert den Fehler selbst → die **5 manuell nachgebauten Fehlerzeilen** in `JobFormFields` entfallen. Fehler steht bewusst außerhalb des positionierten Wrappers, sonst rutscht der absolut verankerte Löschen-Button auf die Fehlerzeile.
- Neuer Job nutzt den gemeinsamen `Button` statt eines `TouchableOpacity`-Nachbaus (inkl. Lade-Spinner); die drei toten Styles sind entfernt.
- Kein FormField-Wrapper eingeführt: `Input` und `DateTimeField` rendern Label + Fehler jetzt beide selbst, ein weiterer Wrapper hätte nichts mehr eingespart.

## 6 — Erfolgs-Reihenfolge

Vorher: `Alert.alert("Erfolgreich", …); router.back();` — fire-and-forget, `router.back()` feuerte sofort. Der Hinweis stand dann über dem *vorherigen* Screen oder verschwand mit dem Wechsel; im Web war er ohnehin unsichtbar.

Jetzt warten Erstellen, Speichern und Löschen den Hinweis über `alertDialog` ab und navigieren **danach**. Die Löschen-Bestätigung läuft über `confirmDialog` und funktioniert damit auch im Web (vorher hing das Löschen dort an einem `onPress`, der nie lief). Kein Toast-System eingeführt.

## 7 — Android-Switch

Der Recurring-Aktiv-Schalter setzt jetzt `thumbColor` und `ios_backgroundColor` explizit — Android zeichnete den Thumb sonst in seiner hellen Standardfarbe, die im Dark Mode auf dem dunklen Track kaum zu unterscheiden war. **Verhalten unverändert.**

## Nicht angetastet (verifiziert)

`git diff --name-only` enthält **keine** Dateien aus `services/`, `supabase/`, `context/`, `offline/` und berührt weder `jobAssignees` noch `jobSchedule`. Damit unverändert:
- Sperre gegen Speichern bei inaktiver Zuweisung (inkl. der harten Server-nahen Prüfung)
- `canRunJobActions` / `isPrimaryAssignee`
- Occurrence-Architektur und `buildSchedulePayload`
- Offline-Queue
- Date/Time-Picker-Plattformaufteilung
- Header/Navigation (Batch 3)

## Verifikation

- `npx tsc --noEmit` → sauber
- `npm run lint` → sauber (exit 0)
- 7 Dateien, +168/−109

**Noch nicht auf dem Gerät getestet** — Checkliste im Folgekommentar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)