### PR TITLE
fix(jobkarten): ein kanonisches Status-Vokabular + JobCard-Remount behoben

### DIFF
--- a/components/JobCard.tsx
+++ b/components/JobCard.tsx
@@ -4,9 +4,10 @@
 //
 // Design-Prinzip:
 // - Card ist Navigations-Tile zum DetailScreen — onPress macht ganze Karte tappable
-// - Nur die wichtigsten Felder sichtbar (Kunde, Service, Ort, Zeit)
+// - Nur die wichtigsten Felder sichtbar, in Feld-Lesereihenfolge:
+//   Kunde → Ort → Service → Zeit → Status → Aktion
 // - Mitarbeiter-Zeile nur wenn `showEmployeeName` gesetzt ist (i.d.R. nur Admin)
-// - Genau EINE kontextuelle Quick-Action: "Start" bei open, "Fertig" bei in_progress
+// - Genau EINE kontextuelle Quick-Action: "Start" bei open, "Abschließen" bei in_progress
 // - Notizen, Edit, ausführliche Felder → leben im DetailScreen
 //
 // Tap-Verhalten:
@@ -27,6 +28,13 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import type { AppTheme } from "@/constants/theme";
 import { confirmCompleteJob } from "@/utils/jobDialogs";
+import { getJobStatusMeta } from "@/utils/jobStatus";
+import {
+  formatDateISO,
+  formatDateOnlyDE,
+  formatTimeHHmm,
+  parseToDate,
+} from "@/utils/date";
 
 type Props = {
   job: Job;
@@ -39,7 +47,7 @@ type Props = {
    */
   onStart?: () => void | Promise<void>;
   /**
-   * Inline-Quick-Action "Fertig" — wird nur gezeigt, wenn übergeben UND job.status === "in_progress".
+   * Inline-Quick-Action "Abschließen" — wird nur gezeigt, wenn übergeben UND job.status === "in_progress".
    * Darf ein Promise zurückgeben; die Karte sperrt dann bis zum Abschluss.
    */
   onComplete?: () => void | Promise<void>;
@@ -63,66 +71,24 @@ type Props = {
 // ─────────────────────────────────────────────
 // Zeit-Formatierung
 // ─────────────────────────────────────────────
-function formatTime(iso?: string | null): string | null {
-  if (!iso) return null;
-  const date = new Date(iso);
-  if (isNaN(date.getTime())) return null;
-  return date.toLocaleTimeString("de-DE", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+// Die Karte hatte hier drei eigene Formatter (formatTime/formatDate/
+// formatDateOnly), die dasselbe taten wie utils/date.ts. Jetzt werden die
+// zentralen Helfer genutzt — gleiche Ausgabe, gleiche lokale Datums-Semantik,
+// aber ein Ort für Änderungen. `formatDateOnlyDE` erwartet "YYYY-MM-DD"
+// (zeitzonenfrei); ein ISO-Zeitstempel wird vorher lokal auf einen
+// Kalendertag reduziert.
+function formatIsoDateDE(iso?: string | null): string | null {
+  return formatDateOnlyDE(formatDateISO(parseToDate(iso)));
 }
 
-function formatDate(iso?: string | null): string | null {
-  if (!iso) return null;
-  const date = new Date(iso);
-  if (isNaN(date.getTime())) return null;
-  return date.toLocaleDateString("de-DE", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
-
-// Formatiert "YYYY-MM-DD" → "dd.mm.yyyy" (ohne Zeitzonen-Verschiebung).
-function formatDateOnly(value?: string | null): string | null {
-  if (!value) return null;
-  const [y, m, d] = value.slice(0, 10).split("-");
-  if (!y || !m || !d) return null;
-  return `${d}.${m}.${y}`;
+function formatIsoTimeDE(iso?: string | null): string | null {
+  return formatTimeHHmm(parseToDate(iso));
 }
 
 // Ist dieser Job eine Parent-Recurring-Regel (keine konkrete Ausführung)?
 // Parent = job_type 'recurring' ohne parentJobId — nur Vorlage, kein startbarer Termin.
 function isParentRecurringJob(job: Job): boolean {
   return job.jobType === "recurring" && !job.parentJobId;
-}
-
-// ── Status-Farben aus Theme (jeder Status hat sein Farbtripel)
-function getStatusConfig(theme: AppTheme, status: Job["status"]) {
-  switch (status) {
-    case "open":
-      return {
-        label: "Offen",
-        textColor: theme.colors.statusOpen,
-        bgColor: theme.colors.statusOpenBg,
-        borderColor: theme.colors.statusOpenBorder,
-      };
-    case "in_progress":
-      return {
-        label: "In Arbeit",
-        textColor: theme.colors.statusInProgress,
-        bgColor: theme.colors.statusInProgressBg,
-        borderColor: theme.colors.statusInProgressBorder,
-      };
-    case "completed":
-      return {
-        label: "Erledigt",
-        textColor: theme.colors.statusCompleted,
-        bgColor: theme.colors.statusCompletedBg,
-        borderColor: theme.colors.statusCompletedBorder,
-      };
-  }
 }
 
 export default function JobCard({
@@ -136,7 +102,8 @@ export default function JobCard({
 }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const status = getStatusConfig(theme, job.status);
+  // Beschriftung + Farben zentral — dieselbe Quelle wie StatusBadge im Detail.
+  const status = getJobStatusMeta(job.status, theme.colors);
 
   // Doppel-Tap-Schutz für die Quick-Actions. Der Ref sperrt SYNCHRON (setBusy
   // wirkt erst beim nächsten Render, zwei schnelle Taps kämen sonst beide
@@ -179,8 +146,8 @@ export default function JobCard({
     const days = getRecurringDaysLabel(job);
     scheduleText = startTime ? `${days} · ${startTime} Uhr` : days;
   } else {
-    const date = formatDateOnly(job.date) ?? formatDate(job.scheduledStart);
-    const endTime = formatTime(job.scheduledEnd);
+    const date = formatDateOnlyDE(job.date) ?? formatIsoDateDE(job.scheduledStart);
+    const endTime = formatIsoTimeDE(job.scheduledEnd);
     if (date && startTime && endTime) {
       scheduleText = `${date} · ${startTime} – ${endTime} Uhr`;
     } else if (date && startTime) {
@@ -200,8 +167,11 @@ export default function JobCard({
     if (job.status === "open") hints.push("Noch nicht gestartet");
   }
 
-  // Service · Ort (kompakte Einzeiler-Subline)
-  const subline = [job.service, job.location].filter(Boolean).join(" · ");
+  // Ort · Service (kompakte Einzeiler-Subline).
+  // Ort steht ZUERST: im Feld ist „wohin muss ich?" die Frage direkt nach
+  // „zu wem?" — der Service beantwortet erst danach „was mache ich dort?".
+  // Bewusst weiterhin EINE Zeile statt zwei: die Karte soll nicht wachsen.
+  const subline = [job.location, job.service].filter(Boolean).join(" · ");
 
   // Quick-Action — exakt EINE, abhängig von Status (oder gar keine).
   // Bei Parent-Recurring-Regeln grundsätzlich keine Quick-Actions.
@@ -221,31 +191,28 @@ export default function JobCard({
   // Footer wird nur gerendert, wenn Mitarbeiter ODER Action vorhanden
   const hasFooter = !!employeeText || showStartAction || showCompleteAction;
 
-  // ── Root: TouchableOpacity wenn navigierbar, sonst stiller View
-  const CardRoot: React.ComponentType<{
-    style: any;
-    children: React.ReactNode;
-  }> = onPress
-    ? (props) => (
-        <TouchableOpacity
-          activeOpacity={0.85}
-          onPress={onPress}
-          {...props}
-        />
-      )
-    : (props) => <View {...props} />;
+  // ── Root-Style: farbige Statuskante links
+  const cardStyle = [
+    styles.card,
+    {
+      borderColor: status.border,
+      borderLeftColor: status.border,
+      borderLeftWidth: 4,
+    },
+  ];
 
-  return (
-    <CardRoot
-      style={[
-        styles.card,
-        {
-          borderColor: status.borderColor,
-          borderLeftColor: status.borderColor,
-          borderLeftWidth: 4,
-        },
-      ]}
-    >
+  // Inhalt einmal bauen und je nach Navigierbarkeit in TouchableOpacity oder
+  // View hängen.
+  //
+  // Vorher stand hier eine im Render definierte Komponente (`const CardRoot =
+  // onPress ? (props) => <TouchableOpacity …/> : …`). Deren Identität war bei
+  // JEDEM Render neu → React sah einen anderen Komponententyp, unmountete den
+  // kompletten Karten-Teilbaum und baute ihn neu auf. Praktische Folge: der
+  // lokale busy-State überlebte zwar (er sitzt im JobCard selbst), aber jeder
+  // Render der Liste warf Press-States und Layout der Karte weg. Zwei feste
+  // Zweige haben stabile Typen — kein Remount, identisches Verhalten.
+  const content = (
+    <>
       {/* ── Header: Kunde + Status + Chevron ── */}
       <View style={styles.header}>
         <Text style={styles.customerName} numberOfLines={1}>
@@ -276,12 +243,12 @@ export default function JobCard({
               style={[
                 styles.statusBadge,
                 {
-                  backgroundColor: status.bgColor,
-                  borderColor: status.borderColor,
+                  backgroundColor: status.bg,
+                  borderColor: status.border,
                 },
               ]}
             >
-              <Text style={[styles.statusText, { color: status.textColor }]}>
+              <Text style={[styles.statusText, { color: status.text }]}>
                 {status.label}
               </Text>
             </View>
@@ -412,13 +379,27 @@ export default function JobCard({
                 size={14}
                 color={theme.colors.statusCompleted}
               />
-              <Text style={styles.quickActionSuccessText}>Fertig</Text>
+              {/* Verb, nicht Status: „Fertig" stand hier direkt neben dem
+                  Status-Badge „Erledigt" und las sich wie ein zweites,
+                  abweichendes Statuswort. „Abschließen" ist derselbe Wortlaut
+                  wie im Detail-Footer und im Bestätigungsdialog. */}
+              <Text style={styles.quickActionSuccessText}>Abschließen</Text>
             </TouchableOpacity>
           ) : null}
         </View>
       ) : null}
-    </CardRoot>
+    </>
   );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity style={cardStyle} activeOpacity={0.85} onPress={onPress}>
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return <View style={cardStyle}>{content}</View>;
 }
 
 function createStyles(theme: AppTheme) {
@@ -600,7 +581,7 @@ function createStyles(theme: AppTheme) {
       color: theme.colors.onPrimaryContainer,
     },
 
-    // Quick-Action "Fertig" (success-Outline)
+    // Quick-Action "Abschließen" (success-Outline)
     quickActionSuccess: {
       flexDirection: "row",
       alignItems: "center",

--- a/components/ui/StatusBadge.tsx
+++ b/components/ui/StatusBadge.tsx
@@ -2,73 +2,43 @@
 // ─────────────────────────────────────────────────────────────────
 // Job-Status-Badge mit farbigem Dot-Indikator.
 // Unterstützt alle drei Job-Status (open, in_progress, completed).
-// Lesbarer und semantisch korrekter als die generische Badge-Komponente.
+//
+// Beschriftung UND Farben kommen aus `utils/jobStatus.ts` — der einzigen
+// Quelle für Job-Status-Darstellung (siehe dortigen Kopfkommentar).
+// Die frühere `labels`-Prop (custom Beschriftungen) ist entfallen: sie war der
+// Weg, über den die Arbeitszeit-Karte „Abgeschlossen" statt „Erledigt" zeigte.
+// Wer den Wortlaut ändern will, ändert ihn in JOB_STATUS_LABELS — für alle.
 // ─────────────────────────────────────────────────────────────────
 
 import { useAppTheme } from "@/hooks/useAppTheme";
 import React, { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import type { ColorPalette } from "@/constants/colors";
+import { getJobStatusMeta, type JobStatusMeta } from "@/utils/jobStatus";
+import type { JobStatus } from "@/types/job";
 
-export type JobStatus = "open" | "in_progress" | "completed";
+export type { JobStatus };
 
 interface StatusBadgeProps {
   status: JobStatus;
-  /** Optionale custom Labels (Standard: Deutsch) */
-  labels?: { open?: string; in_progress?: string; completed?: string };
 }
 
-const DEFAULT_LABELS = {
-  open:        "Offen",
-  in_progress: "In Arbeit",
-  completed:   "Erledigt",
-};
-
-function getStatusColors(status: JobStatus, colors: ColorPalette) {
-  switch (status) {
-    case "open":
-      return {
-        text:   colors.statusOpen,
-        bg:     colors.statusOpenBg,
-        border: colors.statusOpenBorder,
-        dot:    colors.statusOpen,
-      };
-    case "in_progress":
-      return {
-        text:   colors.statusInProgress,
-        bg:     colors.statusInProgressBg,
-        border: colors.statusInProgressBorder,
-        dot:    colors.statusInProgress,
-      };
-    case "completed":
-      return {
-        text:   colors.statusCompleted,
-        bg:     colors.statusCompletedBg,
-        border: colors.statusCompletedBorder,
-        dot:    colors.statusCompleted,
-      };
-  }
-}
-
-export function StatusBadge({ status, labels }: StatusBadgeProps) {
+export function StatusBadge({ status }: StatusBadgeProps) {
   const theme = useAppTheme();
-  const statusColors = useMemo(
-    () => getStatusColors(status, theme.colors),
-    [status, theme.colors]
+  const meta = useMemo(
+    () => getJobStatusMeta(status, theme.colors),
+    [status, theme.colors],
   );
-  const styles = useMemo(() => createStyles(statusColors), [statusColors]);
-
-  const label = { ...DEFAULT_LABELS, ...labels }[status];
+  const styles = useMemo(() => createStyles(meta), [meta]);
 
   return (
     <View style={styles.badge}>
       <View style={styles.dot} />
-      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.label}>{meta.label}</Text>
     </View>
   );
 }
 
-function createStyles(statusColors: ReturnType<typeof getStatusColors>) {
+function createStyles(meta: JobStatusMeta) {
   return StyleSheet.create({
     badge: {
       flexDirection: "row",
@@ -77,21 +47,21 @@ function createStyles(statusColors: ReturnType<typeof getStatusColors>) {
       paddingHorizontal: 10,
       paddingVertical: 5,
       borderRadius: 9999,
-      backgroundColor: statusColors.bg,
+      backgroundColor: meta.bg,
       borderWidth: 1,
-      borderColor: statusColors.border,
+      borderColor: meta.border,
       alignSelf: "flex-start",
     },
     dot: {
       width: 6,
       height: 6,
       borderRadius: 9999,
-      backgroundColor: statusColors.dot,
+      backgroundColor: meta.text,
     },
     label: {
       fontSize: 12,
       fontWeight: "600" as const,
-      color: statusColors.text,
+      color: meta.text,
       letterSpacing: 0.3,
     },
   });

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/services/jobs/jobs.service";
 import { formatDateISO } from "@/utils/date";
 import { isAssignedTo } from "@/utils/jobAssignees";
+import { getJobStatusLabel } from "@/utils/jobStatus";
 import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
@@ -279,7 +280,7 @@ export default function AdminDashboardScreen() {
         </View>
         <View style={styles.kpiItem}>
           <KPICard
-            label="Offen"
+            label={getJobStatusLabel("open")}
             value={openCount ?? "—"}
             icon="folder-open-outline"
             accentColor={theme.colors.statusOpen}
@@ -288,7 +289,7 @@ export default function AdminDashboardScreen() {
         </View>
         <View style={styles.kpiItem}>
           <KPICard
-            label="In Arbeit"
+            label={getJobStatusLabel("in_progress")}
             value={inProgressCount ?? "—"}
             icon="time-outline"
             accentColor={theme.colors.statusInProgress}
@@ -297,7 +298,7 @@ export default function AdminDashboardScreen() {
         </View>
         <View style={styles.kpiItem}>
           <KPICard
-            label="Erledigt"
+            label={getJobStatusLabel("completed")}
             value={completedCount ?? "—"}
             icon="checkmark-done-outline"
             accentColor={theme.colors.statusCompleted}

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -26,6 +26,7 @@ import type { Job, JobStatus } from "@/types/job";
 import { formatForDisplay } from "@/utils/date";
 import { getEmployeeStatus } from "@/utils/employeeStatus";
 import { isAssignedTo } from "@/utils/jobAssignees";
+import { getJobStatusLabel } from "@/utils/jobStatus";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useMemo, useState } from "react";
@@ -343,7 +344,7 @@ export default function EmployeeDetailScreen() {
             </View>
             <View style={styles.kpiItem}>
               <KPICard
-                label="Offen"
+                label={getJobStatusLabel("open")}
                 value={openCount}
                 icon="folder-open-outline"
                 accentColor={theme.colors.statusOpen}
@@ -351,7 +352,7 @@ export default function EmployeeDetailScreen() {
             </View>
             <View style={styles.kpiItem}>
               <KPICard
-                label="In Arbeit"
+                label={getJobStatusLabel("in_progress")}
                 value={inProgressCount}
                 icon="time-outline"
                 accentColor={theme.colors.statusInProgress}
@@ -359,7 +360,7 @@ export default function EmployeeDetailScreen() {
             </View>
             <View style={styles.kpiItem}>
               <KPICard
-                label="Erledigt"
+                label={getJobStatusLabel("completed")}
                 value={completedCount}
                 icon="checkmark-circle-outline"
                 accentColor={theme.colors.statusCompleted}

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -25,6 +25,7 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import type { Job, JobStatus } from "@/types/job";
 import { isJobToday } from "@/utils/jobSchedule";
+import { getJobStatusLabel, JOB_STATUS_ORDER } from "@/utils/jobStatus";
 import { confirmCompleteJob } from "@/utils/jobDialogs";
 import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
@@ -34,11 +35,11 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 type Filter = "all" | JobStatus;
 
+// Beschriftungen aus der kanonischen Status-Quelle — identisch zu den Badges
+// auf den Karten darunter und zu den Chips im Jobs-Tab (utils/jobStatus.ts).
 const FILTERS: { key: Filter; label: string }[] = [
   { key: "all", label: "Alle" },
-  { key: "open", label: "Offen" },
-  { key: "in_progress", label: "In Arbeit" },
-  { key: "completed", label: "Erledigt" },
+  ...JOB_STATUS_ORDER.map((key) => ({ key, label: getJobStatusLabel(key) })),
 ];
 
 // Sortier-Priorität für "Heute anstehend": offen zuerst, dann in Arbeit, dann erledigt
@@ -316,7 +317,7 @@ export default function EmployeeOverviewScreen() {
           </View>
           <View style={styles.kpiItem}>
             <KPICard
-              label="Offen"
+              label={getJobStatusLabel("open")}
               value={todayOpen}
               icon="folder-open-outline"
               accentColor={theme.colors.statusOpen}
@@ -325,7 +326,7 @@ export default function EmployeeOverviewScreen() {
           </View>
           <View style={styles.kpiItem}>
             <KPICard
-              label="In Arbeit"
+              label={getJobStatusLabel("in_progress")}
               value={todayInProgress}
               icon="time-outline"
               accentColor={theme.colors.statusInProgress}
@@ -334,7 +335,7 @@ export default function EmployeeOverviewScreen() {
           </View>
           <View style={styles.kpiItem}>
             <KPICard
-              label="Erledigt"
+              label={getJobStatusLabel("completed")}
               value={todayCompleted}
               icon="checkmark-done-outline"
               accentColor={theme.colors.statusCompleted}
@@ -360,9 +361,15 @@ export default function EmployeeOverviewScreen() {
               style={styles.activeNavArea}
             >
               <View style={styles.activeTopRow}>
+                {/* Derselbe Status wie das in_progress-Badge auf den Karten —
+                    also auch derselbe Wortlaut. „Läuft" war ein viertes Wort
+                    für denselben Zustand; der Puls-Punkt trägt das „jetzt
+                    gerade" ohnehin. */}
                 <View style={styles.activeBadge}>
                   <View style={styles.activePulse} />
-                  <Text style={styles.activeBadgeText}>Läuft</Text>
+                  <Text style={styles.activeBadgeText}>
+                    {getJobStatusLabel("in_progress")}
+                  </Text>
                 </View>
                 <Ionicons
                   name="chevron-forward"
@@ -496,7 +503,7 @@ export default function EmployeeOverviewScreen() {
         <View style={styles.kpiGrid}>
           <View style={styles.kpiItem}>
             <KPICard
-              label="Erledigt"
+              label={getJobStatusLabel("completed")}
               value={monthCompleted}
               icon="checkmark-done-outline"
               accentColor={theme.colors.statusCompleted}
@@ -505,7 +512,7 @@ export default function EmployeeOverviewScreen() {
           </View>
           <View style={styles.kpiItem}>
             <KPICard
-              label="In Arbeit"
+              label={getJobStatusLabel("in_progress")}
               value={monthInProgress}
               icon="time-outline"
               accentColor={theme.colors.statusInProgress}
@@ -514,7 +521,7 @@ export default function EmployeeOverviewScreen() {
           </View>
           <View style={styles.kpiItem}>
             <KPICard
-              label="Offen"
+              label={getJobStatusLabel("open")}
               value={monthOpen}
               icon="folder-open-outline"
               accentColor={theme.colors.statusOpen}

--- a/features/jobs/JobsListScreen.tsx
+++ b/features/jobs/JobsListScreen.tsx
@@ -16,6 +16,7 @@ import {
   getAssigneeNames,
   isAssignedTo,
 } from "@/utils/jobAssignees";
+import { getJobStatusLabel, JOB_STATUS_ORDER } from "@/utils/jobStatus";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
@@ -37,11 +38,11 @@ import type { AppTheme } from "@/constants/theme";
 
 type Filter = "all" | "open" | "in_progress" | "completed";
 
+// Beschriftungen aus der kanonischen Status-Quelle — die Chips müssen exakt so
+// heißen wie die Badges auf den Karten darunter (utils/jobStatus.ts).
 const FILTERS: { key: Filter; label: string }[] = [
   { key: "all", label: "Alle" },
-  { key: "open", label: "Offen" },
-  { key: "in_progress", label: "In Arbeit" },
-  { key: "completed", label: "Erledigt" },
+  ...JOB_STATUS_ORDER.map((key) => ({ key, label: getJobStatusLabel(key) })),
 ];
 
 // ── Sortier-Optionen

--- a/features/jobs/components/WorkedTimeCard.tsx
+++ b/features/jobs/components/WorkedTimeCard.tsx
@@ -139,10 +139,11 @@ export function WorkedTimeCard({ job }: Props) {
           </View>
           <Text style={styles.headerTitle}>Arbeitszeit</Text>
         </View>
-        <StatusBadge
-          status={isRunning ? "in_progress" : "completed"}
-          labels={{ in_progress: "In Arbeit", completed: "Abgeschlossen" }}
-        />
+        {/* Kanonischer Wortlaut (Offen/In Arbeit/Erledigt). Die frühere
+            labels-Prop beschriftete `completed` hier als „Abgeschlossen" —
+            direkt über der Spalte „ERLEDIGT" und abweichend von jeder
+            Job-Karte. Siehe utils/jobStatus.ts. */}
+        <StatusBadge status={isRunning ? "in_progress" : "completed"} />
       </View>
 
       <View style={styles.divider} />

--- a/utils/jobStatus.ts
+++ b/utils/jobStatus.ts
@@ -1,0 +1,85 @@
+// utils/jobStatus.ts
+// ─────────────────────────────────────────────────────────────────
+// EINE kanonische Darstellung für den Job-Status (Wortlaut + Farbtripel).
+//
+// Warum zentral: Wortlaut und Farben lagen doppelt in `components/JobCard.tsx`
+// (getStatusConfig) und `components/ui/StatusBadge.tsx` (DEFAULT_LABELS +
+// getStatusColors), dazu ein drittes und viertes Mal als Filter-Chip- und
+// KPI-Beschriftungen in den Screens. Jede Kopie konnte eigenständig
+// abdriften — genau das war passiert (die Arbeitszeit-Karte beschriftete
+// `completed` als „Abgeschlossen", während direkt darunter „ERLEDIGT" stand).
+//
+// KANONISCHES VOKABULAR (Stand dieses PRs):
+//   open        → „Offen"
+//   in_progress → „In Arbeit"
+//   completed   → „Erledigt"
+//
+// „In Arbeit" (statt „In Bearbeitung") ist bewusst gewählt: es ist der Wortlaut,
+// den bereits ALLE Live-Flächen verwendeten (Karten, Badges, Filter, KPIs), es
+// ist kürzer und bricht damit in schmalen Chips/KPI-Kacheln nicht um.
+// „In Bearbeitung"/„Abgeschlossen" standen nur in `i18n/translations.ts`, das
+// ausschließlich vom nicht gerouteten HomeScreen benutzt wird.
+// Eine spätere Umbenennung ist jetzt eine Ein-Zeilen-Änderung an JOB_STATUS_LABELS.
+//
+// Bewusst KEINE React-/Theme-Imports: die Farbpalette kommt als Parameter
+// herein (`useAppTheme().colors`), damit die Datei rein und testbar bleibt.
+// ─────────────────────────────────────────────────────────────────
+
+import type { ColorPalette } from "@/constants/colors";
+import type { JobStatus } from "@/types/job";
+
+/** Kanonische deutsche Beschriftung je Job-Status. */
+export const JOB_STATUS_LABELS: Record<JobStatus, string> = {
+  open: "Offen",
+  in_progress: "In Arbeit",
+  completed: "Erledigt",
+};
+
+/** Reihenfolge für Status-Sortierung/Filterleisten: offen → in Arbeit → erledigt. */
+export const JOB_STATUS_ORDER: JobStatus[] = ["open", "in_progress", "completed"];
+
+/** Kanonische Beschriftung eines Status (für Chips, KPIs, Fließtext). */
+export function getJobStatusLabel(status: JobStatus): string {
+  return JOB_STATUS_LABELS[status];
+}
+
+export type JobStatusMeta = {
+  label: string;
+  /** Textfarbe (auch für Dot/Icon in derselben Semantik). */
+  text: string;
+  bg: string;
+  border: string;
+};
+
+/**
+ * Beschriftung + Farbtripel eines Status aus der aktuellen Palette.
+ * Light/Dark kommen automatisch mit, weil die Palette vom Theme stammt.
+ */
+export function getJobStatusMeta(
+  status: JobStatus,
+  colors: ColorPalette,
+): JobStatusMeta {
+  switch (status) {
+    case "open":
+      return {
+        label: JOB_STATUS_LABELS.open,
+        text: colors.statusOpen,
+        bg: colors.statusOpenBg,
+        border: colors.statusOpenBorder,
+      };
+    case "in_progress":
+      return {
+        label: JOB_STATUS_LABELS.in_progress,
+        text: colors.statusInProgress,
+        bg: colors.statusInProgressBg,
+        border: colors.statusInProgressBorder,
+      };
+    case "completed":
+      return {
+        label: JOB_STATUS_LABELS.completed,
+        text: colors.statusCompleted,
+        bg: colors.statusCompletedBg,
+        border: colors.statusCompletedBorder,
+      };
+  }
+}


### PR DESCRIPTION
Batch 4 des UI/UX-Audits: **Job-Karten & Status-Konsistenz**. JS/TS only, kein Build noetig, keine Backend-/Schema-Aenderung.

## Ausgangslage (Inventar)

**Live JobCard-Nutzer:** `EmployeeOverviewScreen`, `JobsListScreen` (Employee + Admin), `EmployeeJobsCalendarScreen`, `AdminScheduleScreen`, `EmployeeDetailScreen`.
**Live StatusBadge-Nutzer:** `JobStatusOverview` (Job-Detail), `OccurrenceRow` (Regel-Detail), `WorkedTimeCard` (Job-Detail).
**Tot (nicht geroutet, bewusst nicht angefasst):** `features/home/HomeScreen.tsx` + `HomeStats`/`HomeHeader`, `i18n/translations.ts`.

Status-Darstellung lag **vierfach** vor:
1. `JobCard.getStatusConfig` — Label + Farbtripel
2. `StatusBadge.DEFAULT_LABELS` + `getStatusColors` — dieselben Labels, dieselben Farben
3. Filter-Chips in `JobsListScreen` und `EmployeeOverviewScreen`
4. KPI-Beschriftungen in Overview / Admin-Dashboard / Employee-Detail

## Kanonisches Vokabular

| Status | Label |
|---|---|
| `open` | **Offen** |
| `in_progress` | **In Arbeit** |
| `completed` | **Erledigt** |

Der Audit-Auftrag praeferierte `In Bearbeitung`, liess aber die aktuelle Business-Copy vorgehen — und die spricht klar fuer **`In Arbeit`**: es war bereits der Wortlaut auf **jeder** Live-Flaeche (Karten, Badges, Filter, KPIs). `In Bearbeitung`/`Abgeschlossen` standen ausschliesslich in `i18n/translations.ts`, das nur der nicht geroutete `HomeScreen` benutzt. `In Arbeit` ist zudem kuerzer und bricht in schmalen Chips/KPI-Kacheln nicht um. Die Umbenennung ist jetzt eine Ein-Zeilen-Aenderung an `JOB_STATUS_LABELS` — bei Bedarf gern in einem Folge-Commit.

## Neuer Shared Helper

`utils/jobStatus.ts` (rein, ohne React-Import, Palette als Parameter):
- `JOB_STATUS_LABELS`, `getJobStatusLabel(status)`
- `getJobStatusMeta(status, colors)` → `{ label, text, bg, border }`
- `JOB_STATUS_ORDER`

`StatusBadge` und `JobCard` konsumieren ihn; die `labels`-Prop des `StatusBadge` ist entfallen (sie war der Weg, ueber den die Abweichung entstand).

## Behobene Abweichungen

- **Arbeitszeit-Karte** zeigte Badge `Abgeschlossen` direkt ueber der Spalte `ERLEDIGT` → jetzt `Erledigt`.
- **Quick-Action** hiess `Fertig` unmittelbar neben dem Badge `Erledigt` — zwei Woerter fuer scheinbar denselben Zustand. Jetzt `Abschliessen`, identisch zu Detail-Footer (`Job abschliessen`) und Bestaetigungsdialog (`Abschliessen`).
- **Aktiver-Job-Karte** (Employee-Uebersicht) zeigte `Laeuft` fuer `in_progress` → jetzt `In Arbeit`; der Puls-Punkt traegt das „jetzt gerade" weiterhin.

## JobCard-Remount (bestaetigt + behoben)

`CardRoot` war eine **im Render definierte Komponente**:
```ts
const CardRoot: React.ComponentType<…> = onPress ? (props) => <TouchableOpacity …/> : (props) => <View {...props}/>;
```
Die Typ-Identitaet war bei jedem Render neu → React unmountete den kompletten Karten-Teilbaum und baute ihn neu auf (Press-States und Layout gingen bei jedem Listen-Render verloren). Ersetzt durch ein gemeinsames `content`-Element und zwei feste Return-Zweige. Kein weiteres Memoization-Refactoring — bewusst.

## Hierarchie & Datum/Zeit

- Subline der Karte jetzt **`Ort - Service`** statt `Service - Ort` (Ort zuerst; weiterhin **eine** Zeile, keine zusaetzliche Kartenhoehe).
- `JobCard` nutzt `utils/date.ts` (`formatDateOnlyDE`/`formatTimeHHmm`/`formatDateISO`/`parseToDate`) statt drei eigener Formatter. **Identische Ausgabe**, unveraenderte lokale Datums-/Zeitzonen-Semantik.

## Unveraendert (bewusst)

Gating (`canRunJobActions`, `isPrimaryAssignee`), Bestaetigungsflow aus Batch 1, Context-Routing der Aktionen, Offline-Queue, Realtime, DB-Statuswerte, ErrorBanner/Pull-to-Refresh/OfflineBanner aus Batch 5. Abgeschlossene Jobs zeigen weiterhin keine Aktion (Status-Gate war bereits korrekt). Busy-Handling (synchroner `busyRef` + sichtbares Dimmen, kein Layout-Sprung) unveraendert.

## Verbleibende Treffer alternativer Copy

| Fundstelle | Einordnung |
|---|---|
| `i18n/translations.ts` (`In Bearbeitung`, `Abgeschlossen`, `Fertig`) | **Tot** — nur `HomeScreen` (nicht geroutet). Copy-Cleanup spaeter. |
| `features/home/components/HomeStats.tsx` | **Tot** — nur `HomeScreen`. |
| `WorkedTimeCard`: `Laeuft…` | **Absichtlich** — Platzhalter fuer die noch laufende Endzeit, kein Status-Badge. |
| `utils/scheduleView.ts`: Filter `Erledigt` | **Absichtlich** — Zeitplan-Filter, deckt sich mit dem kanonischen Wort. |
| `app/(admin-tabs)/employees.tsx`: `Eingeladen` | **Absichtlich** — Mitarbeiter-Status, kein Job-Status. |
| `Laeuft` in Kommentaren/Hooks | **Absichtlich** — Prosa, keine UI-Copy. |

## Checks

- `npx tsc --noEmit` — sauber
- `npm run lint` — sauber
- Kein JS-Testsuite im Repo (nur `supabase/tests/*.sql`, von diesem PR nicht beruehrt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)