### PR TITLE
fix(navigation): Header- und Back-Button-Konsistenz (Batch 3)

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -75,7 +75,8 @@ export default function AdminTabsLayout() {
       <Tabs.Screen
         name="profile"
         options={{
-          title: "Profile",
+          // Deutsch wie überall sonst in der App (siehe Employee-Layout).
+          title: "Profil",
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="person-outline" size={size} color={color} />
           ),

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -216,7 +216,6 @@ function RootNavigator() {
           <Stack.Screen name="jobs/create" />
           <Stack.Screen name="jobs/[id]/edit" />
           <Stack.Screen name="employees/[id]/index" />
-          <Stack.Screen name="timesheets/index" />
         </Stack.Protected>
 
         {/* Employee-Bereich: nur die eigenen Tabs. */}
@@ -225,10 +224,13 @@ function RootNavigator() {
         </Stack.Protected>
 
         {/* Von beiden Rollen genutzt: Job-Detail (rollenabhängige UI innerhalb
-            des Screens) und Passwort ändern. */}
+            des Screens), Passwort ändern und Stundenzettel (Admin sieht alle
+            Mitarbeiter, Mitarbeitende nur die eigene Zeit — siehe
+            TimesheetScreen). */}
         <Stack.Protected guard={isAuthed}>
           <Stack.Screen name="jobs/[id]/index" />
           <Stack.Screen name="change-password" />
+          <Stack.Screen name="timesheets/index" />
         </Stack.Protected>
       </Stack>
     </JobProvider>

--- a/components/ui/AppHeader.tsx
+++ b/components/ui/AppHeader.tsx
@@ -52,6 +52,8 @@ export function AppHeader({
             style={styles.iconBtn}
             activeOpacity={0.7}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Zurück"
           >
             <Ionicons
               name="arrow-back"

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -3,7 +3,7 @@
 // Vollständig auf useAppTheme() migriert — Light + Dark Mode.
 // Business-Logik (createJob, useJobForm, AuthContext, JobContext) unverändert.
 
-import { Button, LoadingScreen } from "@/components/ui";
+import { AppHeader, Button, LoadingScreen } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
@@ -11,7 +11,6 @@ import { JobFormFields } from "@/features/jobs/components/JobFormFields";
 import { useJobForm } from "@/features/jobs/hooks/useJobForm";
 import { formatDateISO, formatTimeHHmm, formatToISO } from "@/utils/date";
 import type { CreateJobInput } from "@/types/job";
-import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -21,7 +20,6 @@ import {
   StatusBar,
   StyleSheet,
   Text,
-  TouchableOpacity,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -101,7 +99,7 @@ export default function AdminScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const { createJob, employees, loading } = useJobs();
-  const { role, loading: authLoading } = useAuth();
+  const { loading: authLoading } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   // Synchrone Re-Entrancy-Sperre gegen Doppel-Absendung. setSubmitting(true)
   // wirkt erst beim nächsten Render — zwei sehr schnelle Taps könnten daher
@@ -229,40 +227,17 @@ export default function AdminScreen() {
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        {/* ── Header ── */}
-        <View style={styles.header}>
-          <TouchableOpacity
-            onPress={() => {
-              if (router.canGoBack()) {
-                router.back();
-              } else {
-                router.replace("/(admin-tabs)/jobs");
-              }
-            }}
-            style={styles.backBtn}
-            activeOpacity={0.7}
-          >
-            <Ionicons
-              name="chevron-back"
-              size={22}
-              color={theme.colors.primary}
-            />
-            <Text style={styles.backLabel}>Zurück</Text>
-          </TouchableOpacity>
-
-          <View style={styles.headerCenter}>
-            <Text style={styles.headerTitle}>Neuer Job</Text>
-            {role ? (
-              <View style={styles.rolePill}>
-                <View style={styles.roleDot} />
-                <Text style={styles.rolePillText}>{role}</Text>
-              </View>
-            ) : null}
-          </View>
-
-          {/* Gegengewicht zum Zurück-Button, damit der Titel mittig bleibt. */}
-          <View style={styles.headerSpacer} />
-        </View>
+        <AppHeader
+          title="Neuer Job"
+          showBack
+          onBack={() => {
+            if (router.canGoBack()) {
+              router.back();
+            } else {
+              router.replace("/(admin-tabs)/jobs");
+            }
+          }}
+        />
 
         {/* ── Scroll-Inhalt ── */}
         <Animated.ScrollView
@@ -308,72 +283,6 @@ function createStyles(theme: AppTheme) {
     },
     flex: {
       flex: 1,
-    },
-
-    // Header
-    header: {
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.md,
-      borderBottomWidth: 1,
-      borderBottomColor: theme.colors.outlineVariant,
-      backgroundColor: theme.colors.background,
-    },
-    backBtn: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 2,
-      minWidth: 72,
-    },
-    backLabel: {
-      fontSize: theme.typography.size.md,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.primary,
-    },
-    headerCenter: {
-      flex: 1,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: theme.spacing.sm,
-    },
-    headerTitle: {
-      fontSize: theme.typography.size.md,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onSurface,
-    },
-
-    // Rolle-Pill (z.B. "admin")
-    rolePill: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 4,
-      backgroundColor: theme.colors.statusInProgressBg,
-      borderWidth: 1,
-      borderColor: theme.colors.statusInProgressBorder,
-      paddingHorizontal: 8,
-      paddingVertical: 3,
-      borderRadius: theme.radius.full,
-    },
-    roleDot: {
-      width: 5,
-      height: 5,
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.statusInProgress,
-    },
-    rolePillText: {
-      fontSize: theme.typography.size.xs,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.statusInProgress,
-    },
-
-    headerSpacer: {
-      minWidth: 72,
     },
 
     // Scroll-Container

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -3,7 +3,7 @@
 // Vollständig auf useAppTheme() migriert — Light + Dark Mode.
 // Business-Logik (updateJob, deleteJob, useJobForm, AuthContext, JobContext) unverändert.
 
-import { Button, Card, Divider, ErrorBanner, LoadingScreen } from "@/components/ui";
+import { AppHeader, Button, Card, Divider, ErrorBanner, LoadingScreen } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
@@ -438,33 +438,7 @@ export default function EditJobScreen() {
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        {/* ── Header ── */}
-        <View style={styles.header}>
-          <TouchableOpacity
-            onPress={() => router.back()}
-            style={styles.backButton}
-            activeOpacity={0.7}
-          >
-            <Ionicons
-              name="chevron-back"
-              size={22}
-              color={theme.colors.primary}
-            />
-            <Text style={styles.backLabel}>Zurück</Text>
-          </TouchableOpacity>
-
-          <View style={styles.headerCenter}>
-            <Text style={styles.headerTitle}>Job bearbeiten</Text>
-            {role && (
-              <View style={styles.roleBadge}>
-                <Text style={styles.roleBadgeText}>{role}</Text>
-              </View>
-            )}
-          </View>
-
-          {/* Gegengewicht zum Zurück-Button, damit der Titel mittig bleibt. */}
-          <View style={styles.headerSpacer} />
-        </View>
+        <AppHeader title="Job bearbeiten" showBack />
 
         {/* ── Scroll-Inhalt ── */}
         <ScrollView
@@ -598,60 +572,6 @@ function createStyles(theme: AppTheme) {
     },
 
     // ── Header
-    header: {
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.md,
-      borderBottomWidth: 1,
-      borderBottomColor: theme.colors.outlineVariant,
-      backgroundColor: theme.colors.background,
-    },
-    backButton: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 2,
-      paddingVertical: theme.spacing.xs,
-      minWidth: 70,
-    },
-    backLabel: {
-      fontSize: theme.typography.size.md,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.primary,
-    },
-    headerCenter: {
-      flex: 1,
-      alignItems: "center",
-      flexDirection: "row",
-      justifyContent: "center",
-      gap: theme.spacing.sm,
-    },
-    headerTitle: {
-      fontSize: theme.typography.size.md,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onSurface,
-    },
-    roleBadge: {
-      backgroundColor: theme.colors.statusInProgressBg,
-      borderWidth: 1,
-      borderColor: theme.colors.statusInProgressBorder,
-      paddingHorizontal: 8,
-      paddingVertical: 2,
-      borderRadius: theme.radius.full,
-    },
-    roleBadgeText: {
-      fontSize: theme.typography.size.xs,
-      fontFamily: theme.typography.family.medium,
-      fontWeight: theme.typography.weight.medium,
-      color: theme.colors.statusInProgress,
-    },
-    headerSpacer: {
-      minWidth: 70,
-    },
-
     // ── Scroll-Container
     scroll: {
       padding: theme.spacing.lg,

--- a/features/profile/ChangePasswordScreen.tsx
+++ b/features/profile/ChangePasswordScreen.tsx
@@ -1,4 +1,4 @@
-import { ErrorBanner, PasswordInput } from "@/components/ui";
+import { AppHeader, ErrorBanner, PasswordInput } from "@/components/ui";
 import { supabase } from "@/lib/supabase";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
@@ -17,7 +17,6 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { Ionicons } from "@expo/vector-icons";
 
 export default function ChangePasswordScreen() {
   const theme = useAppTheme();
@@ -73,18 +72,7 @@ export default function ChangePasswordScreen() {
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        {/* ── Header ── */}
-        <View style={styles.header}>
-          <TouchableOpacity
-            style={styles.backButton}
-            activeOpacity={0.8}
-            onPress={() => router.back()}
-          >
-            <Ionicons name="chevron-back" size={18} color={theme.colors.onSurface} />
-          </TouchableOpacity>
-          <Text style={styles.headerTitle}>Passwort ändern</Text>
-          <View style={styles.headerSpacer} />
-        </View>
+        <AppHeader title="Passwort ändern" showBack />
 
         <ScrollView
           contentContainerStyle={styles.content}
@@ -156,35 +144,6 @@ function createStyles(theme: AppTheme) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,
-    },
-
-    // ── Header
-    header: {
-      flexDirection: "row",
-      alignItems: "center",
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.md,
-      borderBottomWidth: 1,
-      borderBottomColor: theme.colors.outlineVariant,
-    },
-    backButton: {
-      width: 36,
-      height: 36,
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.surfaceContainerHigh,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    headerTitle: {
-      flex: 1,
-      textAlign: "center",
-      fontSize: theme.typography.size.lg,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onSurface,
-    },
-    headerSpacer: {
-      width: 36,
     },
 
     // ── Content

--- a/features/profile/DeleteAccountScreen.tsx
+++ b/features/profile/DeleteAccountScreen.tsx
@@ -7,7 +7,7 @@
 // Backend: services/account/deleteAccount.ts → Edge Function delete-account.
 // Nach Erfolg: lokale Caches leeren, lokal abmelden, zurück zum Login.
 
-import { Card } from "@/components/ui";
+import { AppHeader, Card } from "@/components/ui";
 import { useAuth } from "@/context/AuthContext";
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
@@ -113,29 +113,18 @@ export default function DeleteAccountScreen() {
         backgroundColor={theme.colors.background}
       />
 
-      {/* ── Header ── */}
-      <View style={styles.header}>
-        <TouchableOpacity
-          style={styles.backButton}
-          activeOpacity={0.8}
-          onPress={() => {
-            if (router.canGoBack()) {
-              router.back();
-              return;
-            }
-            router.replace("/");
-          }}
-          disabled={loading}
-        >
-          <Ionicons
-            name="chevron-back"
-            size={18}
-            color={theme.colors.onSurface}
-          />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Konto löschen</Text>
-        <View style={styles.headerSpacer} />
-      </View>
+      <AppHeader
+        title="Konto löschen"
+        showBack
+        onBack={() => {
+          if (loading) return;
+          if (router.canGoBack()) {
+            router.back();
+            return;
+          }
+          router.replace("/");
+        }}
+      />
 
       <ScrollView
         contentContainerStyle={styles.content}
@@ -358,35 +347,6 @@ function createStyles(theme: AppTheme) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,
-    },
-
-    // ── Header
-    header: {
-      flexDirection: "row",
-      alignItems: "center",
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.md,
-      borderBottomWidth: 1,
-      borderBottomColor: theme.colors.outlineVariant,
-    },
-    backButton: {
-      width: 36,
-      height: 36,
-      borderRadius: theme.radius.full,
-      backgroundColor: theme.colors.surfaceContainerHigh,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    headerTitle: {
-      flex: 1,
-      textAlign: "center",
-      fontSize: theme.typography.size.lg,
-      fontFamily: theme.typography.family.semibold,
-      fontWeight: theme.typography.weight.semibold,
-      color: theme.colors.onSurface,
-    },
-    headerSpacer: {
-      width: 36,
     },
 
     // ── Content

--- a/features/timesheets/TimesheetScreen.tsx
+++ b/features/timesheets/TimesheetScreen.tsx
@@ -20,7 +20,6 @@ import {
   Card,
   EmptyState,
   ErrorBanner,
-  ScreenContainer,
   SectionHeader,
 } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
@@ -31,11 +30,14 @@ import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
 import {
   ActivityIndicator,
+  ScrollView,
+  StatusBar,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function TimesheetScreen() {
   const theme = useAppTheme();
@@ -72,12 +74,20 @@ export default function TimesheetScreen() {
   const hasEntries = !!data && data.entries.length > 0;
 
   return (
-    <ScreenContainer>
+    <SafeAreaView style={styles.safe} edges={["top"]}>
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
       <AppHeader
         title={isAdmin ? "Stundenzettel" : "Meine Arbeitszeit"}
         showBack
       />
 
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
       {/* ── Mitarbeiter wählen (nur Admin) ──
           In der Eigen-Sicht gibt es nichts zu wählen: der Stundenzettel ist
           fest an die angemeldete Person gebunden. */}
@@ -275,7 +285,8 @@ export default function TimesheetScreen() {
       />
 
       <View style={{ height: theme.spacing.xxl }} />
-    </ScreenContainer>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
@@ -290,6 +301,15 @@ function formatDayShort(isoDate: string): string {
 
 function createStyles(theme: AppTheme) {
   return StyleSheet.create({
+    safe: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scroll: {
+      flexGrow: 1,
+      paddingHorizontal: theme.spacing.gutter,
+      paddingBottom: 32,
+    },
     section: {
       marginTop: theme.spacing.lg,
     },


### PR DESCRIPTION
## Zusammenfassung

Batch 3 der UI/UX-Audit-Serie: **Headers & Navigation Consistency**. Rein
präsentations-/navigationsseitig, kein Backend/Native/Dependency-Change.

- Vier hand-gerollte Detail-/Formular-Header (`jobs/create`, `jobs/[id]/edit`,
  `change-password`, `delete-account`) auf die bestehende `AppHeader`-
  Komponente umgestellt. Vorher gab es 4 verschiedene Zurück-Button-Varianten
  (Icon+Text-Pill, runder 36×36-Chip mit 18px-Icon, Icon-only) — jetzt überall
  derselbe `arrow-back` 22px in einem 44px-Slot, jetzt mit
  `accessibilityLabel="Zurück"`.
- `TimesheetScreen`: Header lag als erstes Kind *in* der scrollbaren
  `ScreenContainer`-Fläche und scrollte weg — einzige `AppHeader`-Nutzung mit
  diesem Verhalten. Umgestellt auf denselben fixen
  `SafeAreaView + AppHeader + ScrollView`-Aufbau wie `JobDetailScreen`/
  `EmployeeDetailScreen`.
- Admin-Profil-Tab hieß `"Profile"` (Englisch), Employee-Tab zeigt
  `"Profil"` — vereinheitlicht.
- `app/_layout.tsx`: `timesheets/index` war nur in der Admin-Guard-Gruppe
  registriert, obwohl `ProfileScreen` bereits einen "Meine Arbeitszeit"-Link
  für Mitarbeitende zeigt (`router.push("/timesheets")`) — die Route war für
  diese Rolle unerreichbar (toter Link). In die gemeinsame `isAuthed`-Gruppe
  verschoben (neben `jobs/[id]/index`, `change-password`).

Bewusst NICHT angefasst: Admin-Kalender, Admin-Dashboard-Redesign,
Urlaub/Krankheit/Sollstunden, Backend/Supabase, Notification-Architektur,
Dead-Code-Cleanup, breites Accessibility-Batch, native Config, neue
Dependencies.

## Header-Inventar (Auszug — vollständig im Session-Report)

- **Root-Tabs** (Übersicht/Jobs/Kalender/Profil, Dashboard/Jobs/Mitarbeiter/
  Profil): unverändert, hand-gerollte Content-Hero-Header sind bewusst
  screen-spezifisch (kein Redesign in diesem Batch).
- **Detail/Form** (Job Detail, Employee Detail, Timesheet, Job erstellen, Job
  bearbeiten, Passwort ändern, Konto löschen): jetzt einheitlich `AppHeader`.
- **5 back-button-Implementierungen gefunden → auf 1 konsolidiert** für alle
  Detail-/Form-Screens (Auth-Screens `forgot-password` etc. bewusst
  ausgeklammert — nicht Teil der Employee-/Admin-Inventarliste dieses
  Batches, eigenes Risiko für einen späteren Batch).
- Admin-Nav (Dashboard/Jobs/Mitarbeiter/Profil, 4 Tabs) ist nicht überladen.
  "Zeitplan" ist bereits ein Segment *innerhalb* des Jobs-Tabs (Segmented
  Control Zeitplan/Daueraufträge) — kein eigener Screen. Empfehlung für
  einen künftigen Admin-Kalender: 5. Tab ergänzen (Dashboard/Jobs/Kalender/
  Mitarbeiter/Profil), nicht bestehenden Tab ersetzen — 4→5 Tabs bleibt in
  einer Standard-Bottom-Tab-Bar komfortabel. Nicht implementiert, nur
  Empfehlung.

## Verifikation

- `npx tsc --noEmit` — clean
- `npm run lint` (`expo lint`) — clean
- Vollständiger Diff manuell geprüft, keine Backend-/Native-/Dependency-
  Änderungen
- `useUnsavedChangesGuard`/`usePreventRemove` in `AdminScreen`/`EditJobScreen`
  unverändert verdrahtet — der Guard greift am Navigations-Dispatch, nicht an
  einem bestimmten Button, daher automatisch auch über den neuen
  `AppHeader`-Zurück-Button abgedeckt.
- Automatisierte Simulator-Verifikation in dieser Session nicht möglich
  (bereits laufende Metro-/Dev-Client-Session ließ sich nicht zuverlässig neu
  verbinden) — bitte manuell über Metro/den unten stehenden Checklist prüfen.

## Manueller Geräte-Testplan

**Employee-Tabs:** Übersicht, Jobs, Kalender, Profil — schneller Tab-Wechsel,
konsistente Titel, kein doppelter Riesen-Titel, Unread-Badge funktioniert.

**Employee Pushed Screens:** Job Detail, Meine Arbeitszeit (jetzt erreichbar!),
Profil-Unterseiten — Zurück-Verhalten korrekt, komfortable Hit-Targets, Dark
Mode.

**Admin Roots:** Dashboard, Jobs, Zeitplan (Segment), Mitarbeiter, Profil —
konsistenter Titel/Header-Abstand.

**Admin Pushed Screens:** Create Job, Edit Job, Employee Detail — Zurück-
Verhalten, Unsaved-Changes-Bestätigung weiterhin aktiv.

**Navigations-Regression:** Übersicht → Jobs → Kalender → Job Detail → Zurück;
Push-Deep-Link → Job Detail; Employee Profil → Meine Arbeitszeit → Zurück
(neu erreichbar, unbedingt testen); Admin Dashboard → Create Job → Zurück;
Edit Job dirty → Zurück → Bestätigungsdialog.

**Performance:** Tab-Wechsel weiterhin flüssig, kein neues Lag durch Header.

**Dark Mode:** alle Header/Actions lesbar, keine hartkodierten Light-Farben.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)