### PR TITLE
feat(jobs): Grundlage für geplante Auftragsdauer (Phase 3)

### DIFF
--- a/context/JobContext.tsx
+++ b/context/JobContext.tsx
@@ -70,6 +70,7 @@ type JobContextType = {
     isActive?: boolean;
     recurrenceStartDate?: string | null;
     recurrenceEndDate?: string | null;
+    plannedDurationMinutes?: number | null;
   }) => Promise<void>;
   deleteJob: (jobId: string) => Promise<void>;
   startJob: (jobId: string) => Promise<void>;

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -150,6 +150,14 @@ export default function AdminScreen() {
     try {
       setSubmitting(true);
 
+      // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
+      // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
+      const parsedDuration = parseInt(values.durationMinutes, 10);
+      const plannedDurationMinutes =
+        Number.isFinite(parsedDuration) && parsedDuration > 0
+          ? parsedDuration
+          : null;
+
       // Gemeinsame Basis
       const base = {
         customerName: values.customerName.trim(),
@@ -157,6 +165,7 @@ export default function AdminScreen() {
         service: values.service.trim(),
         employeeIds: values.employeeIds,
         notes: values.notes.trim() || null,
+        plannedDurationMinutes,
       };
 
       // Terminierung je nach Auftragstyp aufbauen

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -192,6 +192,10 @@ export default function EditJobScreen() {
       recurrenceEndDate: job.recurrenceEndDate
         ? new Date(job.recurrenceEndDate)
         : null,
+      durationMinutes:
+        job.plannedDurationMinutes != null
+          ? String(job.plannedDurationMinutes)
+          : "",
     });
 
     setErrors({});
@@ -200,6 +204,11 @@ export default function EditJobScreen() {
   const hasChanges = useMemo(() => {
     if (!job) return false;
 
+    const originalDurationMinutes =
+      job.plannedDurationMinutes != null
+        ? String(job.plannedDurationMinutes)
+        : "";
+
     // Basisfelder
     const basicsChanged =
       values.customerName !== job.customerName ||
@@ -207,7 +216,8 @@ export default function EditJobScreen() {
       values.service !== job.service ||
       !sameIdSet(values.employeeIds, assignedEmployeeIds) ||
       values.notes !== (job.notes ?? "") ||
-      values.jobType !== (job.jobType ?? "single");
+      values.jobType !== (job.jobType ?? "single") ||
+      values.durationMinutes !== originalDurationMinutes;
 
     if (basicsChanged) return true;
 
@@ -297,6 +307,14 @@ export default function EditJobScreen() {
         activeEmployeeIds.has(id),
       );
 
+      // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
+      // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
+      const parsedDuration = parseInt(values.durationMinutes, 10);
+      const plannedDurationMinutes =
+        Number.isFinite(parsedDuration) && parsedDuration > 0
+          ? parsedDuration
+          : null;
+
       const base = {
         jobId: job.id,
         customerName: values.customerName.trim(),
@@ -304,6 +322,7 @@ export default function EditJobScreen() {
         service: values.service.trim(),
         employeeIds: submittableEmployeeIds,
         notes: values.notes.trim() || null,
+        plannedDurationMinutes,
       };
 
       await updateJob(

--- a/features/jobs/components/JobFormFields.tsx
+++ b/features/jobs/components/JobFormFields.tsx
@@ -209,6 +209,16 @@ export function JobFormFields({
         </View>
       )}
 
+      <Input
+        label="Geplante Dauer in Minuten (optional)"
+        placeholder="z. B. 90"
+        keyboardType="number-pad"
+        value={values.durationMinutes}
+        onChangeText={(val) =>
+          onChangeField("durationMinutes", val.replace(/[^0-9]/g, ""))
+        }
+      />
+
       {showEmployeePicker ? (
         <>
           <Text style={styles.sectionLabel}>Mitarbeiter (optional)</Text>

--- a/features/jobs/components/JobScheduleCard.tsx
+++ b/features/jobs/components/JobScheduleCard.tsx
@@ -1,6 +1,6 @@
 // features/jobs/components/JobScheduleCard.tsx
 // Terminierungs-Details eines AUSFÜHRBAREN Termins: geplanter Start und —
-// falls gesetzt — das geplante Ende.
+// falls eine Dauer geplant ist — geplante Dauer + daraus abgeleitetes Ende.
 //
 // Parent-Regeln laufen seit der eigenen Regel-Ansicht
 // (RecurringRuleDetailScreen → RuleScheduleSummary) nicht mehr durch diese
@@ -9,23 +9,30 @@
 // die Herkunft steht jetzt EINMAL und antippbar im Screen
 // (OccurrenceOriginLink) statt zweimal als toter Text.
 //
+// Das geplante Ende kommt seit Phase 3 (Planned Duration Foundation) aus
+// startTime + plannedDurationMinutes (getPlannedEndTime) — NICHT aus
+// scheduledEnd, das von keinem Schreibpfad befüllt wird (siehe CLAUDE.md).
+//
 // Reine Anzeige, keine geänderte Terminierungs-Logik, keine neue Abfrage.
 
 import { Card, InfoRow } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { Job } from "@/types/job";
-import { formatDateTimeDE } from "@/utils/date";
+import { formatDateTimeDE, formatDurationLong } from "@/utils/date";
+import { getPlannedEndTime } from "@/utils/jobSchedule";
 import React, { useMemo } from "react";
 import { StyleSheet, View } from "react-native";
 
 type Props = {
-  job: Pick<Job, "scheduledStart" | "scheduledEnd">;
+  job: Pick<Job, "scheduledStart" | "startTime" | "plannedDurationMinutes">;
 };
 
 export function JobScheduleCard({ job }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const plannedEnd = getPlannedEndTime(job);
 
   return (
     <Card padding={theme.spacing.lg} style={styles.card}>
@@ -36,12 +43,22 @@ export function JobScheduleCard({ job }: Props) {
         value={formatDateTimeDE(job.scheduledStart) ?? "Kein Termin geplant"}
         icon="calendar-outline"
       />
-      {job.scheduledEnd ? (
+      {job.plannedDurationMinutes ? (
+        <>
+          <View style={styles.rowDivider} />
+          <InfoRow
+            label="Geplante Dauer"
+            value={formatDurationLong(job.plannedDurationMinutes)}
+            icon="time-outline"
+          />
+        </>
+      ) : null}
+      {plannedEnd ? (
         <>
           <View style={styles.rowDivider} />
           <InfoRow
             label="Geplantes Ende"
-            value={formatDateTimeDE(job.scheduledEnd) ?? "—"}
+            value={plannedEnd}
             icon="calendar-outline"
           />
         </>

--- a/features/jobs/hooks/useJobForm.ts
+++ b/features/jobs/hooks/useJobForm.ts
@@ -23,6 +23,10 @@ export type JobFormValues = {
     // recurring: Gültigkeitszeitraum (Startdatum Pflicht, Enddatum optional)
     recurrenceStartDate: Date | null;
     recurrenceEndDate:   Date | null;
+    // Geplante Dauer in Minuten, optional (Phase 3 Planned Duration).
+    // Als Rohtext gehalten wie andere Input-Felder; nur Ziffern (siehe
+    // JobFormFields onChangeText), leer = keine Dauer geplant.
+    durationMinutes: string;
 };
 
 export type JobFormErrors = Partial<Record<keyof JobFormValues, string>>;
@@ -40,6 +44,7 @@ const emptyValues: JobFormValues = {
     isActive: true,
     recurrenceStartDate: null,
     recurrenceEndDate: null,
+    durationMinutes: "",
 };
 
 export function useJobForm(initialValues?: Partial<JobFormValues>) {
@@ -80,7 +85,8 @@ export function useJobForm(initialValues?: Partial<JobFormValues>) {
             values.recurrenceStartDate?.getTime() !==
                 base.recurrenceStartDate?.getTime() ||
             values.recurrenceEndDate?.getTime() !==
-                base.recurrenceEndDate?.getTime()
+                base.recurrenceEndDate?.getTime() ||
+            values.durationMinutes !== base.durationMinutes
         );
     }, [values]);
 

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -104,6 +104,11 @@ create table if not exists public.jobs (
   start_time time,
   recurring_days text[],
   is_active boolean not null default true,
+  -- Optionale geplante Dauer in Minuten (Phase 3 Planned Duration,
+  -- 20260813000000). NULL = keine Dauer geplant (Bestand). Zusammen mit
+  -- start_time die EINZIGE Quelle der geplanten Terminierung —
+  -- scheduled_end wird hierfür bewusst NICHT verwendet.
+  planned_duration_minutes integer,
   -- ── Recurring-Job-Materialisierung ──
   -- Gesetzt wenn dieser Job eine generierte Occurrence eines Recurring-Parents ist.
   -- NULL bei normalen Single-Jobs und bei Recurring-Parent-Regeln selbst.
@@ -129,6 +134,7 @@ alter table public.jobs add column if not exists is_active boolean not null defa
 alter table public.jobs add column if not exists parent_job_id uuid references public.jobs(id) on delete cascade;
 alter table public.jobs add column if not exists recurrence_start_date date;
 alter table public.jobs add column if not exists recurrence_end_date   date;
+alter table public.jobs add column if not exists planned_duration_minutes integer;
 
 -- Constraint: Enddatum darf nicht vor Startdatum liegen (NULL-Werte ausgenommen).
 alter table public.jobs
@@ -139,6 +145,13 @@ alter table public.jobs
     or recurrence_start_date is null
     or recurrence_end_date >= recurrence_start_date
   );
+
+-- Constraint: geplante Dauer, wenn gesetzt, muss positiv sein.
+alter table public.jobs
+  drop constraint if exists chk_jobs_planned_duration_positive;
+alter table public.jobs
+  add constraint chk_jobs_planned_duration_positive
+  check (planned_duration_minutes is null or planned_duration_minutes > 0);
 
 -- Job-Kommentare (append-only): Mitarbeiter schreiben kurze Nachrichten zu
 -- ihren Jobs, Admins lesen (und schreiben optional) firmenweit.
@@ -1832,12 +1845,13 @@ begin
       insert into public.jobs (
         company_id, parent_job_id, customer_name, service_name,
         location_address, notes, status, assigned_to,
-        job_type, date, start_time, scheduled_start, is_active, created_by
+        job_type, date, start_time, planned_duration_minutes,
+        scheduled_start, is_active, created_by
       )
       values (
         parent.company_id, parent.id, parent.customer_name, parent.service_name,
         parent.location_address, parent.notes, 'open', effective_assigned_to,
-        'single', check_date, parent.start_time,
+        'single', check_date, parent.start_time, parent.planned_duration_minutes,
         case
           when parent.start_time is not null
           then (check_date::text || ' ' || parent.start_time::text)::timestamptz

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -66,6 +66,7 @@ type JobRow = {
   parent_job_id: string | null;
   recurrence_start_date: string | null;
   recurrence_end_date: string | null;
+  planned_duration_minutes: number | null;
   profiles?:
   | {
     id: string;
@@ -111,6 +112,7 @@ type UpdateJobInput = {
   isActive?: boolean;
   recurrenceStartDate?: string | null;
   recurrenceEndDate?: string | null;
+  plannedDurationMinutes?: number | null;
 };
 
 // Validiert & normalisiert die Terminierungs-Felder serverseitig
@@ -259,6 +261,7 @@ const JOB_SELECT = `
   parent_job_id,
   recurrence_start_date,
   recurrence_end_date,
+  planned_duration_minutes,
   assigned_to,
   profiles:assigned_to (
     id,
@@ -420,6 +423,9 @@ function mapJob(row: JobRow): Job {
     isOccurrence: row.parent_job_id != null,
     recurrenceStartDate: row.recurrence_start_date ?? null,
     recurrenceEndDate: row.recurrence_end_date ?? null,
+
+    // Geplante Dauer (Phase 3, Planned Duration Foundation).
+    plannedDurationMinutes: row.planned_duration_minutes ?? null,
   };
 }
 
@@ -614,6 +620,7 @@ export async function createJob(input: CreateJobInput): Promise<CreateJobResult>
     // damit Detail-/Monats-Anzeigen weiter funktionieren; recurring → null.
     scheduled_start: input.scheduledStart ?? null,
     scheduled_end: input.scheduledEnd ?? null,
+    planned_duration_minutes: input.plannedDurationMinutes ?? null,
     notes: input.notes?.trim() ? input.notes.trim() : null,
     status: "open" as const,
     ...schedule,
@@ -856,6 +863,7 @@ export async function updateJob(input: UpdateJobInput): Promise<Job> {
     scheduled_start: string | null;
     notes: string | null;
     scheduled_end?: string | null;
+    planned_duration_minutes: number | null;
     job_type: JobType;
     date: string | null;
     start_time: string | null;
@@ -869,6 +877,9 @@ export async function updateJob(input: UpdateJobInput): Promise<Job> {
     // single: aus date+time abgeleiteter ISO-Wert; recurring: null
     scheduled_start: input.scheduledStart ?? null,
     notes: input.notes?.trim() ? input.notes.trim() : null,
+    // Anders als scheduled_end wird dies vom Formular IMMER mitgeschickt
+    // (siehe useJobForm/JobFormFields) — kein "nur wenn explizit" nötig.
+    planned_duration_minutes: input.plannedDurationMinutes ?? null,
     ...schedule,
   };
 

--- a/supabase/migrations/20260813000000_planned_duration_foundation.sql
+++ b/supabase/migrations/20260813000000_planned_duration_foundation.sql
@@ -1,0 +1,306 @@
+-- =========================================================
+-- MIGRATION: Planned Duration — Grundlage (Phase 3)
+-- Datum: 2026-08-13
+-- =========================================================
+-- ZWECK
+--   jobs traegt bislang keine geplante Dauer — nur einen geplanten Start
+--   (date/start_time). jobs.scheduled_end existiert als Spalte, wird aber
+--   von KEINEM Schreibpfad befuellt (siehe Architektur-Audit); diese
+--   Migration nutzt sie NICHT und aendert nichts an ihr.
+--
+--   Neu: jobs.planned_duration_minutes (nullable). Zusammen mit dem
+--   bereits vorhandenen start_time bleibt "Start + Dauer" die EINZIGE
+--   Quelle der geplanten Terminierung — kein zweiter, potenziell
+--   abweichender Zeitstempel wie scheduled_end.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   * Keine Overlap-Erkennung (weder geplant noch tatsaechlich).
+--   * Keine Pflichtfeld-Validierung — planned_duration_minutes ist und
+--     bleibt optional; bestehende Jobs funktionieren unveraendert mit
+--     NULL weiter.
+--   * Keine Aenderung an jobs.scheduled_end, an dessen Schreib- oder
+--     Lesepfaden.
+--   * Keine Aenderung an Autorisierung/RLS.
+--
+-- PROPAGATION AUF OCCURRENCES
+--   generate_job_occurrences kopiert planned_duration_minutes von der
+--   Parent-Regel auf jede neu erzeugte Occurrence — exakt wie start_time.
+--   update_job_occurrences behandelt es wie die uebrigen Inhaltsfelder
+--   (customer_name, service_name, location_address, notes, is_active) im
+--   SYNC-Schritt: nicht individuell angepasste, zukuenftige, offene
+--   Termine erhalten die neue Dauer der Regel. NICHT wie start_time im
+--   PRUNE-Schritt behandelt — eine Dauer-Aenderung allein macht einen
+--   Termin nicht "nicht mehr zur Regel passend" (anders als ein Wochentag-
+--   oder Uhrzeit-Wechsel, der den Termin selbst verschiebt).
+--
+-- IDEMPOTENZ
+--   Spalte via ADD COLUMN IF NOT EXISTS, Constraint via DROP + ADD,
+--   Funktionen via CREATE OR REPLACE (identische Signaturen) — vollstaendig
+--   wiederholbar.
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgefuehrt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Spalte
+-- ---------------------------------------------------------
+alter table public.jobs
+  add column if not exists planned_duration_minutes integer;
+
+alter table public.jobs
+  drop constraint if exists chk_jobs_planned_duration_positive;
+
+alter table public.jobs
+  add constraint chk_jobs_planned_duration_positive
+  check (planned_duration_minutes is null or planned_duration_minutes > 0);
+
+comment on column public.jobs.planned_duration_minutes is
+'Optionale geplante Dauer in Minuten. NULL = keine Dauer geplant (Bestand). '
+'Zusammen mit start_time die EINZIGE Quelle der geplanten Terminierung — '
+'scheduled_end wird hierfuer bewusst NICHT verwendet (siehe Migrationskopf). '
+'Bei recurring-Parent-Regeln die Dauer je Occurrence, propagiert ueber '
+'generate_job_occurrences/update_job_occurrences.';
+
+
+-- ---------------------------------------------------------
+-- 2. generate_job_occurrences: Dauer mit erzeugen
+-- ---------------------------------------------------------
+-- Unveraendert gegenueber 20260728000000_occurrence_assignment_inheritance.sql
+-- bis auf die zusaetzliche Spalte planned_duration_minutes im INSERT
+-- (kopiert von der Parent-Regel, exakt wie start_time).
+create or replace function public.generate_job_occurrences(
+  parent_job_id_input uuid
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  parent                public.jobs%rowtype;
+  generation_start      date;
+  generation_end        date;
+  hard_limit            date;
+  check_date            date;
+  day_code              text;
+  inserted_count        int := 0;
+  rows_affected         int;
+  effective_assigned_to uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can generate occurrences';
+  end if;
+
+  select * into parent
+  from public.jobs
+  where id          = parent_job_id_input
+    and company_id  = public.current_user_company_id()
+    and job_type    = 'recurring'
+    and parent_job_id is null;
+
+  if not found then
+    raise exception 'Recurring parent job not found or not accessible';
+  end if;
+
+  select case
+    when parent.assigned_to is not null
+      and exists (
+        select 1 from public.profiles p
+        where p.id = parent.assigned_to
+          and p.is_active = true
+      )
+    then parent.assigned_to
+    else null
+  end
+  into effective_assigned_to;
+
+  generation_start := greatest(
+    coalesce(parent.recurrence_start_date, current_date),
+    current_date
+  );
+
+  hard_limit := generation_start + interval '730 days';
+
+  generation_end := least(
+    case
+      when parent.recurrence_end_date is not null
+        then parent.recurrence_end_date
+      else generation_start + interval '3 months'
+    end,
+    hard_limit
+  );
+
+  check_date := generation_start;
+  while check_date <= generation_end loop
+
+    day_code := case extract(isodow from check_date)::int
+      when 1 then 'mon'
+      when 2 then 'tue'
+      when 3 then 'wed'
+      when 4 then 'thu'
+      when 5 then 'fri'
+      when 6 then 'sat'
+      when 7 then 'sun'
+    end;
+
+    if parent.recurring_days @> array[day_code] then
+      insert into public.jobs (
+        company_id, parent_job_id, customer_name, service_name,
+        location_address, notes, status, assigned_to,
+        job_type, date, start_time, planned_duration_minutes,
+        scheduled_start, is_active, created_by
+      )
+      values (
+        parent.company_id, parent.id, parent.customer_name, parent.service_name,
+        parent.location_address, parent.notes, 'open', effective_assigned_to,
+        'single', check_date, parent.start_time, parent.planned_duration_minutes,
+        case
+          when parent.start_time is not null
+          then (check_date::text || ' ' || parent.start_time::text)::timestamptz
+          else null
+        end,
+        parent.is_active, parent.created_by
+      )
+      on conflict (parent_job_id, date, start_time)
+        where parent_job_id is not null
+      do nothing;
+
+      get diagnostics rows_affected = row_count;
+      inserted_count := inserted_count + rows_affected;
+    end if;
+
+    check_date := check_date + 1;
+  end loop;
+
+  -- Vollstaendige Zuweisungsmenge der Regel auf die nicht angepassten
+  -- Termine uebertragen (unveraendert seit Phase 4).
+  perform public.inherit_occurrence_assignments(parent_job_id_input);
+
+  return inserted_count;
+end;
+$$;
+
+grant execute on function public.generate_job_occurrences(uuid) to authenticated;
+
+comment on function public.generate_job_occurrences(uuid) is
+'Erzeugt konkrete Single-Jobs aus einer Recurring-Regel. Zeitraum aus '
+'recurrence_start/end_date, hartes Maximum 730 Tage, idempotent. Weist keine '
+'Occurrence einem inaktiven Mitarbeiter zu. Kopiert planned_duration_minutes '
+'von der Regel auf jede erzeugte Occurrence (Phase 3 Planned Duration, '
+'20260813000000). Uebertraegt die vollstaendige Zuweisungsmenge der Regel '
+'auf nicht angepasste Termine.';
+
+
+-- ---------------------------------------------------------
+-- 3. update_job_occurrences: Dauer im SYNC-Schritt mitfuehren
+-- ---------------------------------------------------------
+-- Unveraendert gegenueber 20260728000000_occurrence_assignment_inheritance.sql
+-- bis auf planned_duration_minutes im SYNC-UPDATE (Behandlung wie
+-- customer_name/notes — ein Inhaltsfeld, kein PRUNE-Kriterium wie
+-- start_time, siehe Migrationskopf).
+create or replace function public.update_job_occurrences(
+  parent_job_id_input uuid
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  parent    public.jobs%rowtype;
+  new_count int;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can update occurrences';
+  end if;
+
+  select * into parent
+  from public.jobs
+  where id         = parent_job_id_input
+    and company_id = public.current_user_company_id()
+    and job_type   = 'recurring'
+    and parent_job_id is null
+  for update;
+
+  if not found then
+    raise exception 'Recurring parent job not found';
+  end if;
+
+  -- ── 1) PRUNE ── unveraendert.
+  delete from public.jobs c
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and not exists (select 1 from public.job_comments      x where x.job_id = c.id)
+    and not exists (select 1 from public.job_photos        x where x.job_id = c.id)
+    and not exists (select 1 from public.job_comment_reads x where x.job_id = c.id)
+    and (
+          not (parent.recurring_days @> array[
+            case extract(isodow from c.date)::int
+              when 1 then 'mon' when 2 then 'tue' when 3 then 'wed'
+              when 4 then 'thu' when 5 then 'fri' when 6 then 'sat'
+              when 7 then 'sun'
+            end
+          ])
+          or c.start_time is distinct from parent.start_time
+          or (parent.recurrence_end_date   is not null and c.date > parent.recurrence_end_date)
+          or (parent.recurrence_start_date is not null and c.date < parent.recurrence_start_date)
+        );
+
+  -- ── 2) SYNC (OHNE assigned_to) ── planned_duration_minutes NEU dabei,
+  -- behandelt wie die uebrigen Inhaltsfelder.
+  update public.jobs c
+  set
+    customer_name             = parent.customer_name,
+    service_name              = parent.service_name,
+    location_address          = parent.location_address,
+    notes                     = parent.notes,
+    is_active                 = parent.is_active,
+    planned_duration_minutes  = parent.planned_duration_minutes
+  where c.parent_job_id = parent_job_id_input
+    and c.date >= current_date
+    and c.status = 'open'
+    and c.started_at is null
+    and c.completed_at is null
+    and (
+         c.customer_name             is distinct from parent.customer_name
+      or c.service_name              is distinct from parent.service_name
+      or c.location_address          is distinct from parent.location_address
+      or c.notes                     is distinct from parent.notes
+      or c.is_active                 is distinct from parent.is_active
+      or c.planned_duration_minutes  is distinct from parent.planned_duration_minutes
+    );
+
+  -- ── 3) GENERATE (inkl. Mengenabgleich) ── unveraendert.
+  select public.generate_job_occurrences(parent_job_id_input)
+  into new_count;
+
+  return new_count;
+end;
+$$;
+
+grant execute on function public.update_job_occurrences(uuid) to authenticated;
+
+comment on function public.update_job_occurrences(uuid) is
+'Nicht-destruktiv: prunt nur unberuehrte, nicht mehr passende Zukunfts-Termine, '
+'synct Inhaltsfelder (customer_name/service_name/location_address/notes/'
+'is_active/planned_duration_minutes, OHNE assigned_to) und gleicht die '
+'Zuweisungsmenge nicht angepasster Termine an die Regel an. Individuell '
+'angepasste Termine behalten ihre Zuweisungen. Bewahrt in_progress/completed, '
+'Zeitstempel, Kommentare und Fotos. planned_duration_minutes-Aenderungen '
+'loesen KEIN Prunen aus (Phase 3 Planned Duration, 20260813000000) — anders '
+'als start_time verschieben sie den Termin selbst nicht.';

--- a/supabase/tests/planned_duration_foundation.test.sql
+++ b/supabase/tests/planned_duration_foundation.test.sql
@@ -1,0 +1,285 @@
+-- =========================================================
+-- TEST: Planned Duration Foundation
+-- (Migration 20260813000000_planned_duration_foundation)
+-- =========================================================
+-- Weist nach:
+--   * jobs.planned_duration_minutes ist nullable (Bestand funktioniert
+--     unveraendert mit NULL weiter).
+--   * chk_jobs_planned_duration_positive lehnt 0/negative Werte ab, laesst
+--     NULL und positive Werte zu.
+--   * generate_job_occurrences kopiert die Dauer der Parent-Regel auf
+--     jede neu erzeugte Occurrence.
+--   * update_job_occurrences synct eine geaenderte Dauer auf nicht
+--     individuell angepasste, offene Zukunfts-Occurrences (wie
+--     customer_name), OHNE sie zu prunen (anders als start_time) und
+--     OHNE geschuetzte Occurrences (mit Anhaengen/Historie) anzufassen.
+--
+-- Aufrufe laufen als 'authenticated' Admin (SET ROLE + request.jwt.claims),
+-- also ueber denselben Pfad wie services/jobs/jobs.service.ts.
+--
+-- AUSFUEHREN lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/planned_duration_foundation.test.sql
+-- Legt Testdaten an, macht am Ende ROLLBACK — KEINE Rueckstaende, KEINE
+-- Produktionsdaten.
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma C = c1…1 | Admin C = c2…1 | Mitarbeiter C = c2…2
+
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000001','authenticated','authenticated','pd-adminC@example.test','{"full_name":"Admin C"}'),
+    ('00000000-0000-0000-0000-000000000000','c2000000-0000-0000-0000-000000000002','authenticated','authenticated','pd-empC@example.test','{"full_name":"Mitarbeiter C"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('c2000000-0000-0000-0000-000000000001','Admin C'),
+  ('c2000000-0000-0000-0000-000000000002','Mitarbeiter C')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('c1000000-0000-0000-0000-000000000001','PD Firma C','pd-firma-c-test');
+
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='admin',    is_active=true where id='c2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='c1000000-0000-0000-0000-000000000001', role='employee', is_active=true where id='c2000000-0000-0000-0000-000000000002';
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub', uid::text, 'role','authenticated')::text, true);
+end $f$;
+
+create temporary table _pd_results (
+  case_no int, beschreibung text, erwartet text, ergebnis text
+) on commit drop;
+
+
+-- =========================================================
+-- CASE 1: Spalte nullable — ein normaler Single-Job ohne Dauer bleibt gueltig.
+-- =========================================================
+insert into public.jobs
+  (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+   status, job_type, date, start_time, is_active)
+values
+  ('c4000000-0000-0000-0000-000000000001','c1000000-0000-0000-0000-000000000001',
+   'c2000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000002',
+   'Bestandskunde','Grundreinigung','Bestandsweg 1','open','single', current_date + 1, '10:00', true);
+
+insert into _pd_results
+select 1, 'Job ohne planned_duration_minutes bleibt gueltig (NULL)', 'NULL',
+  case when (select planned_duration_minutes from public.jobs where id='c4000000-0000-0000-0000-000000000001') is null
+       then 'NULL' else 'GESETZT' end;
+
+
+-- =========================================================
+-- CASE 2: CHECK-Constraint lehnt 0/negative Werte ab.
+-- =========================================================
+do $$
+declare
+  rejected boolean := false;
+begin
+  begin
+    insert into public.jobs
+      (id, company_id, created_by, customer_name, service_name, location_address,
+       status, job_type, date, start_time, is_active, planned_duration_minutes)
+    values
+      ('c4000000-0000-0000-0000-000000000099','c1000000-0000-0000-0000-000000000001',
+       'c2000000-0000-0000-0000-000000000001','Ungueltig','Test','Testweg 0',
+       'open','single', current_date + 1, '10:00', true, 0);
+  exception when check_violation then
+    rejected := true;
+  end;
+
+  insert into _pd_results values
+    (2, 'CHECK-Constraint lehnt planned_duration_minutes=0 ab', 'REJECTED',
+     case when rejected then 'REJECTED' else 'AKZEPTIERT' end);
+end $$;
+
+-- CASE 3: positiver Wert wird akzeptiert.
+insert into public.jobs
+  (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+   status, job_type, date, start_time, is_active, planned_duration_minutes)
+values
+  ('c4000000-0000-0000-0000-000000000002','c1000000-0000-0000-0000-000000000001',
+   'c2000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000002',
+   'Dauerkunde','Fensterreinigung','Dauerweg 2','open','single', current_date + 1, '11:00', true, 90);
+
+insert into _pd_results
+select 3, 'Positiver planned_duration_minutes-Wert wird akzeptiert', '90',
+  coalesce((select planned_duration_minutes::text from public.jobs where id='c4000000-0000-0000-0000-000000000002'), 'NULL');
+
+
+-- =========================================================
+-- FIXTURE: Recurring-Regel R (Dauer 60 Min), ein Wochentag = heute+7.
+-- =========================================================
+do $$
+declare
+  d_future1 date := current_date + 7;
+  d_future2 date := current_date + 14;
+  wd_f1 text;
+begin
+  wd_f1 := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_future1)::int + 1];
+
+  insert into public.jobs
+    (id, company_id, created_by, assigned_to, customer_name, service_name, location_address,
+     status, job_type, recurring_days, start_time, planned_duration_minutes, is_active,
+     recurrence_start_date, recurrence_end_date)
+  values
+    ('c3000000-0000-0000-0000-000000000001','c1000000-0000-0000-0000-000000000001',
+     'c2000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000002',
+     'Regelkunde','Unterhaltsreinigung','Regelweg 1',
+     'open','recurring', array[wd_f1]::text[], '08:00', 60, true,
+     current_date - 1, current_date + 60);
+end $$;
+
+
+-- =========================================================
+-- CASE 4: generate_job_occurrences kopiert die Dauer der Regel auf jede
+-- erzeugte Occurrence.
+-- =========================================================
+do $$
+declare ret int;
+begin
+  perform pg_temp.act_as('c2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.generate_job_occurrences('c3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+end $$;
+
+insert into _pd_results
+select 4, 'Neu erzeugte Occurrences erben planned_duration_minutes=60', 'OK',
+  case when exists (
+    select 1 from public.jobs
+    where parent_job_id='c3000000-0000-0000-0000-000000000001'
+  ) and not exists (
+    select 1 from public.jobs
+    where parent_job_id='c3000000-0000-0000-0000-000000000001'
+      and planned_duration_minutes is distinct from 60
+  ) then 'OK' else 'FALSCH' end;
+
+
+-- =========================================================
+-- FIXTURE: eine zukuenftige, offene, unberuehrte Occurrence (a) und eine
+-- geschuetzte (mit Kommentar) Occurrence (b) — beide manuell ergaenzt, um
+-- den SYNC-Schritt gezielt zu pruefen (unabhaengig von generate's eigenen
+-- Occurrences oben, die denselben Wochentag/Uhrzeit teilen wuerden).
+-- =========================================================
+do $$
+declare
+  -- +10/+17 Tage: bewusst KEIN Vielfaches von 7 gegenueber d_future1
+  -- (heute+7) versetzt, damit ihr Wochentag nicht mit den bereits von
+  -- generate_job_occurrences erzeugten woechentlichen Terminen kollidiert
+  -- (sonst verletzt der Insert unten idx_jobs_occurrence_unique).
+  d_free      date := current_date + 10;
+  d_protected date := current_date + 17;
+  wd_free text;
+begin
+  wd_free := (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from d_free)::int + 1];
+  update public.jobs set recurring_days = array[
+    (array['sun','mon','tue','wed','thu','fri','sat'])[extract(dow from current_date + 7)::int + 1],
+    wd_free
+  ]::text[]
+  where id='c3000000-0000-0000-0000-000000000001';
+
+  -- unberuehrte offene Zukunfts-Occurrence, abweichende Dauer (soll gesynct werden)
+  insert into public.jobs
+    (id, company_id, parent_job_id, created_by, assigned_to, customer_name, service_name,
+     location_address, status, job_type, date, start_time, planned_duration_minutes, is_active)
+  values
+    ('c4000000-0000-0000-0000-000000000003','c1000000-0000-0000-0000-000000000001',
+     'c3000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000001',
+     'c2000000-0000-0000-0000-000000000002','Regelkunde','Unterhaltsreinigung','Regelweg 1',
+     'open','single', d_free, '08:00', 45, true);
+
+  -- geschuetzte offene Occurrence (Kommentar), eigener Wochentag NICHT in
+  -- recurring_days (bleibt trotzdem geschuetzt, weil sie Anhaenge traegt).
+  insert into public.jobs
+    (id, company_id, parent_job_id, created_by, assigned_to, customer_name, service_name,
+     location_address, status, job_type, date, start_time, planned_duration_minutes, is_active)
+  values
+    ('c4000000-0000-0000-0000-000000000004','c1000000-0000-0000-0000-000000000001',
+     'c3000000-0000-0000-0000-000000000001','c2000000-0000-0000-0000-000000000001',
+     'c2000000-0000-0000-0000-000000000002','Regelkunde','Unterhaltsreinigung','Regelweg 1',
+     'open','single', d_protected, '08:00', 45, true);
+
+  insert into public.job_comments (id, company_id, job_id, author_id, message)
+  values ('c5000000-0000-0000-0000-000000000001','c1000000-0000-0000-0000-000000000001',
+          'c4000000-0000-0000-0000-000000000004','c2000000-0000-0000-0000-000000000002','Geschuetzt.');
+end $$;
+
+
+-- =========================================================
+-- EDIT: Regel-Dauer 60 -> 120. update_job_occurrences ausfuehren.
+-- =========================================================
+do $$
+declare ret int;
+begin
+  update public.jobs set planned_duration_minutes = 120
+   where id='c3000000-0000-0000-0000-000000000001';
+
+  perform pg_temp.act_as('c2000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select public.update_job_occurrences('c3000000-0000-0000-0000-000000000001') into ret;
+  execute 'reset role';
+end $$;
+
+-- CASE 5: unberuehrte offene Zukunfts-Occurrence uebernimmt die neue Dauer (SYNC).
+insert into _pd_results
+select 5, 'Unberuehrte offene Zukunfts-Occurrence uebernimmt neue Dauer (120)', '120',
+  coalesce((select planned_duration_minutes::text from public.jobs where id='c4000000-0000-0000-0000-000000000003'), 'WEG/NULL');
+
+-- CASE 6: SYNC prunt NICHT — die Occurrence existiert nach der Dauer-Aenderung weiterhin.
+insert into _pd_results
+select 6, 'Dauer-Aenderung allein loest KEIN Prunen aus', 'PRESERVED',
+  case when exists (select 1 from public.jobs where id='c4000000-0000-0000-0000-000000000003')
+       then 'PRESERVED' else 'WEG' end;
+
+-- CASE 7: Kommentar/Foto schuetzen eine Occurrence nur vor PRUNE
+-- (Loeschen), NICHT vor SYNC (Inhaltsfelder synct sich weiter — exakt wie
+-- customer_name im bestehenden non_destructive_update_job_occurrences-Test,
+-- CASE 16). Die geschuetzte Occurrence uebernimmt die neue Dauer also
+-- ebenfalls.
+insert into _pd_results
+select 7, 'Geschuetzte, aber offene/unberuehrte Occurrence synct Dauer trotzdem (120)', '120',
+  coalesce((select planned_duration_minutes::text from public.jobs where id='c4000000-0000-0000-0000-000000000004'), 'WEG/NULL');
+
+-- CASE 8: Kommentar der geschuetzten Occurrence weiterhin vorhanden.
+insert into _pd_results
+select 8, 'Kommentar der geschuetzten Occurrence bleibt erhalten', 'OK',
+  case when exists (select 1 from public.job_comments where id='c5000000-0000-0000-0000-000000000001') then 'OK' else 'WEG' end;
+
+-- CASE 9: neu generierte Occurrences (aus GENERATE-Schritt) erhalten ebenfalls 120.
+insert into _pd_results
+select 9, 'Neu generierte Occurrences nach Dauer-Aenderung tragen 120', 'OK',
+  case when not exists (
+    select 1 from public.jobs
+    where parent_job_id='c3000000-0000-0000-0000-000000000001'
+      and status = 'open'
+      and started_at is null
+      and id not in ('c4000000-0000-0000-0000-000000000004')
+      and planned_duration_minutes is distinct from 120
+  ) then 'OK' else 'FALSCH' end;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _pd_results order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _pd_results where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'PLANNED DURATION FOUNDATION TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE FAELLE PASS';
+end $$;
+
+rollback;

--- a/types/job.ts
+++ b/types/job.ts
@@ -90,6 +90,14 @@ export type Job = {
   // Nur aktive Aufträge werden Mitarbeitern "heute" angezeigt.
   isActive: boolean;
 
+  // Optionale geplante Dauer in Minuten (Phase 3, Planned Duration
+  // Foundation). NULL/undefined = keine Dauer geplant (Bestand). Zusammen
+  // mit startTime die EINZIGE Quelle der geplanten Terminierung —
+  // scheduledEnd wird hierfür NICHT verwendet. Bei recurring-Parent-Regeln
+  // die Dauer je Occurrence, propagiert über generate_job_occurrences/
+  // update_job_occurrences (siehe lib/schema.sql).
+  plannedDurationMinutes?: number | null;
+
   // True, wenn dieser Job für den aktuellen User ungelesene Kommentare hat
   // (roter Punkt). Wird im JobContext nach getJobs gemerged, nicht in mapJob.
   hasUnreadComments?: boolean;
@@ -133,6 +141,9 @@ export type CreateJobInput = {
   // (hält die bestehenden Detail-/Monats-Anzeigen lauffähig).
   scheduledStart?: string | null;
   scheduledEnd?: string | null;
+  // Optionale geplante Dauer in Minuten (Phase 3, Planned Duration
+  // Foundation). Siehe Hinweis bei Job.plannedDurationMinutes.
+  plannedDurationMinutes?: number | null;
 };
 
 export type EmployeeOption = {

--- a/utils/jobSchedule.ts
+++ b/utils/jobSchedule.ts
@@ -71,3 +71,25 @@ export function getRecurringDaysLabel(job: Job): string {
   if (job.jobType !== "recurring") return "";
   return formatRecurringDays(job.recurringDays);
 }
+
+/**
+ * Geplantes Ende "HH:mm", abgeleitet aus startTime + plannedDurationMinutes
+ * (Phase 3, Planned Duration Foundation). NULL, wenn eines der beiden fehlt —
+ * KEIN Rückgriff auf scheduledEnd (siehe CLAUDE.md: start_time + Dauer ist
+ * die einzige Quelle der geplanten Terminierung).
+ */
+export function getPlannedEndTime(
+  job: Pick<Job, "startTime" | "plannedDurationMinutes">,
+): string | null {
+  const start = normalizeTime(job.startTime);
+  const duration = job.plannedDurationMinutes;
+  if (!start || !duration || duration <= 0) return null;
+
+  const [h, m] = start.split(":").map(Number);
+  if (Number.isNaN(h) || Number.isNaN(m)) return null;
+
+  const totalMinutes = (h * 60 + m + duration) % (24 * 60);
+  const endH = Math.floor(totalMinutes / 60);
+  const endM = totalMinutes % 60;
+  return `${String(endH).padStart(2, "0")}:${String(endM).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- Adds nullable `jobs.planned_duration_minutes`. `start_time + Dauer` bleibt die einzige Quelle der geplanten Terminierung — `scheduled_end` wird bewusst nicht angefasst (wird von keinem Schreibpfad befüllt, siehe Architektur-Audit).
- `generate_job_occurrences` kopiert die Dauer der Recurring-Regel auf jede erzeugte Occurrence; `update_job_occurrences` synct eine geänderte Dauer im bestehenden SYNC-Schritt (wie `customer_name`/`notes`) auf nicht individuell angepasste, offene Zukunfts-Occurrences — löst dabei bewusst **kein** Prunen aus, anders als eine Uhrzeit-Änderung.
- Typen/Service (`types/job.ts`, `services/jobs/jobs.service.ts`): neues Feld durchgereicht (Select, Mapper, Create-/Update-Payload).
- Admin-Formular (Erstellen + Bearbeiten): optionales, nur-Ziffern Eingabefeld "Geplante Dauer in Minuten". Keine Pflichtvalidierung, bestehende Jobs funktionieren unverändert mit `NULL` weiter.
- `JobScheduleCard` zeigt Dauer + daraus abgeleitetes geplantes Ende (`utils/jobSchedule.ts#getPlannedEndTime`) nur, wenn eine Dauer gesetzt ist — ersetzt den bisher toten `scheduledEnd`-Anzeigepfad.
- Reine Grundlage — **keine** Overlap-Erkennung, kein Blocking, keine UI dafür.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Lokaler Supabase-Stack (`supabase db reset`, alle Migrationen inkl. der neuen sauber angewendet)
- [x] Neuer pgTAP-Test `supabase/tests/planned_duration_foundation.test.sql` — 9/9 Fälle PASS (Spalte nullable, CHECK-Constraint, Propagation auf neue Occurrences, SYNC ohne Prunen, geschützte Occurrences)
- [x] Regressions-Check bestehender Tests: `non_destructive_update_job_occurrences` (20/20 PASS), `job_assignments` (25/25 PASS), `occurrence_assignment_inheritance` (32/32 PASS)
- [x] `shared_job_time_multi_assignment` CASE 24 schlägt fehl — verifiziert **vorbestehend** (identischer Fehlschlag ohne diese Migration, verursacht durch bereits gemergte Phase-1-Worked-Time-Migration `20260812000000`), unrelated zu diesem PR. Separat geflaggt.
- [ ] Manuelle UI-Prüfung (Create/Edit-Formular, Job-Detail) durch Reviewer — kein Preview-Server in dieser Session verfügbar (Expo/React Native, kein Browser-Target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)