### PR TITLE
feat(admin): Firmenweiter Kalender-Tab

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -63,6 +63,16 @@ export default function AdminTabsLayout() {
       />
 
       <Tabs.Screen
+        name="kalender"
+        options={{
+          title: "Kalender",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="calendar-outline" size={size} color={color} />
+          ),
+        }}
+      />
+
+      <Tabs.Screen
         name="employees"
         options={{
           title: "Mitarbeiter",

--- a/app/(admin-tabs)/kalender.tsx
+++ b/app/(admin-tabs)/kalender.tsx
@@ -1,0 +1,8 @@
+import AdminJobsCalendarScreen from "@/features/jobs/AdminJobsCalendarScreen";
+
+// Admin-Kalender-Tab: firmenweite Monatsübersicht (eigene Datenquelle,
+// eigene Filter). Kein Zusammenhang mit der Mitarbeiter-Kalenderansicht
+// (EmployeeJobsCalendarScreen) — siehe Kommentar im Screen selbst.
+export default function AdminKalenderTab() {
+  return <AdminJobsCalendarScreen />;
+}

--- a/features/jobs/AdminJobsCalendarScreen.tsx
+++ b/features/jobs/AdminJobsCalendarScreen.tsx
@@ -1,0 +1,595 @@
+// features/jobs/AdminJobsCalendarScreen.tsx
+// ─────────────────────────────────────────────────────────────────
+// Admin-Kalender: firmenweite Planungs-Übersicht über einen Monat.
+//
+// Bewusst KEINE Kopie des Mitarbeiter-Kalenders (EmployeeJobsCalendarScreen):
+// dessen Datenquelle (`useJobs().jobs`) ist für Employees RLS-begrenzt auf
+// eigene Aufträge und für Admins ein fixes −30/+60-Tage-Kompatibilitäts-
+// fenster (siehe JobContext) — für eine firmenweite Monatsansicht ungeeignet.
+//
+// Datenquelle hier: `getScheduleOccurrences({ from, to })`, GENAU für den
+// sichtbaren Rasterbereich (inkl. Vor-/Nachlauftage aus Nachbarmonaten),
+// dieselbe Funktion, die bereits AdminScheduleScreen nutzt — kein neuer
+// Backend-Code, keine Migration.
+//
+// Mitarbeiter- UND Status-Filter laufen rein clientseitig auf den bereits
+// geladenen Monatsdaten — ein Umschalten löst NIE einen Request aus, nur der
+// Monatswechsel selbst tut das.
+//
+// Kein eigener Supabase-Realtime-Kanal: JobContext hat bereits GENAU EINEN
+// "jobs"-Kanal, der bei jeder Änderung (und jeder lokalen Admin-Aktion
+// anderswo in der App) `refreshJobs()` aufruft und damit IMMER ein neues
+// `jobs`-Array liefert. Dieser Screen beobachtet dieses Array nur als Signal
+// und lädt NICHT bei jeder Referenzänderung blind neu — er vergleicht erst,
+// ob sich innerhalb des sichtbaren Rasterbereichs überhaupt etwas geändert
+// hat (Status/Datum/Zuweisung), und lädt nur dann nach. Das deckt Änderungen
+// zuverlässig ab, solange der angezeigte Monat das feste JobContext-Fenster
+// überschneidet (der Normalfall: aktueller Monat und Nachbarmonate) — für
+// weiter entfernte Monate bleibt es bei Fokus-/Pull-to-Refresh-Aktualisierung
+// (bewusst dokumentierte Grenze, siehe PR-Beschreibung).
+// ─────────────────────────────────────────────────────────────────
+
+import { ErrorBanner, LoadingScreen } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useJobs } from "@/context/JobContext";
+import { DayAgendaSheet } from "@/features/jobs/components/DayAgendaSheet";
+import {
+  EmployeeFilterControl,
+  employeeSelectionLabel,
+  type EmployeeSelection,
+} from "@/features/jobs/components/EmployeeFilterControl";
+import { MonthGrid } from "@/features/jobs/components/MonthGrid";
+import { MonthYearPickerSheet } from "@/features/jobs/components/MonthYearPickerSheet";
+import {
+  StatusFilterRow,
+  statusSelectionLabel,
+  type StatusSelection,
+} from "@/features/jobs/components/StatusFilterRow";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { getScheduleOccurrences } from "@/services/jobs/jobs.service";
+import type { Job } from "@/types/job";
+import {
+  addMonths,
+  buildDaySummaries,
+  buildMonthMatrix,
+  formatMonthLabel,
+  groupJobsByDateKey,
+  monthKeyOf,
+} from "@/utils/calendarMonth";
+import { formatDateISO } from "@/utils/date";
+import { isAssignedTo, isUnassigned } from "@/utils/jobAssignees";
+import { toUserMessage } from "@/utils/userMessages";
+import { Ionicons } from "@expo/vector-icons";
+import { router, useFocusEffect } from "expo-router";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  RefreshControl,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const EMPTY_JOBS: never[] = [];
+// Deckt die größte bekannte Firma (≈90 Aufträge/60-Tage-Fenster, Stand
+// Prod-Stichprobe) großzügig ab — dient nur als Sicherheitsdeckel, kein
+// erwarteter Regelfall. Wird erreicht → Hinweis statt stiller Untertreibung.
+const OCCURRENCE_LIMIT = 500;
+const REALTIME_ECHO_DEBOUNCE_MS = 300;
+
+export default function AdminJobsCalendarScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const { employees, jobs: contextJobs } = useJobs();
+
+  const todayKey = useMemo(() => formatDateISO(new Date()) ?? "", []);
+  const todayMonthKey = useMemo(() => monthKeyOf(new Date()), []);
+
+  const [monthKey, setMonthKey] = useState(todayMonthKey);
+  const [selectedKey, setSelectedKey] = useState(todayKey);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [employeeSel, setEmployeeSel] = useState<EmployeeSelection>("all");
+  const [statusSel, setStatusSel] = useState<StatusSelection>("all");
+
+  const [rawJobs, setRawJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [possiblyIncomplete, setPossiblyIncomplete] = useState(false);
+
+  const loadInProgressRef = useRef(false);
+
+  // Wie EmployeeJobsCalendarScreen: „von einem Job-Detail zurück" behält den
+  // betrachteten Monat, „von einem anderen Tab" springt auf heute zurück.
+  const cameFromDetailRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (cameFromDetailRef.current) {
+        cameFromDetailRef.current = false;
+        return;
+      }
+      setMonthKey(todayMonthKey);
+      setSelectedKey(todayKey);
+      setSheetOpen(false);
+    }, [todayMonthKey, todayKey]),
+  );
+
+  // ── Datumsbereich des sichtbaren Rasters (inkl. Nachbarmonats-Tage) ──
+  const gridRange = useMemo(() => {
+    const weeks = buildMonthMatrix(monthKey);
+    return {
+      from: weeks[0][0].key,
+      to: weeks[weeks.length - 1][6].key,
+    };
+  }, [monthKey]);
+
+  const load = useCallback(
+    async (isRefresh = false) => {
+      if (loadInProgressRef.current) return;
+      loadInProgressRef.current = true;
+      if (!isRefresh) setLoading(true);
+      setError(null);
+      try {
+        const items = await getScheduleOccurrences({
+          from: gridRange.from,
+          to: gridRange.to,
+          limit: OCCURRENCE_LIMIT,
+        });
+        setRawJobs(items);
+        setPossiblyIncomplete(items.length >= OCCURRENCE_LIMIT);
+      } catch (err: unknown) {
+        setError(toUserMessage(err, "Kalender konnte nicht geladen werden."));
+      } finally {
+        loadInProgressRef.current = false;
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [gridRange],
+  );
+
+  // Lädt bei jedem Monatswechsel neu (gridRange ändert sich → load ändert sich).
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // ── Realtime-Echo: kein eigener Kanal, siehe Dateikopf ──
+  const prevContextJobsRef = useRef<Job[]>([]);
+  const isFirstContextJobsRunRef = useRef(true);
+
+  useEffect(() => {
+    const prev = prevContextJobsRef.current;
+    const curr = contextJobs;
+    prevContextJobsRef.current = curr;
+
+    if (isFirstContextJobsRunRef.current) {
+      isFirstContextJobsRunRef.current = false;
+      return;
+    }
+    if (prev === curr) return;
+
+    // Signatur je Job INNERHALB des sichtbaren Rasterbereichs — nur das kann
+    // die aktuelle Ansicht überhaupt betreffen.
+    const signatureOf = (list: Job[]): Map<string, string> => {
+      const map = new Map<string, string>();
+      for (const job of list) {
+        if (!job.date || job.date < gridRange.from || job.date > gridRange.to) {
+          continue;
+        }
+        const assigneeIds = job.assignees
+          .map((a) => a.employeeId ?? "")
+          .sort()
+          .join(",");
+        map.set(job.id, `${job.status}|${job.date}|${assigneeIds}`);
+      }
+      return map;
+    };
+
+    const prevSig = signatureOf(prev);
+    const currSig = signatureOf(curr);
+
+    let changed = prevSig.size !== currSig.size;
+    if (!changed) {
+      for (const [id, sig] of currSig) {
+        if (prevSig.get(id) !== sig) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) return;
+
+    const timeout = setTimeout(() => {
+      load(true);
+    }, REALTIME_ECHO_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [contextJobs, gridRange, load]);
+
+  // ── Filter: rein clientseitig auf den bereits geladenen Monatsdaten ──
+  const visibleJobs = useMemo(() => {
+    return rawJobs.filter((job) => {
+      if (statusSel !== "all" && job.status !== statusSel) return false;
+      if (employeeSel === "all") return true;
+      if (employeeSel === "unassigned") return isUnassigned(job);
+      return isAssignedTo(job, employeeSel);
+    });
+  }, [rawJobs, employeeSel, statusSel]);
+
+  const jobsByDay = useMemo(() => groupJobsByDateKey(visibleJobs), [visibleJobs]);
+  const summaries = useMemo(() => buildDaySummaries(jobsByDay), [jobsByDay]);
+  const selectedJobs = useMemo(
+    () => jobsByDay.get(selectedKey) ?? EMPTY_JOBS,
+    [jobsByDay, selectedKey],
+  );
+
+  const monthHasJobs = useMemo(() => {
+    for (const key of summaries.keys()) {
+      if (key.startsWith(monthKey)) return true;
+    }
+    return false;
+  }, [summaries, monthKey]);
+
+  const hasActiveFilter = employeeSel !== "all" || statusSel !== "all";
+
+  // Nur aktive Mitarbeiter zur Auswahl — deckungsgleich mit der Vorauswahl in
+  // app/(admin-tabs)/employees.tsx.
+  const activeEmployees = useMemo(
+    () => employees.filter((e) => e.isActive !== false),
+    [employees],
+  );
+
+  const employeeLabel = useMemo(
+    () => employeeSelectionLabel(employeeSel, employees),
+    [employeeSel, employees],
+  );
+  const statusLabel = useMemo(() => statusSelectionLabel(statusSel), [statusSel]);
+
+  // ── Navigation (identisch zum Mitarbeiter-Kalender: kein Swipe) ──
+  const goPrevMonth = useCallback(() => setMonthKey((m) => addMonths(m, -1)), []);
+  const goNextMonth = useCallback(() => setMonthKey((m) => addMonths(m, 1)), []);
+  const goToday = useCallback(() => {
+    setMonthKey(todayMonthKey);
+    setSelectedKey(todayKey);
+  }, [todayMonthKey, todayKey]);
+  const handlePickMonth = useCallback((next: string) => setMonthKey(next), []);
+
+  const handleSelectDay = useCallback(
+    (key: string) => {
+      setSelectedKey(key);
+      const keyMonth = key.slice(0, 7);
+      if (keyMonth !== monthKey) setMonthKey(keyMonth);
+      if ((jobsByDay.get(key)?.length ?? 0) > 0) setSheetOpen(true);
+    },
+    [jobsByDay, monthKey],
+  );
+
+  const handleOpenJob = useCallback((jobId: string) => {
+    cameFromDetailRef.current = true;
+    setSheetOpen(false);
+    router.push(`/jobs/${jobId}`);
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    load(true);
+  }, [load]);
+
+  // Admin führt Aufträge nie selbst aus — canRunJobActions verlangt serverseitig
+  // role='employee', hier also bewusst statt einer echten Prüfung: nie.
+  const canRunActions = useCallback(() => false, []);
+  const noopAction = useCallback(() => {}, []);
+
+  const dayAgendaEmptyMessage = hasActiveFilter
+    ? "Keine Aufträge für diesen Tag mit der aktuellen Filterauswahl."
+    : "Keine Aufträge an diesem Tag.";
+
+  const isOnTodayMonth = monthKey === todayMonthKey;
+
+  if (loading) return <LoadingScreen />;
+
+  return (
+    <SafeAreaView style={styles.safe} edges={["top"]}>
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
+
+      <ScrollView
+        style={styles.flex}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+          />
+        }
+      >
+        {error ? (
+          <ErrorBanner message={error} onDismiss={() => setError(null)} />
+        ) : null}
+
+        {/* ── Kopf: Monat + Jahr, Heute, Blättern ── */}
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.monthTitleBtn}
+            onPress={() => setPickerOpen(true)}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Monat und Jahr auswählen"
+            accessibilityValue={{ text: formatMonthLabel(monthKey) }}
+          >
+            <Text style={styles.monthLabel} numberOfLines={1} maxFontSizeMultiplier={1.4}>
+              {formatMonthLabel(monthKey)}
+            </Text>
+            <Ionicons name="chevron-down" size={16} color={theme.colors.primary} />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.todayBtn, isOnTodayMonth && styles.todayBtnQuiet]}
+            onPress={goToday}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="Zu heute springen"
+          >
+            <Text style={styles.todayBtnText} maxFontSizeMultiplier={1.3}>
+              Heute
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.navBtn}
+            onPress={goPrevMonth}
+            activeOpacity={0.7}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 4 }}
+            accessibilityRole="button"
+            accessibilityLabel="Vorheriger Monat"
+          >
+            <Ionicons name="chevron-back" size={20} color={theme.colors.primary} />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.navBtn}
+            onPress={goNextMonth}
+            activeOpacity={0.7}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Nächster Monat"
+          >
+            <Ionicons name="chevron-forward" size={20} color={theme.colors.primary} />
+          </TouchableOpacity>
+        </View>
+
+        {/* ── Filter: Mitarbeiter-Icon-Button + Status-Chips ── */}
+        <View style={styles.filterRow}>
+          <EmployeeFilterControl
+            value={employeeSel}
+            onChange={setEmployeeSel}
+            employees={activeEmployees}
+          />
+          <View style={styles.statusFilterWrap}>
+            <StatusFilterRow value={statusSel} onChange={setStatusSel} />
+          </View>
+        </View>
+
+        {/* ── Aktive Filter: entfernbare Chips ── */}
+        {hasActiveFilter ? (
+          <View style={styles.activeFilterRow}>
+            {employeeSel !== "all" ? (
+              <View style={styles.activeFilterChip}>
+                <Ionicons name="people" size={13} color={theme.colors.onPrimaryContainer} />
+                <Text style={styles.activeFilterText} numberOfLines={1}>
+                  Mitarbeiter: {employeeLabel}
+                </Text>
+                <TouchableOpacity
+                  onPress={() => setEmployeeSel("all")}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Mitarbeiter-Filter ${employeeLabel} entfernen`}
+                >
+                  <Ionicons name="close" size={14} color={theme.colors.onPrimaryContainer} />
+                </TouchableOpacity>
+              </View>
+            ) : null}
+
+            {statusSel !== "all" ? (
+              <View style={styles.activeFilterChip}>
+                <Ionicons
+                  name="ellipse"
+                  size={9}
+                  color={theme.colors.onPrimaryContainer}
+                />
+                <Text style={styles.activeFilterText} numberOfLines={1}>
+                  Status: {statusLabel}
+                </Text>
+                <TouchableOpacity
+                  onPress={() => setStatusSel("all")}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Status-Filter ${statusLabel} entfernen`}
+                >
+                  <Ionicons name="close" size={14} color={theme.colors.onPrimaryContainer} />
+                </TouchableOpacity>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* ── Monatsraster ── */}
+        <MonthGrid
+          monthKey={monthKey}
+          selectedKey={selectedKey}
+          todayKey={todayKey}
+          summaries={summaries}
+          onSelectDay={handleSelectDay}
+        />
+
+        {!monthHasJobs ? (
+          <Text style={styles.emptyMonthHint} numberOfLines={2}>
+            {hasActiveFilter
+              ? "Keine Aufträge für die aktuelle Filterauswahl in diesem Monat."
+              : "In diesem Monat sind keine Aufträge geplant."}
+          </Text>
+        ) : null}
+
+        {possiblyIncomplete ? (
+          <Text style={styles.capHint} numberOfLines={2}>
+            Sehr viele Aufträge in diesem Monat — Anzeige möglicherweise nicht
+            vollständig.
+          </Text>
+        ) : null}
+      </ScrollView>
+
+      <MonthYearPickerSheet
+        visible={pickerOpen}
+        monthKey={monthKey}
+        onSelect={handlePickMonth}
+        onClose={() => setPickerOpen(false)}
+      />
+
+      <DayAgendaSheet
+        visible={sheetOpen}
+        dayKey={selectedKey}
+        jobs={selectedJobs}
+        onClose={() => setSheetOpen(false)}
+        onOpenJob={handleOpenJob}
+        canRunActions={canRunActions}
+        onStart={noopAction}
+        onComplete={noopAction}
+        showEmployeeName
+        emptyMessage={dayAgendaEmptyMessage}
+      />
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    safe: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    flex: {
+      flex: 1,
+    },
+    scrollContent: {
+      flexGrow: 1,
+      paddingHorizontal: theme.spacing.sm,
+      paddingTop: theme.spacing.md,
+      paddingBottom: theme.spacing.md,
+      gap: theme.spacing.sm,
+    },
+
+    // ── Kopfzeile (identisch zum Mitarbeiter-Kalender)
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.xs,
+      paddingHorizontal: theme.spacing.xs,
+    },
+    monthTitleBtn: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+      paddingVertical: 4,
+    },
+    monthLabel: {
+      flexShrink: 1,
+      fontSize: theme.typography.size.xl,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+      letterSpacing: theme.typography.letterSpacing.tight,
+      textTransform: "capitalize",
+    },
+    todayBtn: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 7,
+      borderRadius: theme.radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.primary,
+    },
+    todayBtnQuiet: {
+      borderColor: theme.colors.outlineVariant,
+    },
+    todayBtnText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.primary,
+    },
+    navBtn: {
+      width: 32,
+      height: 32,
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+    },
+
+    // ── Filterzeile: Mitarbeiter-Button + Status-Chips
+    filterRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.xs,
+    },
+    statusFilterWrap: {
+      flex: 1,
+    },
+
+    // ── Aktive Filter: entfernbare Chips (Muster aus AdminScheduleScreen)
+    activeFilterRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.xs,
+      paddingHorizontal: theme.spacing.xs,
+    },
+    activeFilterChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      maxWidth: "100%",
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 6,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    activeFilterText: {
+      flexShrink: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onPrimaryContainer,
+    },
+
+    emptyMonthHint: {
+      textAlign: "center",
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    capHint: {
+      textAlign: "center",
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      paddingHorizontal: theme.spacing.md,
+    },
+  });
+}

