### PR TITLE
fix(mitarbeiter): keine versteckten Aufträge, eigene Arbeitszeit erreichbar

### DIFF
--- a/app/(employee-tabs)/_layout.tsx
+++ b/app/(employee-tabs)/_layout.tsx
@@ -67,7 +67,9 @@ export default function EmployeeTabsLayout() {
       <Tabs.Screen
         name="profile"
         options={{
-          title: "Profile",
+          // Deutsch wie der Rest der App ("Übersicht", "Jobs") — "Profile" war
+          // das einzige englische Tab-Label.
+          title: "Profil",
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="person-outline" size={size} color={color} />
           ),

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -22,6 +22,7 @@ import { useAuth } from "@/context/AuthContext";
 import { canRunJobActions } from "@/utils/jobAssignees";
 import { useJobs } from "@/context/JobContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { useJobWorkedTime } from "@/hooks/useJobWorkedTime";
 import type { AppTheme } from "@/constants/theme";
 import type { Job, JobStatus } from "@/types/job";
 import { isJobToday } from "@/utils/jobSchedule";
@@ -41,6 +42,25 @@ const FILTERS: { key: Filter; label: string }[] = [
   { key: "all", label: "Alle" },
   ...JOB_STATUS_ORDER.map((key) => ({ key, label: getJobStatusLabel(key) })),
 ];
+
+// Wie viele Aufträge die Übersicht als Vorschau zeigt. Alles darüber bleibt
+// erreichbar — siehe "Alle … Aufträge anzeigen" unter der Liste.
+const UPCOMING_PREVIEW_COUNT = 5;
+
+// Platzhalter für useJobWorkedTime, wenn gerade kein Job läuft (siehe unten).
+const NO_ACTIVE_JOB_TIME = {
+  status: "open",
+  startedAt: null,
+  completedAt: null,
+} satisfies Pick<Job, "status" | "startedAt" | "completedAt">;
+
+// Filter-Key → Label, für den Leer-Zustand ("keine Aufträge mit Status X").
+const FILTER_LABEL_BY_KEY: Record<Filter, string> = {
+  all: "Alle",
+  open: getJobStatusLabel("open"),
+  in_progress: getJobStatusLabel("in_progress"),
+  completed: getJobStatusLabel("completed"),
+};
 
 // Sortier-Priorität für "Heute anstehend": offen zuerst, dann in Arbeit, dann erledigt
 const STATUS_ORDER: Record<JobStatus, number> = {
@@ -225,16 +245,40 @@ export default function EmployeeOverviewScreen() {
     [jobs, role, profile?.id],
   );
 
-  // ── "Heute anstehend": gefiltert + nach Status sortiert, max. 5
-  const upcomingJobs = useMemo(() => {
+  // Laufzeit des aktiven Jobs. Der Hook muss unbedingt bei JEDEM Render
+  // aufgerufen werden (Hook-Regeln) — ohne aktiven Job wird ein neutraler
+  // Platzhalter übergeben, der nie tickt (status "open").
+  const { label: activeWorkedLabel } = useJobWorkedTime(
+    activeJob ?? NO_ACTIVE_JOB_TIME,
+  );
+  const activeScheduledTime = activeJob
+    ? (activeJob.startTime ?? formatTime(activeJob.scheduledStart))
+    : null;
+
+  // ── "Heute anstehend": gefiltert + nach Status sortiert.
+  //
+  // Die Liste war vorher hart auf `.slice(0, 5)` gekappt — ohne jeden Hinweis.
+  // Wer heute sechs Aufträge hatte, sah fünf und hatte keine Möglichkeit zu
+  // erkennen, dass überhaupt etwas fehlt. Jetzt wird weiterhin gekürzt (die
+  // Übersicht soll eine Übersicht bleiben), aber die Gesamtzahl ist bekannt
+  // und der Rest ist über einen sichtbaren Verweis in den Jobs-Tab erreichbar.
+  const filteredTodayJobs = useMemo(() => {
     const base =
       filter === "all"
         ? todayJobs
         : todayJobs.filter((j) => j.status === filter);
-    return [...base]
-      .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
-      .slice(0, 5);
+    return [...base].sort(
+      (a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status],
+    );
   }, [todayJobs, filter]);
+
+  const upcomingJobs = useMemo(
+    () => filteredTodayJobs.slice(0, UPCOMING_PREVIEW_COUNT),
+    [filteredTodayJobs],
+  );
+
+  // Wie viele Aufträge liegen hinter der Vorschau? 0 = nichts verborgen.
+  const hiddenJobCount = filteredTodayJobs.length - upcomingJobs.length;
 
   // ── Monatsaktivität (mit Datum-Fallback)
   const monthJobs = useMemo(() => {
@@ -400,7 +444,23 @@ export default function EmployeeOverviewScreen() {
                     </Text>
                   </View>
                 ) : null}
-                {activeJob.startTime ?? formatTime(activeJob.scheduledStart) ? (
+                {/* Bei einem LAUFENDEN Auftrag ist die geplante Startzeit die
+                    unwichtigere Zahl — interessant ist, wie lange er schon
+                    läuft. Gleicher Hook wie JobCard/WorkedTimeCard (minütlicher
+                    Tick, keine neue Timer-Architektur). Fehlt startedAt
+                    (Alt-/Offline-Daten), bleibt es bei der geplanten Zeit. */}
+                {activeWorkedLabel ? (
+                  <View style={styles.activeMetaItem}>
+                    <Ionicons
+                      name="hourglass-outline"
+                      size={14}
+                      color={theme.colors.onPrimaryContainer}
+                    />
+                    <Text style={styles.activeMetaText}>
+                      Läuft seit {activeWorkedLabel}
+                    </Text>
+                  </View>
+                ) : activeScheduledTime ? (
                   <View style={styles.activeMetaItem}>
                     <Ionicons
                       name="time-outline"
@@ -408,7 +468,7 @@ export default function EmployeeOverviewScreen() {
                       color={theme.colors.onPrimaryContainer}
                     />
                     <Text style={styles.activeMetaText}>
-                      {activeJob.startTime ?? formatTime(activeJob.scheduledStart)}
+                      {activeScheduledTime}
                     </Text>
                   </View>
                 ) : null}
@@ -436,9 +496,15 @@ export default function EmployeeOverviewScreen() {
 
       {/* ── Heute anstehend ── */}
       <View style={styles.section}>
+        {/* Untertitel nennt die tatsächliche Anzahl — die Liste darunter ist
+            eine Vorschau, das darf nicht verschwiegen werden. */}
         <SectionHeader
           title="Heute anstehend"
-          subtitle="Deine wichtigsten Aufträge"
+          subtitle={
+            todayTotal === 1
+              ? "1 Auftrag heute"
+              : `${todayTotal} Aufträge heute`
+          }
         />
 
         {/* Filter-Chips (wirken nur auf diese Liste) */}
@@ -462,13 +528,25 @@ export default function EmployeeOverviewScreen() {
           })}
         </View>
 
+        {/* Leer-Zustand unterscheidet jetzt zwischen "heute nichts geplant"
+            und "der aktive Filter trifft nichts" — vorher stand in beiden
+            Fällen "Du hast heute keine geplanten Aufträge.", was bei gesetztem
+            Filter schlicht falsch war. */}
         {upcomingJobs.length === 0 ? (
           <Card>
-            <EmptyState
-              title="Keine Jobs für heute"
-              message="Du hast heute keine geplanten Aufträge."
-              icon="calendar-outline"
-            />
+            {filter === "all" ? (
+              <EmptyState
+                title="Heute keine Aufträge"
+                message="Für heute sind keine Aufträge für dich geplant."
+                icon="calendar-outline"
+              />
+            ) : (
+              <EmptyState
+                title="Keine passenden Aufträge"
+                message={`Heute hast du keine Aufträge mit dem Status „${FILTER_LABEL_BY_KEY[filter]}“. Wähle „Alle“, um alle ${todayTotal} zu sehen.`}
+                icon="funnel-outline"
+              />
+            )}
           </Card>
         ) : (
           <View style={styles.jobList}>
@@ -490,6 +568,29 @@ export default function EmployeeOverviewScreen() {
                 }
               />
             ))}
+
+            {/* Nichts wird still unterschlagen: sobald die Vorschau kürzt,
+                steht hier, wie viele Aufträge noch folgen — mit direktem Weg
+                in den Jobs-Tab (Kalender startet auf heute). */}
+            {hiddenJobCount > 0 ? (
+              <TouchableOpacity
+                style={styles.showAllButton}
+                activeOpacity={0.8}
+                onPress={() => router.push("/(employee-tabs)/jobs")}
+                accessibilityRole="button"
+              >
+                <Text style={styles.showAllText}>
+                  {hiddenJobCount === 1
+                    ? "1 weiterer Auftrag heute — alle anzeigen"
+                    : `${hiddenJobCount} weitere Aufträge heute — alle anzeigen`}
+                </Text>
+                <Ionicons
+                  name="chevron-forward"
+                  size={16}
+                  color={theme.colors.primary}
+                />
+              </TouchableOpacity>
+            ) : null}
           </View>
         )}
       </View>
@@ -714,6 +815,27 @@ function createStyles(theme: AppTheme) {
     // ── Job-Liste
     jobList: {
       gap: theme.spacing.sm,
+    },
+
+    // ── "Alle anzeigen" unter der gekürzten Vorschau
+    showAllButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 6,
+      marginTop: 2,
+      paddingVertical: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    showAllText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.primary,
     },
   });
 }

--- a/features/jobs/EmployeeJobsCalendarScreen.tsx
+++ b/features/jobs/EmployeeJobsCalendarScreen.tsx
@@ -271,17 +271,35 @@ export default function EmployeeJobsCalendarScreen() {
               />
             ) : null}
 
-            {/* ── Titel: ausgewähltes Datum ── */}
-            <Text style={styles.dayTitle}>{selectedLabel}</Text>
+            {/* ── Titel: ausgewähltes Datum + Anzahl ──
+                Die Anzahl macht sichtbar, dass die Liste darunter VOLLSTÄNDIG
+                ist (der Tag wird nie gekürzt). */}
+            <View style={styles.dayTitleRow}>
+              <Text style={styles.dayTitle} numberOfLines={2}>
+                {selectedLabel}
+              </Text>
+              {dayJobs.length > 0 ? (
+                <Text style={styles.dayCount}>
+                  {dayJobs.length === 1 ? "1 Auftrag" : `${dayJobs.length} Aufträge`}
+                </Text>
+              ) : null}
+            </View>
           </View>
         }
