### PR TITLE
feat(timesheets): Stundenzettel auf individuelle Mitarbeiter-Arbeitszeit umstellen (Phase 2)

### DIFF
--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -2,9 +2,29 @@
 // Stundenzettel-Operationen: Laden der abgeschlossenen Jobs eines Mitarbeiters
 // für einen Monat sowie PDF-Export (expo-print) + Teilen (expo-sharing).
 //
-// Quelle ist ausschließlich die jobs-Tabelle — keine eigene Timesheet-Tabelle,
-// keine RPC. Lesezugriff ist durch die RLS-Policy "admin read jobs in own company"
-// abgesichert (Admin sieht nur Jobs der eigenen Firma).
+// Quelle ist job_assignments (Phase 2, Worked Time) — keine eigene
+// Timesheet-Tabelle, keine RPC. Lesezugriff ist durch die RLS-Policies
+// "admin read assignments in own company" bzw.
+// "employee read assignments on assigned jobs" abgesichert (siehe
+// supabase/migrations/20260727000000_job_assignments_rls.sql).
+//
+// WARUM job_assignments STATT jobs (Phase 2, vorher jobs.started_at/
+// completed_at — die GETEILTE Job-Uhr):
+// Bei mehreren Zugewiesenen ist die geteilte Uhr für den Stundenzettel nicht
+// mehr aussagekräftig — Ahmad und Maria hätten beide dieselbe Auftragsdauer,
+// obwohl sie unterschiedlich lange vor Ort waren. Seit Phase 1 (Migration
+// 20260812000000) pflegen start_own_job/complete_own_job zusätzlich die
+// EIGENE Zuweisungszeile jedes Mitarbeiters (employee_started_at/
+// employee_completed_at). Der Stundenzettel liest jetzt genau diese Werte.
+//
+// RÜCKWÄRTSKOMPATIBILITÄT: Zuweisungszeilen aus der Zeit VOR Phase 1 haben
+// employee_started_at/employee_completed_at = null (die Spalten existierten
+// zwar schon seit Migration 20260725000000, wurden aber von keinem Code
+// beschrieben). Ein Eintrag ohne beide Werte fällt pro Zeile auf die
+// GETEILTE Job-Uhr (jobs.started_at/completed_at) zurück — siehe mapEntry
+// unten. Damit bleiben historische Stundenzettel korrekt (keine 0-Stunden-
+// Einträge) und neue Mehrfachzuweisungen bekommen trotzdem ihre eigene,
+// individuelle Dauer.
 
 import { supabase } from "@/lib/supabase";
 import { buildTimesheetHtml } from "@/services/timesheets/timesheetHtml";