--- a/features/jobs/components/DayAgendaSheet.tsx
+++ b/features/jobs/components/DayAgendaSheet.tsx
@@ -53,6 +53,17 @@ type Props = {
   /** Fehler der letzten Aktion — im Sheet sichtbar, weil er hier entsteht. */
   errorMessage?: string;
   onDismissError?: () => void;
+  /**
+   * Mitarbeiter-Zeile auf jeder Karte zeigen (`JobCard.showEmployeeName`).
+   * Default `false` — die bestehende Mitarbeiter-Ansicht bleibt unverändert.
+   * Für den Admin-Kalender: Admin sieht IMMER, wer zugewiesen ist.
+   */
+  showEmployeeName?: boolean;
+  /**
+   * Text für einen leeren Tag. Default ist der bisherige Mitarbeiter-Text
+   * ("dir keine Aufträge zugewiesen") — unverändert, wenn nicht übergeben.
+   */
+  emptyMessage?: string;
 };
 
 export function DayAgendaSheet({
@@ -66,6 +77,8 @@ export function DayAgendaSheet({
   onComplete,
   errorMessage,
   onDismissError,
+  showEmployeeName = false,
+  emptyMessage = "Für diesen Tag sind dir keine Aufträge zugewiesen.",
 }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -115,9 +128,7 @@ export function DayAgendaSheet({
                 Sheet per Realtime verschwindet — dann hier eine ruhige Zeile
                 statt einer leeren Fläche. */}
             {jobs.length === 0 ? (
-              <Text style={styles.emptyHint}>
-                Für diesen Tag sind dir keine Aufträge zugewiesen.
-              </Text>
+              <Text style={styles.emptyHint}>{emptyMessage}</Text>
             ) : null}
 
             {jobs.map((job) => (
@@ -125,6 +136,7 @@ export function DayAgendaSheet({
                 key={job.id}
                 job={job}
                 onPress={() => onOpenJob(job.id)}
+                showEmployeeName={showEmployeeName}
                 // Start/Abschließen laufen unverändert über den JobContext;
                 // das Gating kommt vom Screen (canRunJobActions).
                 onStart={canRunActions(job) ? () => onStart(job.id) : undefined}

--- a/features/jobs/components/StatusFilterRow.tsx
+++ b/features/jobs/components/StatusFilterRow.tsx
@@ -1,0 +1,151 @@
+// features/jobs/components/StatusFilterRow.tsx
+// ─────────────────────────────────────────────────────────────────
+// Kompakter Status-Filter für den Admin-Kalender: „Alle" + ein Chip je
+// kanonischem Status (Offen / In Arbeit / Erledigt).
+//
+// Reine Präsentation — die Filterung selbst passiert im aufrufenden Screen,
+// rein clientseitig auf den bereits geladenen Monatsdaten. Ein Umschalten
+// hier löst NIE einen Netzwerk-Request aus.
+//
+// Wortlaut und Farben kommen ausschließlich aus utils/jobStatus.ts
+// (JOB_STATUS_ORDER/JOB_STATUS_LABELS/getJobStatusMeta) — keine zweite
+// Status-Tabelle, dieselbe Quelle wie Kalender-Punkte und Job-Karten.
+//
+// Horizontal scrollbar statt umbrechend: bei vier Chips + Mitarbeiter-Icon-
+// Button in einer Zeile bleibt die Zeile so auf jeder Gerätebreite eine Zeile
+// hoch, statt bei schmalen Displays ins Raster hineinzuwachsen.
+// ─────────────────────────────────────────────────────────────────
+
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { JobStatus } from "@/types/job";
+import {
+  JOB_STATUS_LABELS,
+  JOB_STATUS_ORDER,
+  getJobStatusMeta,
+} from "@/utils/jobStatus";
+import React, { useMemo } from "react";
+import { ScrollView, StyleSheet, Text, TouchableOpacity } from "react-native";
+
+export type StatusSelection = "all" | JobStatus;
+
+export const ALL_STATUS_LABEL = "Alle";
+
+/** Lesbares Label der aktuellen Auswahl (für Chip/Accessibility). */
+export function statusSelectionLabel(selection: StatusSelection): string {
+  return selection === "all" ? ALL_STATUS_LABEL : JOB_STATUS_LABELS[selection];
+}
+
+type Props = {
+  value: StatusSelection;
+  onChange: (next: StatusSelection) => void;
+};
+
+export function StatusFilterRow({ value, onChange }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.row}
+    >
+      <Chip
+        label={ALL_STATUS_LABEL}
+        active={value === "all"}
+        onPress={() => onChange("all")}
+        activeBg={theme.colors.primaryContainer}
+        activeBorder={theme.colors.primaryContainer}
+        activeText={theme.colors.onPrimaryContainer}
+        styles={styles}
+      />
+      {JOB_STATUS_ORDER.map((status) => {
+        const meta = getJobStatusMeta(status, theme.colors);
+        return (
+          <Chip
+            key={status}
+            label={meta.label}
+            active={value === status}
+            onPress={() => onChange(status)}
+            activeBg={meta.bg}
+            activeBorder={meta.border}
+            activeText={meta.text}
+            styles={styles}
+          />
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+  activeBg,
+  activeBorder,
+  activeText,
+  styles,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  activeBg: string;
+  activeBorder: string;
+  activeText: string;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.chip,
+        active && { backgroundColor: activeBg, borderColor: activeBorder },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={`Status-Filter: ${label}`}
+    >
+      <Text
+        style={[
+          styles.chipText,
+          active && styles.chipTextActive,
+          active && { color: activeText },
+        ]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.xs,
+    },
+    chip: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 7,
+      borderRadius: theme.radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    chipText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+    chipTextActive: {
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Neuer eigenständiger Admin-Tab **Kalender** (`Dashboard | Jobs | Kalender | Mitarbeiter | Profil`) mit firmenweiter Monatsübersicht: Job-Anzahl-Pille + Status-Punkte pro Tag, Mitarbeiter- und Status-Filter, Tages-Agenda mit sichtbarer Mitarbeiter-Zuweisung.
- Datenquelle: `getScheduleOccurrences({ from, to })` (bereits vorhandene, monatsbezogene Query von `AdminScheduleScreen`), begrenzt exakt auf den sichtbaren Rasterbereich — **kein** Rückgriff auf das feste ±30/60-Tage-`JobContext`-Fenster, **keine** Backend-/Migrations-Änderung.
- Mitarbeiter- **und** Status-Filter laufen rein clientseitig auf den bereits geladenen Monatsdaten (kein Request pro Umschalten).
- Kein neuer Supabase-Realtime-Kanal: der Screen beobachtet `JobContext`s bereits bestehenden `jobs`-Kanal und lädt nur bei einer echten, den sichtbaren Bereich betreffenden Änderung nach (Diff-Guard, 300ms debounced).
- Wiederverwendet unverändert: `MonthGrid`, `CalendarDayCell`, `MonthYearPickerSheet`, `EmployeeFilterControl`, `utils/calendarMonth.ts`, `utils/jobStatus.ts`, `utils/jobAssignees.ts`.
- `DayAgendaSheet` bekommt zwei additive, default-erhaltende Props (`showEmployeeName`, `emptyMessage`) — der bestehende Mitarbeiter-Kalender (`EmployeeJobsCalendarScreen`) ist dadurch unverändert.

## Data-source decision
`JobContext.jobs` ist für Admins ein dokumentierter Kompatibilitäts-Cache (±30/60 Tage, `limit 500`) und laut eigenem Kommentar bewusst NICHT für reichhaltige Ansichten gedacht. Stattdessen ruft der neue Screen dieselbe `getScheduleOccurrences()`-Funktion wie `AdminScheduleScreen` auf, mit `from`/`to` = genau dem sichtbaren Rasterbereich (`buildMonthMatrix`). Verifiziert gegen Prod (read-only): max. 7 Aufträge an einem Tag firmenweit, größte Firma ≈ 84–90 Aufträge/60-Tage-Fenster — der `limit: 500`-Deckel ist großzügig, wird aber erkannt und mit Hinweistext versehen, falls er je erreicht wird.

## Bekannte, bewusste Grenzen (nicht in diesem PR behoben)
- **Realtime-Abdeckung**: der Diff-Guard erkennt Änderungen zuverlässig, solange der angezeigte Monat das `JobContext`-Fenster (±30/60 Tage) überschneidet. Für weiter entfernte Monate bleibt es bei Fokus-/Pull-to-Refresh statt Live-Update — bewusst keine zusätzliche Infrastruktur für diesen Randfall.
- **Recurring-Materialisierungshorizont** (vorbestehend): Occurrences werden serverseitig nur ~3 Monate im Voraus generiert und nur bei Regel-Bearbeitung neu materialisiert (kein Cron). Weit in der Zukunft liegende, lange nicht bearbeitete Regeln können Lücken zeigen.
- **Workload-Heatmap**: kein verlässlicher Schwellenwert in den Daten vorhanden — bewusst nur die Zähl-Pille, keine erfundene Ampel-Logik.

## Test plan
- [x] `npx tsc --noEmit` — sauber
- [x] `npm run lint` — sauber (exit 0)
- [x] `npx expo export --platform web` — vollständiger Build ohne Fehler, `/(admin-tabs)/kalender` als generierte Route bestätigt
- [x] Diff-Audit: nur 5 App-Layer-Dateien geändert, keine `supabase/migrations`, keine Edge Functions, keine `package.json`/Lockfile-, `app.json`/`eas.json`-Änderungen
- [ ] **Manueller Geräte-Check erforderlich** (siehe PR-Kommentar/Chat-Report): Login-basierte UI-Verifikation (Tab-Leiste bei 5 Tabs auf schmalen Android-Breiten, Filter/Agenda/Dark-Mode end-to-end, Regressionscheck Mitarbeiter-Kalender + Zeitplan) konnte in dieser Session nicht durchgeführt werden — Login-Eingabe ist eine harte Grenze für den Agenten, unabhängig von Autorisierung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)