+        // Leer-Zustand sagt jetzt, WELCHER Tag leer ist und was als Nächstes
+        // hilft. "Keine Jobs für diesen Tag" + "Wähle einen markierten Tag"
+        // war für den häufigsten Fall (heute ist frei) unnötig technisch.
         ListEmptyComponent={
           <EmptyState
-            title="Keine Jobs für diesen Tag"
+            title={
+              selectedKey === todayKey
+                ? "Heute keine Aufträge"
+                : "Keine Aufträge an diesem Tag"
+            }
             message={
               markedKeys.size > 0
-                ? "Wähle einen markierten Tag im Kalender aus."
-                : "Keine Jobs in diesem Monat."
+                ? "Tage mit Aufträgen sind im Kalender markiert."
+                : "In diesem Monat sind dir keine Aufträge zugewiesen."
             }
             icon="calendar-outline"
           />
@@ -358,7 +376,20 @@ function createStyles(theme: AppTheme) {
     },
 
     // ── Titel des ausgewählten Tags
+    dayTitleRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    dayCount: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
     dayTitle: {
+      flexShrink: 1,
       fontSize: theme.typography.size.md,
       fontFamily: theme.typography.family.semibold,
       fontWeight: theme.typography.weight.semibold,

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -3,10 +3,12 @@
 // Vollständig theme-aware (Light + Dark Mode).
 // Business-Logik unverändert: nutzt nur profile/role/user/signOut aus AuthContext.
 //
-// Hinweis: Die meisten Rows sind bewusst UI-only ("Bald"). Echte Funktion haben:
-// - "Team verwalten" (Admin) → navigiert zu /(admin-tabs)/employees
-// - "Abmelden" → bestehende signOut-Funktion
-// - "Erscheinungsbild" → Info, dass die App der Systemeinstellung folgt (kein eigener Toggle)
+// JEDE Zeile mit Chevron führt auch wirklich irgendwohin. Früher waren sieben
+// der elf Zeilen reine Attrappen ("Bald"): sie sahen aus wie Navigation, ein
+// Tap brachte aber nur ein "Diese Funktion kommt später."-Alert — das im Web
+// nicht einmal erschien (Alert.alert ist dort eine leere Attrappe). Die
+// Attrappen sind entfernt; rein informative Werte (E-Mail, Sprache) stehen
+// jetzt als nicht tippbare Info-Zeilen ohne Chevron.
 
 import { Card, InitialsAvatar } from "@/components/ui";
 import { alertDialog, confirmDialog } from "@/utils/dialogs";
@@ -18,7 +20,6 @@ import Constants from "expo-constants";
 import { router } from "expo-router";
 import React, { useMemo } from "react";
 import {
-  Alert,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -33,12 +34,6 @@ const APP_VERSION =
   Constants.expoConfig?.version ??
   (Constants as any).manifest?.version ??
   "1.0.0";
-
-const COMING_SOON_MSG = "Diese Funktion kommt später.";
-
-function showComingSoon() {
-  Alert.alert("Bald verfügbar", COMING_SOON_MSG);
-}
 
 export default function ProfileScreen({
   showBack = false,
@@ -156,22 +151,30 @@ export default function ProfileScreen({
           </View>
         </Card>
 
+        {/* ── Meine Arbeit (nur Mitarbeiter) ──
+            Die eigene erfasste Arbeitszeit war bisher überhaupt nicht
+            erreichbar: /timesheets war nur über das Admin-Dashboard und den
+            Admin-Bereich dieses Screens verlinkt. Mitarbeitende kommen jetzt
+            hier an ihre eigenen Zeiten (gleiche Berechnung, eigene Sicht). */}
+        {!isAdmin && (
+          <SettingsSection title="Meine Arbeit" styles={styles} theme={theme}>
+            <SettingsRow
+              icon="time-outline"
+              label="Meine Arbeitszeit"
+              onPress={() => router.push("/timesheets")}
+              isLast
+              styles={styles}
+              theme={theme}
+            />
+          </SettingsSection>
+        )}
+
         {/* ── Account ── */}
         <SettingsSection title="Account" styles={styles} theme={theme}>
-          <SettingsRow
-            icon="person-outline"
-            label="Profil bearbeiten"
-            comingSoon
-            onPress={showComingSoon}
-            styles={styles}
-            theme={theme}
-          />
           <SettingsRow
             icon="mail-outline"
             label="E-Mail"
             value={email}
-            comingSoon
-            onPress={showComingSoon}
             styles={styles}
             theme={theme}
           />
@@ -191,29 +194,21 @@ export default function ProfileScreen({
             icon="language-outline"
             label="Sprache"
             value="Deutsch"
-            comingSoon
-            onPress={showComingSoon}
             styles={styles}
             theme={theme}
           />
-          <SettingsRow
-            icon="notifications-outline"
-            label="Benachrichtigungen"
-            comingSoon
-            onPress={showComingSoon}
-            styles={styles}
-            theme={theme}
-          />
+          {/* alertDialog statt Alert.alert: Alert ist im Web eine leere
+              Attrappe — der Hinweis erschien dort nie. */}
           <SettingsRow
             icon="contrast-outline"
             label="Erscheinungsbild"
             value="Systemeinstellung"
-            onPress={() =>
-              Alert.alert(
+            onPress={() => {
+              void alertDialog(
                 "Erscheinungsbild",
                 "Die App folgt automatisch der Hell-/Dunkel-Einstellung deines Geräts.",
-              )
-            }
+              );
+            }}
             isLast
             styles={styles}
             theme={theme}
@@ -228,14 +223,6 @@ export default function ProfileScreen({
             theme={theme}
           >
             <SettingsRow
-              icon="business-outline"
-              label="Firmenprofil"
-              comingSoon
-              onPress={showComingSoon}
-              styles={styles}
-              theme={theme}
-            />
-            <SettingsRow
               icon="people-outline"
               label="Team verwalten"
               onPress={() => router.push("/(admin-tabs)/employees")}
@@ -246,14 +233,6 @@ export default function ProfileScreen({
               icon="document-text-outline"
               label="Stundenzettel"
               onPress={() => router.push("/timesheets")}
-              styles={styles}
-              theme={theme}
-            />
-            <SettingsRow
-              icon="options-outline"
-              label="App-Einstellungen"
-              comingSoon
-              onPress={showComingSoon}
               isLast
               styles={styles}
               theme={theme}
@@ -261,24 +240,8 @@ export default function ProfileScreen({
           </SettingsSection>
         )}
 
-        {/* ── Support ── */}
-        <SettingsSection title="Support" styles={styles} theme={theme}>
-          <SettingsRow
-            icon="help-circle-outline"
-            label="Hilfe & Support"
-            comingSoon
-            onPress={showComingSoon}
-            styles={styles}
-            theme={theme}
-          />
-          <SettingsRow
-            icon="shield-checkmark-outline"
-            label="Datenschutz"
-            comingSoon
-            onPress={showComingSoon}
-            styles={styles}
-            theme={theme}
-          />
+        {/* ── Konto & App-Info ── */}
+        <SettingsSection title="Sonstiges" styles={styles} theme={theme}>
           <SettingsRow
             icon="trash-outline"
             label="Konto löschen"
@@ -339,11 +302,12 @@ function SettingsSection({
 // ─────────────────────────────────────────────
 // SettingsRow
 // ─────────────────────────────────────────────
+// Ohne `onPress` ist die Zeile eine reine Info-Zeile: kein Touchable, kein
+// Chevron — sie sieht damit nicht mehr aus wie etwas, das irgendwohin führt.
 function SettingsRow({
   icon,
   label,
   value,
-  comingSoon = false,
   onPress,
   isLast = false,
   styles,
@@ -352,7 +316,6 @@ function SettingsRow({
   icon: React.ComponentProps<typeof Ionicons>["name"];
   label: string;
   value?: string;
-  comingSoon?: boolean;
   onPress?: () => void;
   isLast?: boolean;
   styles: ReturnType<typeof createStyles>;
@@ -375,12 +338,7 @@ function SettingsRow({
       </Text>
 
       <View style={styles.rowRight}>
-        {comingSoon && (
-          <View style={styles.soonBadge}>
-            <Text style={styles.soonText}>Bald</Text>
-          </View>
-        )}
-        {value && !comingSoon ? (
+        {value ? (
           <Text style={styles.rowValue} numberOfLines={1}>
             {value}
           </Text>
@@ -556,21 +514,6 @@ function createStyles(theme: AppTheme) {
       fontFamily: theme.typography.family.regular,
       color: theme.colors.onSurfaceVariant,
       flexShrink: 1,
-    },
-    soonBadge: {
-      backgroundColor: theme.colors.surfaceContainerHigh,
-      borderWidth: 1,
-      borderColor: theme.colors.outlineVariant,
-      borderRadius: theme.radius.full,
-      paddingHorizontal: theme.spacing.sm,
-      paddingVertical: 2,
-    },
-    soonText: {
-      fontSize: theme.typography.size.xs,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onSurfaceVariant,
-      letterSpacing: theme.typography.letterSpacing.wide,
     },
 
     // ── Logout

--- a/features/timesheets/TimesheetScreen.tsx
+++ b/features/timesheets/TimesheetScreen.tsx
@@ -1,7 +1,18 @@
 // features/timesheets/TimesheetScreen.tsx
-// Stundenzettel-Screen (nur Admin): Mitarbeiter + Monat wählen, Vorschau der
-// abgeschlossenen Jobs, Summe und PDF-Export (expo-print + expo-sharing).
-// Vollständig theme-aware (Light + Dark Mode).
+// Stundenzettel-Screen: Monat wählen, Vorschau der abgeschlossenen Jobs, Summe
+// und PDF-Export (expo-print + expo-sharing). Vollständig theme-aware.
+//
+// ZWEI SICHTEN, EINE BERECHNUNG:
+//  • Admin      — "Stundenzettel": Mitarbeiter frei wählbar (unverändert).
+//  • Mitarbeiter— "Meine Arbeitszeit": fest auf die EIGENE Person gebunden,
+//                 ohne Auswahlliste.
+//
+// Vorher stand hier für Mitarbeitende eine Sperre ("Nur für Admins"). Damit
+// hatte ein Mitarbeiter KEINE Möglichkeit, die eigene erfasste Arbeitszeit zu
+// sehen — obwohl genau diese Zeit aus seinen eigenen Aufträgen stammt.
+// Geändert hat sich nur die Sichtbarkeit: Abfrage (getTimesheet), Berechnung
+// und PDF-Aufbau sind unverändert, und RLS liefert Mitarbeitenden ohnehin nur
+// die eigenen zugewiesenen Aufträge ("employee read own assigned jobs").
 
 import {
   AppHeader,
@@ -30,7 +41,18 @@ export default function TimesheetScreen() {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const { role } = useAuth();
+  const { role, profile } = useAuth();
+  const isAdmin = role === "admin";
+
+  // Mitarbeiter-Sicht: fest auf die eigene Person gebunden (keine Auswahl).
+  const selfEmployee = useMemo(
+    () =>
+      !isAdmin && profile?.id
+        ? { id: profile.id, fullName: profile.full_name?.trim() || "Ich" }
+        : null,
+    [isAdmin, profile?.id, profile?.full_name],
+  );
+
   const {
     employees,
     selectedEmployeeId,
@@ -45,76 +67,68 @@ export default function TimesheetScreen() {
     exporting,
     exportError,
     exportPdf,
-  } = useTimesheet();
-
-  // Route ist Teil des authed-Stacks (Admin + Employee). Stundenzettel ist aber
-  // ein reines Admin-Feature → Mitarbeiter sehen einen klaren Hinweis.
-  if (role !== "admin") {
-    return (
-      <ScreenContainer scrollable={false}>
-        <AppHeader title="Stundenzettel" showBack />
-        <EmptyState
-          title="Nur für Admins"
-          message="Stundenzettel können nur von Administratoren erstellt werden."
-          icon="lock-closed-outline"
-        />
-      </ScreenContainer>
-    );
-  }
+  } = useTimesheet(selfEmployee);
 
   const hasEntries = !!data && data.entries.length > 0;
 
   return (
     <ScreenContainer>
-      <AppHeader title="Stundenzettel" showBack />
+      <AppHeader
+        title={isAdmin ? "Stundenzettel" : "Meine Arbeitszeit"}
+        showBack
+      />
 
-      {/* ── Mitarbeiter wählen ── */}
-      <View style={styles.section}>
-        <SectionHeader
-          title="Mitarbeiter"
-          subtitle="Für wen soll der Nachweis erstellt werden?"
-        />
-        {employees.length === 0 ? (
-          <Card>
-            <EmptyState
-              title="Keine Mitarbeiter"
-              message="Lege zuerst Mitarbeiter an, um einen Nachweis zu erstellen."
-              icon="people-outline"
-              compact
-            />
-          </Card>
-        ) : (
-          <Card padding={0}>
-            {employees.map((emp, idx) => {
-              const selected = emp.id === selectedEmployeeId;
-              return (
-                <TouchableOpacity
-                  key={emp.id}
-                  activeOpacity={0.7}
-                  onPress={() => setSelectedEmployeeId(emp.id)}
-                  style={[styles.empRow, idx > 0 && styles.rowDivider]}
-                >
-                  <View style={styles.empInfo}>
-                    <Text style={styles.empName} numberOfLines={1}>
-                      {emp.fullName}
-                    </Text>
-                    {emp.isActive === false && (
-                      <Text style={styles.empInactive}>Inaktiv</Text>
-                    )}
-                  </View>
-                  <Ionicons
-                    name={selected ? "radio-button-on" : "radio-button-off"}
-                    size={22}
-                    color={
-                      selected ? theme.colors.primary : theme.colors.outline
-                    }
-                  />
-                </TouchableOpacity>
-              );
-            })}
-          </Card>
-        )}
-      </View>
+      {/* ── Mitarbeiter wählen (nur Admin) ──
+          In der Eigen-Sicht gibt es nichts zu wählen: der Stundenzettel ist
+          fest an die angemeldete Person gebunden. */}
+      {isAdmin ? (
+        <View style={styles.section}>
+          <SectionHeader
+            title="Mitarbeiter"
+            subtitle="Für wen soll der Nachweis erstellt werden?"
+          />
+          {employees.length === 0 ? (
+            <Card>
+              <EmptyState
+                title="Keine Mitarbeiter"
+                message="Lege zuerst Mitarbeiter an, um einen Nachweis zu erstellen."
+                icon="people-outline"
+                compact
+              />
+            </Card>
+          ) : (
+            <Card padding={0}>
+              {employees.map((emp, idx) => {
+                const selected = emp.id === selectedEmployeeId;
+                return (
+                  <TouchableOpacity
+                    key={emp.id}
+                    activeOpacity={0.7}
+                    onPress={() => setSelectedEmployeeId(emp.id)}
+                    style={[styles.empRow, idx > 0 && styles.rowDivider]}
+                  >
+                    <View style={styles.empInfo}>
+                      <Text style={styles.empName} numberOfLines={1}>
+                        {emp.fullName}
+                      </Text>
+                      {emp.isActive === false && (
+                        <Text style={styles.empInactive}>Inaktiv</Text>
+                      )}
+                    </View>
+                    <Ionicons
+                      name={selected ? "radio-button-on" : "radio-button-off"}
+                      size={22}
+                      color={
+                        selected ? theme.colors.primary : theme.colors.outline
+                      }
+                    />
+                  </TouchableOpacity>
+                );
+              })}
+            </Card>
+          )}
+        </View>
+      ) : null}
 
       {/* ── Monat wählen ── */}
       <View style={styles.section}>
@@ -160,7 +174,7 @@ export default function TimesheetScreen() {
       {/* ── Vorschau ── */}
       <View style={styles.section}>
         <SectionHeader
-          title="Vorschau"
+          title={isAdmin ? "Vorschau" : "Deine Zeiten"}
           subtitle="Abgeschlossene Aufträge im Zeitraum"
         />
 
@@ -185,7 +199,11 @@ export default function TimesheetScreen() {
           <Card>
             <EmptyState
               title="Keine Einträge"
-              message="Keine abgeschlossenen Jobs in diesem Zeitraum"
+              message={
+                isAdmin
+                  ? "Keine abgeschlossenen Jobs in diesem Zeitraum"
+                  : "In diesem Monat hast du noch keinen Auftrag abgeschlossen."
+              }
               icon="calendar-clear-outline"
             />
           </Card>

--- a/features/timesheets/hooks/useTimesheet.ts
+++ b/features/timesheets/hooks/useTimesheet.ts
@@ -40,12 +40,39 @@ function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0);
 }
 
-export function useTimesheet(): UseTimesheetResult {
+/**
+ * @param selfEmployee Eigener Mitarbeiter-Datensatz, wenn der Screen die
+ *   EIGENE Arbeitszeit zeigt (Mitarbeiter-Sicht). Dann entfällt die Auswahl:
+ *   der Stundenzettel ist fest auf diese Person gebunden. Für Admins bleibt
+ *   der Parameter leer und alles verhält sich unverändert.
+ *
+ *   Nötig, weil `useJobs().employees` nur für Admins gefüllt ist — der Name
+ *   für die Kopfzeile/PDF muss in der Mitarbeiter-Sicht aus dem eigenen
+ *   Profil kommen. Die Abfrage selbst (getTimesheet) ist unverändert; RLS
+ *   erlaubt Mitarbeitenden das Lesen der eigenen zugewiesenen Jobs
+ *   ("employee read own assigned jobs" + "employee read assignments on
+ *   assigned jobs").
+ */
+export function useTimesheet(
+  selfEmployee?: { id: string; fullName: string } | null,
+): UseTimesheetResult {
   const { employees } = useJobs();
 
   const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(
-    null,
+    selfEmployee?.id ?? null,
   );
+
+  // Profil kann nach dem ersten Render eintreffen (Auth-Bootstrap) — dann die
+  // Auswahl nachziehen. Greift nur in der Eigen-Sicht.
+  // Bewusst als primitive Werte gehalten: `selfEmployee` ist ein Objekt-Literal
+  // und wäre bei jedem Render neu — als Effect-Dependency würde es den
+  // Stundenzettel endlos neu laden.
+  const selfId = selfEmployee?.id ?? null;
+  const selfName = selfEmployee?.fullName ?? null;
+
+  useEffect(() => {
+    if (selfId) setSelectedEmployeeId(selfId);
+  }, [selfId]);
   const [monthDate, setMonthDate] = useState<Date>(() =>
     startOfMonth(new Date()),
   );
@@ -96,7 +123,10 @@ export function useTimesheet(): UseTimesheetResult {
     }
 
     const employee = employees.find((e) => e.id === selectedEmployeeId);
-    const employeeName = employee?.fullName ?? "Mitarbeiter";
+    const employeeName =
+      employee?.fullName ??
+      (selfId === selectedEmployeeId ? selfName : null) ??
+      "Mitarbeiter";
 
     let cancelled = false;
     setLoading(true);
@@ -130,7 +160,7 @@ export function useTimesheet(): UseTimesheetResult {
     return () => {
       cancelled = true;
     };
-  }, [selectedEmployeeId, monthDate, employees]);
+  }, [selectedEmployeeId, monthDate, employees, selfId, selfName]);
 
   const exportPdf = useCallback(async () => {
     if (!data || data.entries.length === 0) return;


### PR DESCRIPTION
Batch 6 des UI/UX-Audits: **Employee Screens**. JS/TS only, kein Build noetig. Keine Backend-, Native- oder Dependency-Aenderung.

## Inventar des Live-Mitarbeiter-Flows

| Flaeche | Datei | Status |
|---|---|---|
| Uebersicht (Tab) | `features/home/EmployeeOverviewScreen.tsx` | live |
| Jobs (Tab) | `features/jobs/EmployeeJobsCalendarScreen.tsx` | live |
| Job-Detail | `features/jobs/JobDetailScreen.tsx` (+ Footer/Comments/Photos/WorkedTime) | live |
| Profil (Tab) | `features/profile/ProfileScreen.tsx` (geteilt mit Admin) | live |
| Arbeitszeit | `features/timesheets/TimesheetScreen.tsx` | live, war fuer Mitarbeitende gesperrt |

**Toter Code (nicht angefasst, Cleanup ausserhalb dieses Batches):** `features/jobs/JobsListScreen.tsx` wird von **keiner** Route mehr importiert — der Employee-Tab nutzt den Kalender, der Admin-Tab `AdminJobsScreen`. Ebenso weiterhin tot: `features/home/HomeScreen.tsx` + `HomeStats`/`HomeHeader`, `i18n/translations.ts`.

**Befunde:** heute-Liste kappte still; eigene Arbeitszeit unerreichbar; sieben Profil-Attrappen; Leer-Zustaende ignorierten den aktiven Filter; ein englisches Tab-Label.

## Goal 2 — Truncation

`upcomingJobs` war `.slice(0, 5)` **ohne Hinweis**. Geloest ueber **Option B** (die risikoaermere): die Vorschau bleibt bei 5, aber
- der Abschnitts-Untertitel nennt die echte Gesamtzahl ("7 Auftraege heute"),
- unter der Liste erscheint bei Kuerzung `N weitere Auftraege heute — alle anzeigen` → `/(employee-tabs)/jobs` (Kalender startet auf heute).

Abfrage-Semantik unveraendert (weiterhin reine Client-Filterung ueber `isJobToday`).

## Goal 3 — Aktiver Job

Nur eine Aenderung: statt der **geplanten Startzeit** zeigt die Karte jetzt die **Laufzeit** — `Läuft seit 1h 35min` — ueber den bereits existierenden `useJobWorkedTime` (minuetlicher Tick, derselbe Hook wie JobCard/WorkedTimeCard). Keine neue Timer-Architektur, kein Hintergrund-Timer. Fehlt `startedAt`, bleibt es bei der geplanten Zeit.

Unveraendert: Navigation und "Job abschliessen" bleiben Geschwister (keine verschachtelten Touchables), Bestaetigung, `await`, Busy-Sperre.

## Goal 4 — Jobs/Kalender

Der Kalender kuerzt nichts — die Tagesliste ist immer vollstaendig. Neu ist die **Anzahl neben dem Tagestitel**, damit das auch sichtbar ist. Status-Vokabular unveraendert kanonisch (Batch 4). Recurring-Parents werden weiterhin clientseitig ausgefiltert (zusaetzlich zur RLS). Es gibt in diesem Screen bewusst **keine** Statusfilter — die einzige Filterleiste lag im toten `JobsListScreen`.

## Goal 5 — Zugang zur eigenen Arbeitszeit

Der Befund war schaerfer als angenommen: `/timesheets` war nicht nur "vergraben", sondern fuer Mitarbeitende **komplett gesperrt** (`if (role !== "admin") → "Nur fuer Admins"`) und ausschliesslich aus Admin-Flaechen verlinkt. Eine reine Profil-Zeile haette also in eine Sperre gefuehrt — genau die Art irrefuehrender Aktion, die Goal 6 beseitigen soll.

Deshalb der kleinste Eingriff, der das Ziel wirklich erreicht — **Sichtbarkeit, nicht Funktionalitaet**:
- **Admin:** unveraendert ("Stundenzettel", Mitarbeiterauswahl, PDF).
- **Mitarbeiter:** derselbe Screen als "Meine Arbeitszeit", fest auf die eigene Person gebunden, ohne Auswahlliste.
- Neue Profil-Sektion "Meine Arbeit" → Zeile **"Meine Arbeitszeit"**.

`getTimesheet`, alle Dauer-Berechnungen und der PDF-Aufbau sind **unveraendert**. `useTimesheet` bekam nur einen optionalen `selfEmployee`-Parameter (Name fuer Kopfzeile/PDF, weil `useJobs().employees` fuer Mitarbeitende leer ist). RLS deckt den Zugriff bereits ab: `employee read own assigned jobs` + `employee read assignments on assigned jobs` — kein Policy-Change noetig, keiner vorgenommen.

## Goal 6 — Profil

Entfernt (Attrappen mit Chevron, die nur ein `Alert.alert` zeigten — im Web wirkungslos): *Profil bearbeiten, Benachrichtigungen, Hilfe & Support, Datenschutz, Firmenprofil, App-Einstellungen*.
Zu **Info-Zeilen** ohne Chevron/Touchable umgebaut: *E-Mail*, *Sprache*.
Behalten und funktionsfaehig: *Passwort aendern, Erscheinungsbild, Konto loeschen, App-Version, Abmelden* sowie (Admin) *Team verwalten, Stundenzettel*.
Zusaetzlich: "Erscheinungsbild" nutzt jetzt `alertDialog` statt `Alert.alert`.
Die `comingSoon`-Prop und das "Bald"-Badge sind damit ersatzlos weg. Der Admin-Teil aendert sich nur insoweit, wie der geteilte Code es erzwingt.

## Goal 7 — Ungelesene Kommentare

End-to-end geprueft, **keine Aenderung noetig**: Tab-Badge haengt an `hasUnread` (RPC-basiert, aus Batch 1 — nicht auf die alte fenster-basierte `jobs.some(...)`-Quelle zurueckgedreht), JobCard zeigt den roten Punkt aus `job.hasUnreadComments`, `JobDetailScreen` markiert beim Oeffnen als gelesen. Die Lese-Markierung bleibt an `isPrimaryAssignee` gebunden (RLS-Bedingung der INSERT-Policy auf `job_comment_reads`) — bewusst nicht angefasst.

## Goal 8 — Leer-Zustaende

- Uebersicht ohne Filter: **"Heute keine Auftraege"** / "Fuer heute sind keine Auftraege fuer dich geplant."
- Uebersicht **mit** Filter: eigener Text, der den Filter benennt und auf "Alle" verweist. Vorher stand dort faelschlich "Du hast heute keine geplanten Auftraege." — auch wenn nur der Filter nicht traf.
- Kalender: unterscheidet heute / anderer Tag, und "keine Auftraege in diesem Monat" vs. "Tage mit Auftraegen sind im Kalender markiert".
- Arbeitszeit (Eigen-Sicht): "In diesem Monat hast du noch keinen Auftrag abgeschlossen."

## Goal 9 — Tab-Label

`Profile` → **`Profil`**. Keine Aenderung an der Navigationsstruktur.

## Bewusst NICHT angefasst (RLS-/Zuweisungs-sensibel)

`canRunJobActions`, `isPrimaryAssignee`, die Kommentar-/Foto-Gates, `job_comment_reads`-Logik, Offline-Queue, Realtime, Timesheet-Berechnung. Keine Datei unter `supabase/`, kein `package.json`, keine Native-Config.

## Checks

- `npx tsc --noEmit` — sauber
- `npm run lint` — sauber
- Geaenderte Dateien: 6, alle JS/TS im UI-Layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)