@@ -18,29 +38,28 @@ import {
 import * as Print from "expo-print";
 import * as Sharing from "expo-sharing";
 
-// So sehen die für den Stundenzettel benötigten Job-Spalten aus der DB aus.
-type TimesheetJobRow = {
-  id: string;
-  customer_name: string;
-  service_name: string;
-  location_address: string;
-  started_at: string;
-  completed_at: string;
+// So sieht eine für den Stundenzettel benötigte job_assignments-Zeile
+// (inkl. eingebettetem Job `j`) aus der DB aus. `j` ist `!inner`, filtert
+// also selbst mit (siehe JOB_EMBED) — pro Zuweisung gibt es dank
+// `unique (job_id, employee_id)` (Migration 20260725000000) höchstens eine
+// Zeile, ein Auftrag erscheint damit weiterhin nie doppelt.
+type TimesheetAssignmentRow = {
+  employee_started_at: string | null;
+  employee_completed_at: string | null;
+  j: {
+    id: string;
+    customer_name: string;
+    service_name: string;
+    location_address: string;
+    started_at: string;
+    completed_at: string;
+  };
 };
 
-// Zusätzlicher Embed, der AUSSCHLIESSLICH als Filter-Prädikat dient:
-// „nur Aufträge, denen dieser Mitarbeiter zugewiesen ist".
-//
-// Identisches Muster wie ASSIGNEE_FILTER_EMBED in services/jobs/jobs.service.ts
-// (dort als duplikatfrei verifiziert). Der Alias `f` verhindert eine Kollision
-// mit anderen Embeds und macht sichtbar, dass die Menge nie GELESEN wird.
-//
-// KEINE DUPLIKATE: Der Filter unten bindet `f.employee_id` auf GENAU EINEN
-// Mitarbeiter, und job_assignments trägt die Bedingung
-// `unique (job_id, employee_id)` (Migration 20260725000000). Pro Auftrag kann
-// also höchstens EINE Zuweisungszeile matchen — ein Auftrag erscheint damit
-// niemals doppelt im Stundenzettel, auch nicht bei mehreren Zugewiesenen.
-const ASSIGNEE_FILTER_EMBED = `,f:job_assignments!inner(employee_id)`;
+// Eingebetteter Job, aliasiert als `j`: trägt sowohl die Anzeige-Spalten
+// (Kunde/Service/Ort) als auch die GETEILTE Job-Uhr für den Fallback.
+// `!inner` macht `j`-Filter unten (status/job_type/started_at-Bereich) wirksam.
+const JOB_EMBED = `,j:jobs!inner(id,customer_name,service_name,location_address,started_at,completed_at)`;
 
 // Baut die Bemerkung aus Service + Ort: "Fensterreinigung · Hauptstr. 1".
 function buildRemark(service: string | null, location: string | null): string {
@@ -50,57 +69,84 @@ function buildRemark(service: string | null, location: string | null): string {
   return parts.join(" · ");
 }
 
-// Wandelt eine DB-Zeile in einen Stundenzettel-Eintrag um.
-// Der Arbeitstag wird lokal aus started_at abgeleitet (timestamptz ist UTC).
-function mapEntry(row: TimesheetJobRow): TimesheetEntry {
-  const startedAt = new Date(row.started_at);
-  const durationMinutes = diffInMinutes(row.started_at, row.completed_at);
+// Wandelt eine job_assignments-Zeile in einen Stundenzettel-Eintrag um.
+//
+// QUELLE PRO ZEILE: individuelle Zeit (employee_started_at/completed_at),
+// wenn BEIDE gesetzt sind — sonst Fallback auf die geteilte Job-Uhr
+// (j.started_at/completed_at). Kein Mischen einzelner Werte (z.B. eigener
+// Start + geteiltes Ende): entweder das vollständige eigene Paar oder das
+// vollständige geteilte Paar, nie eine Kombination aus beiden.
+//
+// Der Arbeitstag wird lokal aus dem jeweils verwendeten Start abgeleitet
+// (timestamptz ist UTC).
+function mapEntry(row: TimesheetAssignmentRow): TimesheetEntry {
+  const hasOwnTimes = !!row.employee_started_at && !!row.employee_completed_at;
+  const startIso = hasOwnTimes ? row.employee_started_at! : row.j.started_at;
+  const endIso = hasOwnTimes ? row.employee_completed_at! : row.j.completed_at;
+
+  const startedAt = new Date(startIso);
+  const durationMinutes = diffInMinutes(startIso, endIso);
 
   return {
-    jobId: row.id,
-    date: formatDateISO(startedAt) ?? row.started_at.slice(0, 10),
+    jobId: row.j.id,
+    date: formatDateISO(startedAt) ?? startIso.slice(0, 10),
     beginLabel: formatTimeHHmm(startedAt) ?? "--:--",
-    endLabel: formatTimeHHmm(new Date(row.completed_at)) ?? "--:--",
+    endLabel: formatTimeHHmm(new Date(endIso)) ?? "--:--",
     durationMinutes,
     durationLabel: formatDurationHm(durationMinutes),
-    customerName: row.customer_name,
-    remark: buildRemark(row.service_name, row.location_address),
+    customerName: row.j.customer_name,
+    remark: buildRemark(row.j.service_name, row.j.location_address),
   };
 }
 
 /**
- * Lädt die abgeschlossenen Jobs eines Mitarbeiters für einen Monat und baut
- * daraus den vollständigen Stundenzettel.
+ * Lädt die abgeschlossenen Zuweisungen eines Mitarbeiters für einen Monat
+ * und baut daraus den vollständigen Stundenzettel.
  *
- * Filter:
- *  - Mitarbeiter ist dem Auftrag ZUGEWIESEN (job_assignments.employee_id),
- *    NICHT mehr der Legacy-Zeiger jobs.assigned_to — siehe Begründung unten
- *  - status = 'completed'
- *  - started_at / completed_at vorhanden
- *  - job_type = 'single' (schließt Recurring-Parent-Regeln aus; konkrete
+ * Filter (alle serverseitig, keine Client-seitige Filterung großer Mengen):
+ *  - job_assignments.employee_id = der gewählte Mitarbeiter — indiziert über
+ *    idx_job_assignments_employee (employee_id, job_id), Migration
+ *    20260725000000. Kein neuer Index nötig.
+ *  - j.status = 'completed'
+ *  - j.job_type = 'single' (schließt Recurring-Parent-Regeln aus; konkrete
  *    Occurrences sind selbst 'single')
- *  - Arbeitstag (started_at, lokal) im gewählten Monat
+ *  - j.started_at / j.completed_at vorhanden
+ *  - Arbeitstag (j.started_at, lokal) im gewählten Monat — bewusst weiterhin
+ *    über die GETEILTE Job-Uhr eingegrenzt, nicht über employee_started_at:
+ *    ein Datumsbereich über zwei mögliche Spalten (eigene ODER geteilte Zeit)
+ *    ließe sich nicht als einzelner Index-Scan ausdrücken, und j.started_at
+ *    ist für jeden Eintrag in diesem Filter ohnehin vorhanden (siehe oben).
+ *    In der ganz seltenen Randlage, in der ein Mitarbeiter über Mitternacht
+ *    hinweg arbeitet, kann der individuelle Kalendertag (unten aus
+ *    employee_started_at abgeleitet) dadurch theoretisch einen Tag vom
+ *    Monatsfilter abweichen — für ein Reinigungs-Business ohne Nachtschicht-
+ *    Betrieb kein relevanter Fall.
  *
- * WARUM NICHT MEHR jobs.assigned_to:
+ * DAUER PRO ZEILE (Phase 2, Worked Time): siehe mapEntry — individuelle Zeit
+ * (employee_started_at/employee_completed_at), sonst Fallback auf die
+ * geteilte Job-Uhr (j.started_at/completed_at). Sortierung nach dem so
+ * gewählten Start passiert client-seitig NACH dem Laden (die Datenmenge ist
+ * durch die obigen Filter bereits auf einen Mitarbeiter-Monat begrenzt,
+ * keine Firmen-weite Menge).
+ *
+ * WARUM NICHT jobs.assigned_to:
  * Seit der Mehrfachzuweisung (Phase 6A) kann ein Auftrag mehreren Mitarbeitern
  * gehören. jobs.assigned_to kann aber nur EINEN tragen; welcher das ist,
  * bestimmt compat_primary_assignee() und ist bei gleichzeitig angelegten
  * Zuweisungen ARBITRÄR (gleicher assigned_at → Tiebreak über die zufällige
- * UUID `id`, siehe Migration 20260726000000). Der alte Filter schloss damit
- * alle übrigen Zugewiesenen aus dem Stundenzettel aus — sie wurden für
- * geleistete Arbeit nicht erfasst.
+ * UUID `id`, siehe Migration 20260726000000).
  *
- * WARUM (NOCH) NICHT counts_for_timesheet:
- * Die Spalte ist als künftige Berechtigungsquelle vorgesehen, wird aber
- * derzeit von NICHTS gepflegt: set_job_assignments legt Zeilen mit dem
- * Default attendance='assigned' an, und start_own_job/complete_own_job fassen
- * job_assignments überhaupt nicht an (Phase 7 offen). counts_for_timesheet ist
- * für neu angelegte Zuweisungen deshalb dauerhaft false — ein Filter darauf
- * lieferte heute LEERE Stundenzettel. Der Umstieg gehört zu Phase 7/9, wenn
- * attendance serverseitig gesetzt wird.
+ * WARUM WEITERHIN NICHT counts_for_timesheet:
+ * Seit Phase 1 (Migration 20260812000000) pflegen die Start/Complete-RPCs
+ * zwar attendance, counts_for_timesheet bleibt aber eine reine
+ * Abrechnungs-BERECHTIGUNG (Manager-Review, künftige Phase) — kein Signal
+ * dafür, WELCHE Zeitquelle anzuzeigen ist. Ein Filter darauf würde exakt die
+ * Zeilen ausblenden, die hier den Fallback brauchen (attendance='assigned',
+ * z. B. historische Zeilen vor Phase 1 oder ein Kollege, der nie selbst
+ * Start gedrückt hat) — bewusst weiterhin ungefiltert gelassen.
  *
  * Bewusst NICHT gefiltert wird zusätzlich nach:
- *  - attendance / review  → siehe oben, werden aktuell nicht gepflegt
+ *  - attendance / review  → siehe oben
  *  - profiles.is_active   → historische Stundenzettel müssen auch für
  *                           inzwischen deaktivierte Mitarbeiter abrufbar
  *                           bleiben (Abrechnung/Nachweis)
@@ -123,35 +169,32 @@ export async function getTimesheet(params: {
   const nextMonthStart = new Date(year, month, 1, 0, 0, 0, 0);
 
   const { data, error } = await supabase
-    .from("jobs")
-    .select(
-      `
-      id,
-      customer_name,
-      service_name,
-      location_address,
-      started_at,
-      completed_at
-      ` + ASSIGNEE_FILTER_EMBED,
-    )
-    .eq("f.employee_id", employeeId)
-    .eq("status", "completed")
-    .eq("job_type", "single")
-    .not("started_at", "is", null)
-    .not("completed_at", "is", null)
-    .gte("started_at", monthStart.toISOString())
-    .lt("started_at", nextMonthStart.toISOString())
-    .order("started_at", { ascending: true });
+    .from("job_assignments")
+    .select(`employee_started_at,employee_completed_at` + JOB_EMBED)
+    .eq("employee_id", employeeId)
+    .eq("j.status", "completed")
+    .eq("j.job_type", "single")
+    .not("j.started_at", "is", null)
+    .not("j.completed_at", "is", null)
+    .gte("j.started_at", monthStart.toISOString())
+    .lt("j.started_at", nextMonthStart.toISOString());
 
   if (error) {
     throw error;
   }
 
-  // Der Filter-Embed `f` ist Teil der Zeile, wird aber nie gelesen — gleiche
-  // Cast-Konvention wie bei den gebundenen Abfragen in jobs.service.ts.
-  const entries = (data ?? []).map((row) =>
-    mapEntry(row as unknown as TimesheetJobRow),
-  );
+  // Client-seitige Sortierung nach der individuellen Zeitquelle (siehe
+  // Dokumentation oben) — "YYYY-MM-DD" + "HH:mm" ist lexikographisch
+  // chronologisch sortierbar.
+  const entries = (data ?? [])
+    .map((row) => mapEntry(row as unknown as TimesheetAssignmentRow))
+    .sort((a, b) =>
+      a.date + a.beginLabel < b.date + b.beginLabel
+        ? -1
+        : a.date + a.beginLabel > b.date + b.beginLabel
+          ? 1
+          : 0,
+    );
   const totalMinutes = entries.reduce((sum, e) => sum + e.durationMinutes, 0);
 
   const monthLabel = monthStart.toLocaleDateString("de-DE", {

--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -17,14 +17,25 @@
 // EIGENE Zuweisungszeile jedes Mitarbeiters (employee_started_at/
 // employee_completed_at). Der Stundenzettel liest jetzt genau diese Werte.
 //
-// RÜCKWÄRTSKOMPATIBILITÄT: Zuweisungszeilen aus der Zeit VOR Phase 1 haben
+// RÜCKWÄRTSKOMPATIBILITÄT — VERSCHÄRFT NACH KORREKTUR (siehe mapEntry/
+// PHASE1_CUTOFF_ISO unten): Zuweisungszeilen aus der Zeit VOR Phase 1 haben
 // employee_started_at/employee_completed_at = null (die Spalten existierten
 // zwar schon seit Migration 20260725000000, wurden aber von keinem Code
-// beschrieben). Ein Eintrag ohne beide Werte fällt pro Zeile auf die
-// GETEILTE Job-Uhr (jobs.started_at/completed_at) zurück — siehe mapEntry
-// unten. Damit bleiben historische Stundenzettel korrekt (keine 0-Stunden-
-// Einträge) und neue Mehrfachzuweisungen bekommen trotzdem ihre eigene,
-// individuelle Dauer.
+// beschrieben) — für SOLCHE Jobs ist der Fallback auf die geteilte Job-Uhr
+// (jobs.started_at/completed_at) weiterhin richtig, weil es schlicht keine
+// andere Datenquelle gibt.
+//
+// Für Jobs, die ERST NACH Phase 1 abgeschlossen wurden, ist ein fehlendes
+// eigenes Zeitpaar dagegen KEINE Datenlücke, sondern eine Tatsachenaussage:
+// start_own_job/complete_own_job schreiben employee_started_at/
+// employee_completed_at seit Phase 1 bei JEDEM erfolgreichen Aufruf (siehe
+// Migration 20260812000000) — fehlt der Wert trotzdem, hat dieser Mitarbeiter
+// den betreffenden Übergang schlicht nie selbst ausgelöst (z. B. bei einem
+// Mehrfach-Auftrag: ein Kollege hat gestartet/abgeschlossen, DIESER
+// Mitarbeiter nie). Auf die geteilte Uhr zurückzufallen würde ihm in diesem
+// Fall fälschlich die volle Auftragsdauer als bezahlte Arbeitszeit gutschreiben
+// — genau das darf nicht passieren. Solche Zeilen werden deshalb NICHT
+// angezeigt (kein 0:00-Eintrag, kein Fallback), siehe mapEntry.
 
 import { supabase } from "@/lib/supabase";
 import { buildTimesheetHtml } from "@/services/timesheets/timesheetHtml";
@@ -61,6 +72,41 @@ type TimesheetAssignmentRow = {
 // `!inner` macht `j`-Filter unten (status/job_type/started_at-Bereich) wirksam.
 const JOB_EMBED = `,j:jobs!inner(id,customer_name,service_name,location_address,started_at,completed_at)`;
 
+// ── Legacy-Cutoff (Korrektur nach PR-#88-Review) ──────────────────────────
+// Entspricht der Versionskennung von Migration 20260812000000
+// (employee_worked_time_foundation, "Phase 1") — dem Zeitpunkt, ab dem
+// start_own_job/complete_own_job employee_started_at/employee_completed_at
+// überhaupt zum ersten Mal schreiben KÖNNEN. Diese Migration wurde bewusst
+// so geschrieben, dass ihr eigener Dateiname bereits der maßgebliche
+// Zeitstempel ist (Repo-Konvention: alle Migrationen dieses Projekts
+// verwenden `YYYYMMDDHHmmss_beschreibung.sql`), ein zusätzlicher DB-Marker
+// (neue Spalte/Tabelle) ist für diese eine Konstante nicht nötig.
+//
+// GEPRÜFT GEGEN jobs.completed_at, NICHT gegen employee_started_at/
+// completed_at selbst UND NICHT gegen "jetzt": jobs.completed_at ist der
+// tatsächliche Zeitpunkt, zu dem der ECHTE complete_own_job-Aufruf für
+// GENAU DIESEN Auftrag lief (der Parameter completed_at_input wird 1:1 in
+// beide Spalten geschrieben, siehe Migration 20260812000000) — er sagt damit
+// zuverlässig aus, ob für diesen Auftrag bereits die NEUE RPC-Fassung aktiv
+// war, unabhängig davon, wann der Stundenzettel später abgefragt wird.
+//
+// DEPLOYMENT-VORAUSSETZUNG (wichtig, siehe PR-Beschreibung): diese Regel
+// setzt voraus, dass Migration 20260812000000 in JEDER Umgebung VOR bzw.
+// spätestens GLEICHZEITIG mit diesem Code angewendet wird. Ist die Migration
+// in einer Umgebung noch nicht angewendet (z. B. Produktion vor dem
+// manuellen SQL-Editor-Schritt, siehe CLAUDE.md), sind employee_started_at/
+// employee_completed_at dort für ALLE Zeilen null — nach Regel 3 unten
+// würden dann auch Aufträge, die nach diesem Zeitpunkt real abgeschlossen
+// wurden, ohne Eintrag bleiben, bis die Migration nachgezogen ist. Die
+// Migration muss deshalb vor dem Rollout dieses PRs angewendet werden.
+const PHASE1_CUTOFF_ISO = "2026-08-12T00:00:00.000Z";
+
+// true, wenn dieser Auftrag VOR Phase 1 abgeschlossen wurde — nur für solche
+// Aufträge ist der Fallback auf die geteilte Job-Uhr laut Regel 2 erlaubt.
+function isLegacyJob(jobCompletedAtIso: string): boolean {
+  return new Date(jobCompletedAtIso).getTime() < Date.parse(PHASE1_CUTOFF_ISO);
+}
+
 // Baut die Bemerkung aus Service + Ort: "Fensterreinigung · Hauptstr. 1".
 function buildRemark(service: string | null, location: string | null): string {
   const parts = [service?.trim(), location?.trim()].filter(
@@ -69,20 +115,41 @@ function buildRemark(service: string | null, location: string | null): string {
   return parts.join(" · ");
 }
 
-// Wandelt eine job_assignments-Zeile in einen Stundenzettel-Eintrag um.
+// Wandelt eine job_assignments-Zeile in einen Stundenzettel-Eintrag um, oder
+// in `null`, wenn für diesen Mitarbeiter/Auftrag KEINE belastbare Dauer
+// existiert (siehe Regel 3 im Kopf-Kommentar).
 //
-// QUELLE PRO ZEILE: individuelle Zeit (employee_started_at/completed_at),
-// wenn BEIDE gesetzt sind — sonst Fallback auf die geteilte Job-Uhr
-// (j.started_at/completed_at). Kein Mischen einzelner Werte (z.B. eigener
-// Start + geteiltes Ende): entweder das vollständige eigene Paar oder das
-// vollständige geteilte Paar, nie eine Kombination aus beiden.
+// QUELLE PRO ZEILE, in dieser Reihenfolge:
+//   1. Eigene Zeit (employee_started_at/completed_at), wenn BEIDE gesetzt
+//      sind — unabhängig vom Cutoff. Kein Mischen einzelner Werte (z.B.
+//      eigener Start + geteiltes Ende): entweder das vollständige eigene
+//      Paar oder das vollständige geteilte Paar, nie eine Kombination.
+//   2. Fehlt das eigene Paar UND der Auftrag wurde VOR Phase 1 abgeschlossen
+//      (isLegacyJob): Fallback auf die geteilte Job-Uhr — die einzige
+//      damals verfügbare Datenquelle.
+//   3. Fehlt das eigene Paar bei einem Auftrag NACH Phase 1: KEIN Eintrag.
+//      Ein fehlender eigener Zeitstempel ist hier eine Tatsachenaussage
+//      ("dieser Mitarbeiter hat den Übergang nie selbst ausgelöst"), kein
+//      Datenloch — die geteilte Dauer eines Kollegen darf ihm nicht
+//      stillschweigend als eigene bezahlte Arbeitszeit gutgeschrieben werden.
 //
 // Der Arbeitstag wird lokal aus dem jeweils verwendeten Start abgeleitet
 // (timestamptz ist UTC).
-function mapEntry(row: TimesheetAssignmentRow): TimesheetEntry {
+function mapEntry(row: TimesheetAssignmentRow): TimesheetEntry | null {
   const hasOwnTimes = !!row.employee_started_at && !!row.employee_completed_at;
-  const startIso = hasOwnTimes ? row.employee_started_at! : row.j.started_at;
-  const endIso = hasOwnTimes ? row.employee_completed_at! : row.j.completed_at;
+
+  let startIso: string;
+  let endIso: string;
+
+  if (hasOwnTimes) {
+    startIso = row.employee_started_at!;
+    endIso = row.employee_completed_at!;
+  } else if (isLegacyJob(row.j.completed_at)) {
+    startIso = row.j.started_at;
+    endIso = row.j.completed_at;
+  } else {
+    return null;
+  }
 
   const startedAt = new Date(startIso);
   const durationMinutes = diffInMinutes(startIso, endIso);
@@ -122,12 +189,16 @@ function mapEntry(row: TimesheetAssignmentRow): TimesheetEntry {
  *    Monatsfilter abweichen — für ein Reinigungs-Business ohne Nachtschicht-
  *    Betrieb kein relevanter Fall.
  *
- * DAUER PRO ZEILE (Phase 2, Worked Time): siehe mapEntry — individuelle Zeit
- * (employee_started_at/employee_completed_at), sonst Fallback auf die
- * geteilte Job-Uhr (j.started_at/completed_at). Sortierung nach dem so
- * gewählten Start passiert client-seitig NACH dem Laden (die Datenmenge ist
- * durch die obigen Filter bereits auf einen Mitarbeiter-Monat begrenzt,
- * keine Firmen-weite Menge).
+ * DAUER PRO ZEILE (Phase 2, Worked Time, siehe mapEntry + PHASE1_CUTOFF_ISO):
+ * individuelle Zeit (employee_started_at/employee_completed_at), wenn BEIDE
+ * gesetzt sind; sonst Fallback auf die geteilte Job-Uhr NUR bei Aufträgen,
+ * die vor Phase 1 abgeschlossen wurden; bei Aufträgen NACH Phase 1 ohne
+ * eigenes Zeitpaar entsteht KEIN Eintrag (mapEntry gibt null zurück, wird
+ * unten herausgefiltert) — die geteilte Dauer wird niemandem stillschweigend
+ * gutgeschrieben, der den Übergang nicht selbst ausgelöst hat. Sortierung
+ * nach dem so gewählten Start passiert client-seitig NACH dem Laden (die
+ * Datenmenge ist durch die obigen Filter bereits auf einen Mitarbeiter-Monat
+ * begrenzt, keine Firmen-weite Menge).
  *
  * WARUM NICHT jobs.assigned_to:
  * Seit der Mehrfachzuweisung (Phase 6A) kann ein Auftrag mehreren Mitarbeitern
@@ -183,11 +254,13 @@ export async function getTimesheet(params: {
     throw error;
   }
 
-  // Client-seitige Sortierung nach der individuellen Zeitquelle (siehe
-  // Dokumentation oben) — "YYYY-MM-DD" + "HH:mm" ist lexikographisch
-  // chronologisch sortierbar.
+  // mapEntry liefert null für Zeilen ohne belastbare Dauer (Regel 3, siehe
+  // oben) — diese werden hier herausgefiltert, nicht als 0:00-Zeile gezeigt.
+  // Client-seitige Sortierung nach der individuellen Zeitquelle —
+  // "YYYY-MM-DD" + "HH:mm" ist lexikographisch chronologisch sortierbar.
   const entries = (data ?? [])
     .map((row) => mapEntry(row as unknown as TimesheetAssignmentRow))
+    .filter((entry): entry is TimesheetEntry => entry !== null)
     .sort((a, b) =>
       a.date + a.beginLabel < b.date + b.beginLabel
         ? -1


### PR DESCRIPTION
## ⚠️ Release Checklist — required before deploying this PR

- [ ] **Apply production migration `supabase/migrations/20260812000000_employee_worked_time_foundation.sql` (Phase 1) BEFORE or IN THE SAME release as this PR.** Verified via `supabase migration list --linked` (project `ivzsbspopudqgobunsdv`) as of this writing: **not yet applied to production** (only applied to Staging `legzogskvcmicdgowyax`, 2026-08-12). Apply manually in the Supabase SQL Editor per the CLAUDE.md convention for this repo.
- **Why this matters:** this PR's fallback logic (see "Fallback correction" below) treats any job completed on/after 2026-08-12T00:00:00Z as "Phase 1 should have recorded per-employee timestamps for it." If the app ships this PR while production is still on the pre-Phase-1 RPCs, `job_assignments.employee_started_at/completed_at` stay null for everyone, and every job completed after that date will show **no timesheet entry** for **any** employee until the migration is applied — not a 0-hour bug, but a full outage of the Timesheet feature for that period.
- **Correct order:** migration `20260812000000` → then this PR's app code. Reversing that order (or shipping both in the same deploy where the migration runs after the app update reaches users) creates the gap above.

## Summary

Phase 2 of Employee Work Tracking: makes the Timesheet use real per-employee worked time (`job_assignments.employee_started_at/employee_completed_at`, written since Phase 1 / PR #87) instead of the shared job clock (`jobs.started_at/completed_at`).

- `getTimesheet` now queries `job_assignments` (joined to `jobs` via `!inner` for the display columns and the shared-clock fallback), filtered by `employee_id`, `status='completed'`, `job_type='single'`, and the month range — all server-side, same filter shape as before, just against the new base table.
- **Per-row duration rule (revised after review — see "Fallback correction" below):**
  1. If **both** `employee_started_at` and `employee_completed_at` exist → use the individual duration.
  2. If either/both are missing **and** the job was completed **before** Phase 1 (`jobs.completed_at < 2026-08-12T00:00:00.000Z`, the Phase 1 migration's own version timestamp) → fall back to the shared job clock — the only data that existed at the time.
  3. If either/both are missing on a job completed **after** Phase 1 → **no entry at all** (not a 0:00 row, not the shared duration). A missing own timestamp on a post-Phase-1 job is a fact ("this employee never triggered that transition themselves"), not a data gap — crediting the shared clock in that case would silently pay someone for a colleague's work.
- Multi-employee example from the original spec verified exactly: shared clock 08:00–10:00, Ahmad 08:10–09:00 → 50 min, Maria 08:30–10:00 → 90 min. Sum is 140 min, not 240 (no double-counting the shared clock).
- `TimesheetEntry`/`TimesheetData` (types) and `timesheetHtml.ts` (PDF) are **unchanged** — they only consume the already-shaped entry list, so PDF export, admin employee-selection, monthly filtering, and the employee/admin screens all work unmodified.

## Fallback correction (post-initial-review fix)

The first version of this PR fell back to the shared job clock **unconditionally** whenever an employee's own timestamps were missing — including on jobs completed *after* Phase 1 went live. On a multi-assignee job where only one employee actually pressed Start/Complete, every *other* assignee (who never touched the job) would have been silently credited with the full shared job duration as paid worked time. This was caught in review before merge and fixed by adding the Phase-1-cutoff rule above. See commit `0265c75` for the fix; no migration or supporting schema change was needed — `jobs.completed_at` (the real timestamp of the actual `complete_own_job` call for that specific job) compared against the Phase 1 migration's own version identifier is a fully deterministic marker already present in existing data.

**Deployment prerequisite:** this rule assumes migration `20260812000000_employee_worked_time_foundation.sql` (Phase 1) is applied to every environment no later than this code is released there. If Phase 1 hasn't been applied to an environment yet (as of this writing, **not yet applied to production** — only Staging), `employee_started_at`/`employee_completed_at` will be null for everyone in that environment, and per rule 3 any job completed after the 2026-08-12 cutoff date will show no timesheet entry there until the migration is applied. **Production must get the Phase 1 migration before or together with this PR's release.**

## What was explicitly NOT done (out of scope for this PR)
- No changes to `start_own_job`/`complete_own_job`, job status logic, or `job_assignments` write path.
- No overlap detection, no planned duration, no Calendar changes.
- No RLS/policy/permission changes — read access is exactly the same two pre-existing policies (`admin read assignments in own company`, `employee read assignments on assigned jobs`) that already governed `job_assignments` since Phase 3 (`20260727000000`).
- No new tables, no new migration (pure query/service change), no new index — `idx_job_assignments_employee (employee_id, job_id)` (Migration `20260725000000`) already covers the `employee_id` filter.
- No UI changes — component tree, labels, PDF layout untouched.

## Files changed
- `services/timesheets/timesheet.service.ts` only.

## Staging verification

**Original query/mapping (4/4 pass):** Ahmad's individual duration = 50 min, Maria's = 90 min (not the shared 120 min for either), legacy row without employee timestamps falls back correctly (45 min, never 0), sum across employees = 140 min not 240.

**Fallback-cutoff fix (5/5 pass, cases A–E from review request):**
- **A** — legacy job (completed before cutoff), no own timestamps → fallback still applies (80 min) — PASS
- **B** — post-cutoff job, employee never started (both timestamps null) → **no entry**, not the shared duration — PASS
- **C** — post-cutoff job, employee started but never completed themselves (colleague completed the shared job) → **no entry** — PASS
- **D** — post-cutoff job, employee has a complete own pair → own duration (55 min) — PASS
- **E** — same post-cutoff job as D, a second employee with a *different* complete own pair → own duration (90 min), independent of D's 55 min — PASS

All runs transactional (`BEGIN…ROLLBACK`) against Staging with throwaway fixtures; zero residue confirmed after each run.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Staging SQL verification — 4/4 original cases + 5/5 fallback-cutoff cases, all pass
- [ ] Manual app smoke test on a dev/staging build (screens, PDF export) — recommended before merge
- [ ] **Confirm Phase 1 migration (`20260812000000`) is applied to production before/with this release**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
