### PR TITLE
feat(timesheets): Grundlage für Admin-Zeitkorrektur (Phase A)

### DIFF
--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -186,6 +186,38 @@ create table if not exists public.job_photos (
   created_at timestamptz not null default now()
 );
 
+-- Prüfpfad für manuelle Korrekturen der Mitarbeiter-Arbeitszeit (Phase A,
+-- 20260814000000). Append-only: eine Zeile je Korrektur-Ereignis mit Alt-/
+-- Neuwerten, korrigierendem Admin, Pflicht-Begründung und Zeitpunkt.
+-- Geschrieben ausschließlich von admin_correct_assignment_time(); es gibt
+-- weder UPDATE- noch DELETE-Policy (wie job_comments/job_photos).
+-- Die abgerechnete Zeit selbst steht IMMER in job_assignments — diese
+-- Tabelle trägt keine Abrechnungsbedeutung.
+-- job_id/assignment_id kaskadieren (mit dem Auftrag entfällt auch der
+-- Nachweis); employee_id/changed_by sind ON DELETE SET NULL, damit eine
+-- Kontolöschung nicht blockiert wird (siehe job_photos.uploaded_by).
+create table if not exists public.employee_time_adjustments (
+  id uuid primary key default gen_random_uuid(),
+  assignment_id uuid not null references public.job_assignments(id) on delete cascade,
+  job_id uuid not null references public.jobs(id) on delete cascade,
+  employee_id uuid references public.profiles(id) on delete set null,
+  old_started_at timestamptz,
+  old_completed_at timestamptz,
+  new_started_at timestamptz,
+  new_completed_at timestamptz,
+  changed_by uuid references public.profiles(id) on delete set null,
+  reason text not null,
+  created_at timestamptz not null default now(),
+  constraint chk_employee_time_adjustments_reason
+    check (length(btrim(reason)) > 0),
+  constraint chk_employee_time_adjustments_new_order
+    check (
+      new_started_at is null
+      or new_completed_at is null
+      or new_completed_at > new_started_at
+    )
+);
+
 -- Admin-Push bei Job-Statuswechsel — Event-Log + Pro-Empfänger-Zustandsmaschine.
 -- notification_outbox: EIN Event pro echtem Statusübergang (transaktional von
 --   start_own_job/complete_own_job geschrieben). fanned_out_at markiert die

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -196,6 +196,16 @@ create table if not exists public.job_photos (
 -- job_id/assignment_id kaskadieren (mit dem Auftrag entfällt auch der
 -- Nachweis); employee_id/changed_by sind ON DELETE SET NULL, damit eine
 -- Kontolöschung nicht blockiert wird (siehe job_photos.uploaded_by).
+--
+-- HINWEIS ZUR REFERENZ-DATEI: der Fremdschlüssel unten zeigt auf
+-- public.job_assignments. Diese Tabelle wird in dieser Datei NICHT
+-- definiert — sie entstand mit Migration 20260725000000 und wurde hier nie
+-- nachgetragen (bestehende Drift, gilt ebenso für ihre Policies und die
+-- RPCs der Phasen 3–7). Diese Datei ist laut CLAUDE.md ausdrücklich nur
+-- REFERENZ und kein ausführbares Bootstrap-Skript; maßgeblich sind die
+-- Migrationen unter supabase/migrations/. Der FK ist hier bewusst
+-- vollständig dokumentiert statt weggelassen — das Nachtragen von
+-- job_assignments selbst gehört in eine eigene Aufräum-Änderung.
 create table if not exists public.employee_time_adjustments (
   id uuid primary key default gen_random_uuid(),
   assignment_id uuid not null references public.job_assignments(id) on delete cascade,
@@ -216,6 +226,43 @@ create table if not exists public.employee_time_adjustments (
       or new_completed_at is null
       or new_completed_at > new_started_at
     )
+);
+
+-- Leserichtungen: Korrektur-Historie eines Auftrags bzw. einer Zuweisung.
+create index if not exists idx_employee_time_adjustments_job
+  on public.employee_time_adjustments (job_id, created_at desc);
+create index if not exists idx_employee_time_adjustments_assignment
+  on public.employee_time_adjustments (assignment_id, created_at desc);
+-- FK-Rückwärtsindizes, damit eine Kontolöschung (ON DELETE SET NULL) nicht
+-- über einen Seq Scan läuft.
+create index if not exists idx_employee_time_adjustments_employee
+  on public.employee_time_adjustments (employee_id) where employee_id is not null;
+create index if not exists idx_employee_time_adjustments_changed_by
+  on public.employee_time_adjustments (changed_by) where changed_by is not null;
+
+-- Zugriff (identisch zu Migration 20260814000000): RLS an, NUR SELECT für
+-- Admins der eigenen Firma. INSERT/UPDATE/DELETE bleiben ohne Grant UND ohne
+-- Policy — geschrieben wird ausschließlich über die SECURITY-DEFINER-RPC
+-- admin_correct_assignment_time(). Mitarbeiter sehen bewusst keine
+-- Korrektur-Einträge (das Feld reason kann interne Bewertungen enthalten);
+-- die korrigierte ZEIT selbst sehen sie in ihrem eigenen Stundenzettel.
+--
+-- REIHENFOLGE IST SICHERHEITSRELEVANT: Supabase vergibt über
+-- ALTER DEFAULT PRIVILEGES auf neue Tabellen im public-Schema automatisch
+-- ALLE Rechte an anon und authenticated. Erst vollständig entziehen, dann
+-- gezielt SELECT vergeben.
+alter table public.employee_time_adjustments enable row level security;
+revoke all on public.employee_time_adjustments from anon, authenticated;
+grant select on public.employee_time_adjustments to authenticated;
+
+drop policy if exists "admin read time adjustments in own company" on public.employee_time_adjustments;
+create policy "admin read time adjustments in own company"
+on public.employee_time_adjustments
+for select
+to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and public.job_in_current_company(job_id)
 );
 
 -- Admin-Push bei Job-Statuswechsel — Event-Log + Pro-Empfänger-Zustandsmaschine.

--- a/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
+++ b/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
@@ -225,14 +225,22 @@ using (
 --   ein redundanter Schreibvorgang und ein zweites Realtime-Event fuer
 --   dieselbe Aenderung. Der Test weist nach, dass updated_at steigt.
 --
--- WARUM NUR ABGESCHLOSSENE AUFTRAEGE KORRIGIERBAR SIND:
---   Der Stundenzettel filtert serverseitig auf
+-- WARUM NUR BESTIMMTE ZEILEN KORRIGIERBAR SIND (drei Ablehnungen):
+--   Der Stundenzettel selektiert serverseitig ueber
+--   job_assignments.employee_id und filtert j.job_type='single' AND
 --   j.status='completed' AND j.started_at IS NOT NULL AND
---   j.completed_at IS NOT NULL (timesheet.service.ts). Eine Korrektur an
---   einem Auftrag, der diese Bedingungen nicht erfuellt, wuerde die
+--   j.completed_at IS NOT NULL (timesheet.service.ts). Jede Korrektur an
+--   einer Zeile, die diesen Filter nicht passiert, wuerde die
 --   Zuweisungszeile zwar veraendern, im Stundenzettel aber WIRKUNGSLOS
---   bleiben — eine stille Nulloperation auf einer Abrechnungskorrektur.
---   Sie wird deshalb hart abgelehnt statt scheinbar zu gelingen.
+--   bleiben — eine stille Nulloperation auf einer Abrechnungskorrektur,
+--   bei der der Admin von einer erfolgreichen Korrektur ausgeht. Alle drei
+--   Faelle werden deshalb hart abgelehnt statt scheinbar zu gelingen:
+--     a) job_type <> 'single' — Recurring-PARENT-Regeln tragen seit Phase 4
+--        Zuweisungen und koennen ueber einen direkten Admin-UPDATE auf jobs
+--        durchaus 'completed' samt Zeitstempeln werden.
+--     b) Auftrag nicht abgeschlossen bzw. geteilte Uhr unvollstaendig.
+--     c) employee_id IS NULL — anonymisierte Zeile einer Kontoloeschung;
+--        der Stundenzettel filtert immer auf eine konkrete employee_id.
 --
 -- WARUM ALT-AUFTRAEGE (VOR PHASE 1) ABGELEHNT WERDEN:
 --   Fuer sie liest der Stundenzettel ueber isLegacyJob() die GETEILTE
@@ -342,7 +350,38 @@ begin
       using errcode = '42501';
   end if;
 
+  -- Anonymisierte Zeile (Konto geloescht, employee_id per ON DELETE SET NULL
+  -- auf NULL) ist NICHT korrigierbar. Der Stundenzettel selektiert immer
+  -- ueber employee_id (timesheet.service.ts) — eine Korrektur an einer
+  -- solchen Zeile koennte fuer NIEMANDEN je erscheinen und haette zudem
+  -- einen Pruefpfad-Eintrag ohne zuordenbare Person zur Folge. Der
+  -- Guard-Trigger enforce_active_assignment laesst dieses UPDATE durch
+  -- (must_check ist false, solange employee_id/job_id unveraendert
+  -- bleiben) — die Ablehnung muss deshalb hier passieren.
+  if v_assignment.employee_id is null then
+    raise exception
+      'Cannot correct an anonymised assignment (employee account was deleted)'
+      using errcode = '22023';
+  end if;
+
   -- ── Fachliche Vorbedingungen am Auftrag ──────────────────────────
+  -- job_type = 'single' ist EIGENSTAENDIGE Bedingung, exakt wie in
+  -- start_own_job/complete_own_job. Recurring-PARENT-Regeln tragen seit
+  -- Phase 4 selbst Zuweisungen (sie sind die Vorlage) und koennen ueber
+  -- einen direkten Admin-UPDATE auf jobs durchaus status='completed' samt
+  -- Zeitstempeln erreichen (die Admin-UPDATE-Policy kennt keine Spalten-
+  -- oder Statusgrenze, und trg_jobs_protect_recurring_history greift nur
+  -- BEFORE DELETE). Ohne diese Bedingung wuerde eine Korrektur an einer
+  -- Parent-Regel vollstaendig gelingen — der Stundenzettel filtert aber
+  -- j.job_type='single' (timesheet.service.ts) und zeigt sie NIE an. Genau
+  -- diese stille Nulloperation auf einer Abrechnungskorrektur soll die RPC
+  -- verhindern; sie wird deshalb hart abgelehnt.
+  if v_job.job_type is distinct from 'single' then
+    raise exception
+      'Only single jobs can be corrected (recurring parent rules never appear in a timesheet)'
+      using errcode = '22023';
+  end if;
+
   if v_job.status is distinct from 'completed'
      or v_job.started_at is null
      or v_job.completed_at is null then
@@ -414,10 +453,15 @@ comment on function public.admin_correct_assignment_time(uuid, timestamptz, time
 'an. Faesst jobs.started_at/completed_at NIEMALS an — die geteilte Job-Uhr '
 'und damit die Zeiten aller uebrigen Zugewiesenen bleiben unveraendert. '
 'Verlangt einen nicht-leeren Grund, mindestens einen der beiden neuen '
-'Zeitstempel und (falls beide gesetzt) Ende nach Beginn. Nur abgeschlossene '
-'Auftraege mit vollstaendiger geteilter Uhr sind korrigierbar; Auftraege, die '
-'vor dem Worked-Time-Grenzwert 2026-08-12 abgeschlossen wurden, werden '
-'abgelehnt (dort gilt weiterhin der Legacy-Fallback des Stundenzettels). '
+'Zeitstempel und (falls beide gesetzt) Ende nach Beginn. Korrigierbar sind '
+'ausschliesslich Auftraege mit job_type=''single'' (Recurring-Parent-Regeln '
+'erscheinen nie im Stundenzettel) und Status ''completed'' mit vollstaendiger '
+'geteilter Uhr; Auftraege, die vor dem Worked-Time-Grenzwert 2026-08-12 '
+'abgeschlossen wurden, werden abgelehnt (dort gilt weiterhin der '
+'Legacy-Fallback des Stundenzettels). Anonymisierte Zuweisungen '
+'(employee_id IS NULL nach Kontoloeschung) werden ebenfalls abgelehnt — eine '
+'Korrektur koennte dort fuer niemanden erscheinen. Alle drei Ablehnungen '
+'verhindern eine stille Nulloperation auf einer Abrechnungskorrektur. '
 'Sperrreihenfolge Auftrag -> Zuweisung, identisch zu set_job_assignments.';
 
 -- Nur eingeloggte Nutzer duerfen die RPC ueberhaupt aufrufen; die

--- a/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
+++ b/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
@@ -1,0 +1,446 @@
+-- =========================================================
+-- MIGRATION: Admin Time Correction — Grundlage (Phase A)
+-- Datum: 2026-08-14
+-- =========================================================
+-- ZWECK
+--   Mitarbeiter vergessen in der Praxis, Start oder Abschluss zu druecken.
+--   Der Stundenzettel liest seit Phase 2 ausschliesslich
+--   job_assignments.employee_started_at/employee_completed_at
+--   (services/timesheets/timesheet.service.ts) — fehlt dieses Paar, entsteht
+--   fuer den betroffenen Mitarbeiter GAR KEIN Eintrag. Diese Migration gibt
+--   Admins den einzigen sicheren Weg, genau dieses Paar nachtraeglich zu
+--   korrigieren, samt vollstaendigem Pruefpfad.
+--
+--   Zwei Objekte:
+--     1. public.employee_time_adjustments — append-only Audit-Log
+--     2. public.admin_correct_assignment_time(...) — die einzige Schreib-RPC
+--
+-- DIE GETEILTE JOB-UHR BLEIBT UNANGETASTET
+--   jobs.started_at/completed_at werden von dieser Migration NIRGENDS
+--   geschrieben. Das ist die zentrale Invariante: die geteilte Uhr ist die
+--   EINE offizielle Ausfuehrungszeit des Auftrags und gilt fuer alle
+--   Zugewiesenen (Phase 7, 20260731000000). Wuerde eine Korrektur sie
+--   anfassen, veraenderte sie die abgerechnete Dauer ALLER Kolleginnen und
+--   Kollegen auf demselben Auftrag — bei Alt-Auftraegen (vor Phase 1) sogar
+--   unmittelbar sichtbar, weil mapEntry() dort auf genau diese Spalten
+--   zurueckfaellt. Korrigiert wird deshalb ausschliesslich die EIGENE
+--   Zuweisungszeile des betroffenen Mitarbeiters.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   * KEINE UPDATE-Policy auf job_assignments. Das Sicherheitsmodell aus
+--     Phase 3 (20260727000000) bleibt unveraendert: authenticated hat auf
+--     job_assignments ausschliesslich SELECT; jeder Schreibvorgang laeuft
+--     ueber SECURITY-DEFINER-RPCs. Diese Migration fuegt exakt eine solche
+--     RPC hinzu — sie erweitert die Rechte des Clients um NICHTS.
+--   * KEINE Aenderung an start_own_job/complete_own_job, an deren
+--     Autorisierung, Statusbedingungen oder Rueckgabewerten.
+--   * KEINE Aenderung am Stundenzettel-Lesepfad. Die RPC schreibt exakt die
+--     Spalten, die timesheet.service.ts ohnehin liest — der Client braucht
+--     dafuer keine Zeile Code.
+--   * KEINE UI. Phase A ist reine Datenschicht.
+--   * Keine Aenderung an jobs, an dessen Policies oder an der
+--     Phase-2-Kompatibilitaetsschicht.
+--
+-- IDEMPOTENZ
+--   Tabelle via IF NOT EXISTS, Constraints/Policies via DROP + CREATE,
+--   Funktion via CREATE OR REPLACE — vollstaendig wiederholbar.
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgefuehrt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Audit-Tabelle
+-- ---------------------------------------------------------
+-- APPEND-ONLY, exakt nach dem Muster von job_comments/job_photos: es gibt
+-- weder UPDATE- noch DELETE-Policy und weder UPDATE- noch DELETE-Grant.
+-- Eine Korrektur ist ein Ereignis, kein veraenderlicher Zustand.
+--
+-- ON-DELETE-Strategie je Spalte (die Unterschiede sind Absicht):
+--   * job_id / assignment_id -> CASCADE. Wird der Auftrag geloescht,
+--     verschwinden seine Zuweisungen ohnehin (Phase 1) und mit ihnen die
+--     Stundenzettel-Eintraege — ein Korrektur-Nachweis fuer eine nicht mehr
+--     existierende Abrechnungszeile waere gegenstandslos. Gleiches Verhalten
+--     wie job_comments/job_photos.
+--   * employee_id / changed_by -> SET NULL. Ein Konto muss loeschbar
+--     bleiben, OHNE dass der Nachweis verschwindet. Genau hier lag der
+--     Produktionsfehler von job_photos.uploaded_by (RESTRICT + NOT NULL
+--     blockierte die Kontoloeschung, behoben in 20260722000000/
+--     20260722000001) — dieser Fehler wird hier nicht wiederholt.
+create table if not exists public.employee_time_adjustments (
+  id uuid primary key default gen_random_uuid(),
+
+  assignment_id uuid not null references public.job_assignments(id) on delete cascade,
+  job_id        uuid not null references public.jobs(id)            on delete cascade,
+  -- NULL = das Mitarbeiterkonto wurde nach der Korrektur geloescht.
+  employee_id   uuid          references public.profiles(id)        on delete set null,
+
+  -- Zustand VOR der Korrektur (beide duerfen NULL sein — genau das ist ja
+  -- der haeufigste Anlass: der Mitarbeiter hat nie gedrueckt).
+  old_started_at   timestamptz,
+  old_completed_at timestamptz,
+
+  -- Zustand NACH der Korrektur.
+  new_started_at   timestamptz,
+  new_completed_at timestamptz,
+
+  -- Der korrigierende Admin. NULL = Konto inzwischen geloescht.
+  changed_by uuid references public.profiles(id) on delete set null,
+
+  -- PFLICHT. Eine abrechnungsrelevante Aenderung ohne Begruendung ist genau
+  -- die Luecke, die eine Pruefung beanstanden wuerde.
+  reason text not null,
+
+  created_at timestamptz not null default now(),
+
+  -- Begruendung darf nicht leer/nur Leerzeichen sein — gleiche Bauform wie
+  -- chk_job_assignments_name_snapshot (Phase 1).
+  constraint chk_employee_time_adjustments_reason
+    check (length(btrim(reason)) > 0),
+
+  -- Ende nach Beginn, sofern BEIDE gesetzt sind. Eine Korrektur, die nur
+  -- den Beginn setzt, bleibt zulaessig (siehe RPC).
+  constraint chk_employee_time_adjustments_new_order
+    check (
+      new_started_at is null
+      or new_completed_at is null
+      or new_completed_at > new_started_at
+    )
+);
+
+comment on table public.employee_time_adjustments is
+'Append-only Pruefpfad fuer manuelle Korrekturen der Mitarbeiter-Arbeitszeit '
+'(job_assignments.employee_started_at/employee_completed_at). Eine Zeile je '
+'Korrektur-Ereignis mit Alt- und Neuwerten, Admin, Begruendung und Zeitpunkt. '
+'Wird ausschliesslich von admin_correct_assignment_time() geschrieben; es '
+'gibt weder UPDATE- noch DELETE-Policy. Traegt selbst KEINE Abrechnungs'
+'bedeutung — die abgerechnete Zeit steht immer in job_assignments.';
+
+comment on column public.employee_time_adjustments.old_started_at is
+'employee_started_at VOR der Korrektur. NULL ist der Regelfall: der '
+'Mitarbeiter hat den Start nie selbst ausgeloest.';
+
+comment on column public.employee_time_adjustments.changed_by is
+'Korrigierender Admin. NULL = Konto inzwischen geloescht (ON DELETE SET '
+'NULL) — der Nachweis selbst bleibt erhalten.';
+
+comment on column public.employee_time_adjustments.reason is
+'PFLICHTFELD. Freitext-Begruendung der Korrektur (abrechnungsrelevant).';
+
+
+-- ---------------------------------------------------------
+-- 2. Indizes
+-- ---------------------------------------------------------
+-- Korrektur-Historie eines Auftrags bzw. einer Zuweisung (die einzigen
+-- beiden Leserichtungen, die Phase B braucht).
+create index if not exists idx_employee_time_adjustments_job
+  on public.employee_time_adjustments (job_id, created_at desc);
+
+create index if not exists idx_employee_time_adjustments_assignment
+  on public.employee_time_adjustments (assignment_id, created_at desc);
+
+-- FK-Rueckwaertsindizes, damit eine Kontoloeschung (ON DELETE SET NULL)
+-- nicht ueber einen Seq Scan laeuft. Partiell, exakt die Bauform von
+-- idx_job_assignments_assigned_by / idx_jobs_started_by.
+create index if not exists idx_employee_time_adjustments_employee
+  on public.employee_time_adjustments (employee_id) where employee_id is not null;
+
+create index if not exists idx_employee_time_adjustments_changed_by
+  on public.employee_time_adjustments (changed_by) where changed_by is not null;
+
+
+-- ---------------------------------------------------------
+-- 3. Zugriff: RLS an, NUR SELECT fuer Admins der eigenen Firma
+-- ---------------------------------------------------------
+-- Wie bei job_assignments (Phase 3): INSERT/UPDATE/DELETE bleiben OHNE
+-- Grant UND OHNE Policy — doppelt verriegelt. Geschrieben wird
+-- ausschliesslich durch die SECURITY-DEFINER-RPC unten.
+--
+-- Mitarbeiter sehen ihre eigenen Korrekturen BEWUSST NICHT: ob und warum
+-- ein Admin eine Zeit korrigiert hat, ist eine Personal-/Abrechnungs-
+-- angelegenheit (das Feld `reason` kann interne Bewertungen enthalten). Die
+-- korrigierte ZEIT selbst sieht der Mitarbeiter ohnehin sofort in seinem
+-- eigenen Stundenzettel — nur der Kommentar des Admins bleibt intern.
+alter table public.employee_time_adjustments enable row level security;
+
+-- REIHENFOLGE IST SICHERHEITSRELEVANT: Supabase vergibt ueber
+-- ALTER DEFAULT PRIVILEGES auf neue Tabellen im public-Schema automatisch
+-- ALLE Rechte an anon und authenticated. Ein blosses "grant select" wuerde
+-- die bereits vorhandenen INSERT/UPDATE/DELETE-Rechte NICHT entfernen — die
+-- Tabelle waere trotz fehlender Schreib-Policy direkt beschreibbar, sobald
+-- irgendeine Policy fuer die Rolle zutrifft. Erst vollstaendig entziehen,
+-- dann gezielt SELECT vergeben (genau die Reihenfolge, die Phase 1/3 fuer
+-- job_assignments ueber zwei Migrationen hinweg herstellt).
+revoke all on public.employee_time_adjustments from anon, authenticated;
+grant select on public.employee_time_adjustments to authenticated;
+
+-- Firmen-Scoping ueber den bestehenden Helfer aus Phase 3 — KEIN neuer
+-- Helfer, keine company_id-Spalte noetig.
+drop policy if exists "admin read time adjustments in own company" on public.employee_time_adjustments;
+create policy "admin read time adjustments in own company"
+on public.employee_time_adjustments
+for select
+to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and public.job_in_current_company(job_id)
+);
+
+-- KEINE INSERT-, UPDATE- oder DELETE-Policy. Beabsichtigt.
+
+
+-- ---------------------------------------------------------
+-- 4. RPC: admin_correct_assignment_time
+-- ---------------------------------------------------------
+-- SECURITY DEFINER — zwingend: authenticated hat auf job_assignments
+-- absichtlich KEIN Schreibrecht (Phase 3) und auf
+-- employee_time_adjustments ebenfalls nicht. Die Funktion prueft
+-- Authentifizierung, Rolle und Firmenzugehoerigkeit selbst und ist
+-- fail-closed.
+--
+-- SPERRREIHENFOLGE: AUFTRAG ZUERST, DANN ZUWEISUNG.
+--   Bewusst NICHT umgekehrt. Zwei bestehende Schreibpfade halten dieselbe
+--   Reihenfolge:
+--     * set_job_assignments() sperrt die jobs-Zeile (FOR UPDATE) und
+--       schreibt DANACH job_assignments (20260727000000).
+--     * update_job_occurrences() sperrt die Parent-Regel und arbeitet
+--       danach auf den Terminen (20260728000000, dort ausdruecklich als
+--       "Sperrreihenfolge Parent -> Termin" dokumentiert).
+--   Zusaetzlich zwingend: der AFTER-Trigger
+--   touch_job_on_assignment_change_trg (Phase 1) fordert NACH jedem
+--   job_assignments-UPDATE selbst eine Sperre auf der jobs-Zeile an. Wuerde
+--   diese RPC zuerst die Zuweisung sperren, entstuende exakt die
+--   umgekehrte Reihenfolge zu set_job_assignments — und damit ein echtes
+--   Deadlock-Fenster zwischen einem Admin, der zuweist, und einem Admin,
+--   der korrigiert.
+--
+-- REALTIME (Anforderung "jobs.updated_at anfassen"): bereits erfuellt, ohne
+--   dass diese RPC etwas dafuer tun muss. job_assignments ist NICHT Teil der
+--   supabase_realtime-Publication, public.jobs schon; genau dafuer existiert
+--   touch_job_on_assignment_change_trg seit Phase 1, und er feuert auch bei
+--   UPDATE. Ein zusaetzliches explizites "update jobs set updated_at" waere
+--   ein redundanter Schreibvorgang und ein zweites Realtime-Event fuer
+--   dieselbe Aenderung. Der Test weist nach, dass updated_at steigt.
+--
+-- WARUM NUR ABGESCHLOSSENE AUFTRAEGE KORRIGIERBAR SIND:
+--   Der Stundenzettel filtert serverseitig auf
+--   j.status='completed' AND j.started_at IS NOT NULL AND
+--   j.completed_at IS NOT NULL (timesheet.service.ts). Eine Korrektur an
+--   einem Auftrag, der diese Bedingungen nicht erfuellt, wuerde die
+--   Zuweisungszeile zwar veraendern, im Stundenzettel aber WIRKUNGSLOS
+--   bleiben — eine stille Nulloperation auf einer Abrechnungskorrektur.
+--   Sie wird deshalb hart abgelehnt statt scheinbar zu gelingen.
+--
+-- WARUM ALT-AUFTRAEGE (VOR PHASE 1) ABGELEHNT WERDEN:
+--   Fuer sie liest der Stundenzettel ueber isLegacyJob() die GETEILTE
+--   Job-Uhr. Wuerde man dort employee_started_at/completed_at setzen,
+--   kippte mapEntry() diese Zeile schlagartig in den Eigenzeit-Zweig
+--   (hasOwnTimes) — die Berechnungsgrundlage eines abgeschlossenen,
+--   moeglicherweise bereits abgerechneten Zeitraums aendert sich damit
+--   still. Der Grenzwert ist derselbe wie im Client (PHASE1_CUTOFF_ISO).
+create or replace function public.admin_correct_assignment_time(
+  assignment_id_input uuid,
+  new_started_at      timestamptz,
+  new_completed_at    timestamptz,
+  reason_input        text
+)
+returns setof public.job_assignments
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_job_id        uuid;
+  v_assignment    public.job_assignments%rowtype;
+  v_job           public.jobs%rowtype;
+  v_reason        text;
+  v_attendance    public.attendance_state;
+  -- Entspricht PHASE1_CUTOFF_ISO in services/timesheets/timesheet.service.ts
+  -- (Migration 20260812000000, "Phase 1 Worked Time"). Bewusst dieselbe
+  -- Konstante: Client und Server duerfen bei der Frage "gilt hier noch der
+  -- Legacy-Fallback?" nicht auseinanderlaufen.
+  c_phase1_cutoff constant timestamptz := timestamptz '2026-08-12 00:00:00+00';
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  -- IS DISTINCT FROM statt <>: current_user_role() liefert fuer ein
+  -- inaktives/fehlendes Profil NULL, und "NULL <> 'admin'" ist NULL — der
+  -- Guard wuerde fuer einen deaktivierten Admin still uebersprungen.
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can correct employee work times'
+      using errcode = '42501';
+  end if;
+
+  -- ── Eingabevalidierung VOR jedem Schreibvorgang ──────────────────
+  v_reason := btrim(coalesce(reason_input, ''));
+  if v_reason = '' then
+    raise exception 'A reason is required for a time correction'
+      using errcode = '23514';
+  end if;
+
+  -- Beide NULL waere keine Korrektur, sondern ein Loeschen der erfassten
+  -- Zeit — dafuer gibt es weder einen definierten attendance-Zustand noch
+  -- einen fachlichen Anlass (eine faelschlich zugewiesene Person wird aus
+  -- der Zuweisungsmenge entfernt, nicht auf NULL korrigiert).
+  if new_started_at is null and new_completed_at is null then
+    raise exception 'At least one of new_started_at / new_completed_at must be set'
+      using errcode = '23514';
+  end if;
+
+  if new_started_at is not null
+     and new_completed_at is not null
+     and new_completed_at <= new_started_at then
+    raise exception 'new_completed_at must be after new_started_at'
+      using errcode = '23514';
+  end if;
+
+  -- ── Auftrag ermitteln (noch ohne Sperre) ─────────────────────────
+  select ja.job_id into v_job_id
+  from public.job_assignments ja
+  where ja.id = assignment_id_input;
+
+  if v_job_id is null then
+    raise exception 'Assignment not found or not accessible'
+      using errcode = '42501';
+  end if;
+
+  -- ── 1) AUFTRAG SPERREN (inkl. Firmenpruefung) ────────────────────
+  -- Firmenfremde Auftraege sind hier bereits nicht auffindbar; die
+  -- Fehlermeldung ist absichtlich identisch mit "nicht gefunden" und
+  -- verraet damit nicht, ob eine fremde Zuweisung existiert.
+  select * into v_job
+  from public.jobs
+  where id         = v_job_id
+    and company_id = public.current_user_company_id()
+  for update;
+
+  if not found then
+    raise exception 'Assignment not found or not accessible'
+      using errcode = '42501';
+  end if;
+
+  -- ── 2) ZUWEISUNG SPERREN ─────────────────────────────────────────
+  select * into v_assignment
+  from public.job_assignments
+  where id = assignment_id_input
+  for update;
+
+  if not found then
+    raise exception 'Assignment not found or not accessible'
+      using errcode = '42501';
+  end if;
+
+  -- Die Zuweisung muss nach dem Sperren immer noch an DIESEM Auftrag
+  -- haengen (Schutz gegen ein Verschieben zwischen den beiden Sperren).
+  if v_assignment.job_id is distinct from v_job.id then
+    raise exception 'Assignment not found or not accessible'
+      using errcode = '42501';
+  end if;
+
+  -- ── Fachliche Vorbedingungen am Auftrag ──────────────────────────
+  if v_job.status is distinct from 'completed'
+     or v_job.started_at is null
+     or v_job.completed_at is null then
+    raise exception
+      'Only completed jobs can be corrected (job must have a shared start and completion)'
+      using errcode = '22023';
+  end if;
+
+  if v_job.completed_at < c_phase1_cutoff then
+    raise exception
+      'Jobs completed before the worked-time cutoff (2026-08-12) cannot be corrected'
+      using errcode = '22023';
+  end if;
+
+  -- ── 3) Neuer attendance-Zustand ──────────────────────────────────
+  -- KEIN neuer Enum-Wert: die Herkunft der Zeit ("vom Admin korrigiert")
+  -- steht im Pruefpfad, nicht im Zustand. Wichtig ist, dass attendance
+  -- ueberhaupt mitgezogen wird: counts_for_timesheet ist eine GENERIERTE
+  -- Spalte auf attendance/review (Phase 1) und bliebe bei 'assigned'
+  -- dauerhaft false — eine korrigierte Zeile waere damit fuer jede kuenftige
+  -- Abrechnungs-Berechtigung unsichtbar.
+  v_attendance := case
+    when new_started_at is not null and new_completed_at is not null then 'completed'
+    when new_completed_at is not null                                then 'completed'
+    else                                                                  'started'
+  end::public.attendance_state;
+
+  -- ── 4) NUR die eigene Zuweisungszeile aktualisieren ───────────────
+  -- Ueberschreibt bewusst (kein COALESCE): eine Korrektur MUSS einen
+  -- bestehenden, falschen Wert ersetzen koennen — anders als
+  -- start_own_job/complete_own_job, wo "der Erste gewinnt" gilt.
+  -- jobs.started_at/completed_at werden hier NICHT angefasst.
+  update public.job_assignments
+  set
+    employee_started_at   = new_started_at,
+    employee_completed_at = new_completed_at,
+    attendance            = v_attendance
+  where id = assignment_id_input;
+
+  -- ── 5) Pruefpfad in DERSELBEN Transaktion ────────────────────────
+  insert into public.employee_time_adjustments (
+    assignment_id, job_id, employee_id,
+    old_started_at, old_completed_at,
+    new_started_at, new_completed_at,
+    changed_by, reason
+  )
+  values (
+    v_assignment.id, v_job.id, v_assignment.employee_id,
+    v_assignment.employee_started_at, v_assignment.employee_completed_at,
+    new_started_at, new_completed_at,
+    auth.uid(), v_reason
+  );
+
+  -- ── 6) Ergebnis ──────────────────────────────────────────────────
+  -- jobs.updated_at wurde durch touch_job_on_assignment_change_trg bereits
+  -- angehoben (siehe Kopf) — kein zusaetzlicher Schreibvorgang noetig.
+  return query
+  select ja.*
+  from public.job_assignments ja
+  where ja.id = assignment_id_input;
+end;
+$$;
+
+comment on function public.admin_correct_assignment_time(uuid, timestamptz, timestamptz, text) is
+'Korrigiert die Arbeitszeit EINER Zuweisung (nur Admin, nur eigene Firma). '
+'Schreibt ausschliesslich job_assignments.employee_started_at/'
+'employee_completed_at/attendance der uebergebenen Zeile und legt in '
+'derselben Transaktion einen Pruefpfad-Eintrag in employee_time_adjustments '
+'an. Faesst jobs.started_at/completed_at NIEMALS an — die geteilte Job-Uhr '
+'und damit die Zeiten aller uebrigen Zugewiesenen bleiben unveraendert. '
+'Verlangt einen nicht-leeren Grund, mindestens einen der beiden neuen '
+'Zeitstempel und (falls beide gesetzt) Ende nach Beginn. Nur abgeschlossene '
+'Auftraege mit vollstaendiger geteilter Uhr sind korrigierbar; Auftraege, die '
+'vor dem Worked-Time-Grenzwert 2026-08-12 abgeschlossen wurden, werden '
+'abgelehnt (dort gilt weiterhin der Legacy-Fallback des Stundenzettels). '
+'Sperrreihenfolge Auftrag -> Zuweisung, identisch zu set_job_assignments.';
+
+-- Nur eingeloggte Nutzer duerfen die RPC ueberhaupt aufrufen; die
+-- Admin-Pruefung passiert intern. anon und PUBLIC bleiben ausgeschlossen.
+revoke all on function public.admin_correct_assignment_time(uuid, timestamptz, timestamptz, text) from public;
+revoke all on function public.admin_correct_assignment_time(uuid, timestamptz, timestamptz, text) from anon;
+grant execute on function public.admin_correct_assignment_time(uuid, timestamptz, timestamptz, text) to authenticated;
+
+
+-- =========================================================
+-- ABWAERTSKOMPATIBILITAET
+-- =========================================================
+-- Rein additiv. Keine bestehende Tabelle, Spalte, Policy, Funktion oder
+-- Trigger wurde veraendert. start_own_job/complete_own_job sind Zeichen
+-- fuer Zeichen unveraendert; der Stundenzettel liest dieselben Spalten wie
+-- zuvor und braucht keine Anpassung. Alte Clients im Feld sehen exakt das
+-- bisherige Verhalten — sie rufen die neue RPC schlicht nie auf.
+--
+-- ROLLBACK:
+--   drop function if exists public.admin_correct_assignment_time(uuid, timestamptz, timestamptz, text);
+--   drop policy if exists "admin read time adjustments in own company" on public.employee_time_adjustments;
+--   drop table if exists public.employee_time_adjustments;
+-- Gefahrlos: kein Bestandsobjekt haengt an der Tabelle oder der Funktion.
+-- Bereits vorgenommene Korrekturen bleiben als Werte in job_assignments
+-- erhalten (nur der Pruefpfad ginge verloren).
+-- =========================================================

--- a/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
+++ b/supabase/migrations/20260814000000_admin_time_correction_foundation.sql
@@ -242,6 +242,14 @@ using (
 --     c) employee_id IS NULL — anonymisierte Zeile einer Kontoloeschung;
 --        der Stundenzettel filtert immer auf eine konkrete employee_id.
 --
+--   Aus demselben Grund verlangt die RPC BEIDE neuen Zeitstempel: sie
+--   schreibt beide Spalten unbedingt, ein einzeln uebergebener Wert wuerde
+--   den anderen also auf NULL setzen. Weil mapEntry nach dem Cutoff beide
+--   Werte verlangt, liesse eine solche "Teilkorrektur" die bereits korrekt
+--   erfasste Zeile des Mitarbeiters vollstaendig verschwinden — derselbe
+--   stille Verlust, nur in die Gegenrichtung. Wer nur einen Wert aendern
+--   will, schickt den anderen unveraendert mit.
+--
 -- WARUM ALT-AUFTRAEGE (VOR PHASE 1) ABGELEHNT WERDEN:
 --   Fuer sie liest der Stundenzettel ueber isLegacyJob() die GETEILTE
 --   Job-Uhr. Wuerde man dort employee_started_at/completed_at setzen,
@@ -265,7 +273,6 @@ declare
   v_assignment    public.job_assignments%rowtype;
   v_job           public.jobs%rowtype;
   v_reason        text;
-  v_attendance    public.attendance_state;
   -- Entspricht PHASE1_CUTOFF_ISO in services/timesheets/timesheet.service.ts
   -- (Migration 20260812000000, "Phase 1 Worked Time"). Bewusst dieselbe
   -- Konstante: Client und Server duerfen bei der Frage "gilt hier noch der
@@ -291,18 +298,29 @@ begin
       using errcode = '23514';
   end if;
 
-  -- Beide NULL waere keine Korrektur, sondern ein Loeschen der erfassten
-  -- Zeit — dafuer gibt es weder einen definierten attendance-Zustand noch
-  -- einen fachlichen Anlass (eine faelschlich zugewiesene Person wird aus
-  -- der Zuweisungsmenge entfernt, nicht auf NULL korrigiert).
-  if new_started_at is null and new_completed_at is null then
-    raise exception 'At least one of new_started_at / new_completed_at must be set'
+  -- BEIDE Zeitstempel sind PFLICHT — eine Korrektur beschreibt immer ein
+  -- VOLLSTAENDIGES Arbeitsintervall.
+  --
+  -- Warum keine Teilkorrektur: die UPDATE-Anweisung unten schreibt beide
+  -- Spalten unbedingt (Ueberschreiben ist gewollt, siehe dort). Ein Aufruf
+  -- mit nur einem Zeitstempel wuerde den anderen also auf NULL setzen. Da
+  -- der Stundenzettel fuer Auftraege nach dem Cutoff BEIDE Werte verlangt
+  -- (mapEntry: hasOwnTimes), verschwindet die Zeile des Mitarbeiters damit
+  -- vollstaendig — aus einer beabsichtigten Teilkorrektur wird ein stiller
+  -- Verlust bereits korrekt erfasster, bezahlter Arbeitszeit.
+  --
+  -- Das Loeschen einer Erfassung bleibt fachlich denkbar ("war doch nicht
+  -- da"), ist aber bewusst NICHT ueber diese RPC moeglich: es waere von
+  -- einer versehentlichen Teilkorrektur nicht zu unterscheiden. Wer nur
+  -- einen der beiden Werte aendern will, schickt den anderen unveraendert
+  -- mit.
+  if new_started_at is null or new_completed_at is null then
+    raise exception
+      'Both new_started_at and new_completed_at are required (a partial correction would clear the other value and remove the timesheet entry)'
       using errcode = '23514';
   end if;
 
-  if new_started_at is not null
-     and new_completed_at is not null
-     and new_completed_at <= new_started_at then
+  if new_completed_at <= new_started_at then
     raise exception 'new_completed_at must be after new_started_at'
       using errcode = '23514';
   end if;
@@ -396,32 +414,29 @@ begin
       using errcode = '22023';
   end if;
 
-  -- ── 3) Neuer attendance-Zustand ──────────────────────────────────
-  -- KEIN neuer Enum-Wert: die Herkunft der Zeit ("vom Admin korrigiert")
-  -- steht im Pruefpfad, nicht im Zustand. Wichtig ist, dass attendance
-  -- ueberhaupt mitgezogen wird: counts_for_timesheet ist eine GENERIERTE
-  -- Spalte auf attendance/review (Phase 1) und bliebe bei 'assigned'
-  -- dauerhaft false — eine korrigierte Zeile waere damit fuer jede kuenftige
-  -- Abrechnungs-Berechtigung unsichtbar.
-  v_attendance := case
-    when new_started_at is not null and new_completed_at is not null then 'completed'
-    when new_completed_at is not null                                then 'completed'
-    else                                                                  'started'
-  end::public.attendance_state;
-
-  -- ── 4) NUR die eigene Zuweisungszeile aktualisieren ───────────────
+  -- ── 3) NUR die eigene Zuweisungszeile aktualisieren ───────────────
   -- Ueberschreibt bewusst (kein COALESCE): eine Korrektur MUSS einen
   -- bestehenden, falschen Wert ersetzen koennen — anders als
   -- start_own_job/complete_own_job, wo "der Erste gewinnt" gilt.
   -- jobs.started_at/completed_at werden hier NICHT angefasst.
+  --
+  -- attendance ist unbedingt 'completed': beide Zeitstempel sind ab hier
+  -- garantiert gesetzt (Validierung oben), die Korrektur beschreibt also
+  -- immer ein abgeschlossenes Arbeitsintervall. KEIN neuer Enum-Wert — die
+  -- Herkunft der Zeit ("vom Admin korrigiert") steht im Pruefpfad, nicht im
+  -- Zustand. Dass attendance ueberhaupt mitgezogen wird, ist wesentlich:
+  -- counts_for_timesheet ist eine GENERIERTE Spalte auf attendance/review
+  -- (Phase 1) und bliebe bei 'assigned' dauerhaft false — eine korrigierte
+  -- Zeile waere damit fuer jede kuenftige Abrechnungs-Berechtigung
+  -- unsichtbar.
   update public.job_assignments
   set
     employee_started_at   = new_started_at,
     employee_completed_at = new_completed_at,
-    attendance            = v_attendance
+    attendance            = 'completed'
   where id = assignment_id_input;
 
-  -- ── 5) Pruefpfad in DERSELBEN Transaktion ────────────────────────
+  -- ── 4) Pruefpfad in DERSELBEN Transaktion ────────────────────────
   insert into public.employee_time_adjustments (
     assignment_id, job_id, employee_id,
     old_started_at, old_completed_at,
@@ -435,7 +450,7 @@ begin
     auth.uid(), v_reason
   );
 
-  -- ── 6) Ergebnis ──────────────────────────────────────────────────
+  -- ── 5) Ergebnis ──────────────────────────────────────────────────
   -- jobs.updated_at wurde durch touch_job_on_assignment_change_trg bereits
   -- angehoben (siehe Kopf) — kein zusaetzlicher Schreibvorgang noetig.
   return query
@@ -452,8 +467,12 @@ comment on function public.admin_correct_assignment_time(uuid, timestamptz, time
 'derselben Transaktion einen Pruefpfad-Eintrag in employee_time_adjustments '
 'an. Faesst jobs.started_at/completed_at NIEMALS an — die geteilte Job-Uhr '
 'und damit die Zeiten aller uebrigen Zugewiesenen bleiben unveraendert. '
-'Verlangt einen nicht-leeren Grund, mindestens einen der beiden neuen '
-'Zeitstempel und (falls beide gesetzt) Ende nach Beginn. Korrigierbar sind '
+'Verlangt einen nicht-leeren Grund sowie BEIDE neuen Zeitstempel mit Ende '
+'nach Beginn — eine Korrektur beschreibt immer ein vollstaendiges '
+'Arbeitsintervall. Teilkorrekturen werden abgelehnt: da beide Spalten '
+'unbedingt geschrieben werden, wuerde ein einzelner Zeitstempel den anderen '
+'auf NULL setzen und die Stundenzettel-Zeile des Mitarbeiters restlos '
+'entfernen (mapEntry verlangt nach dem Cutoff beide Werte). Korrigierbar sind '
 'ausschliesslich Auftraege mit job_type=''single'' (Recurring-Parent-Regeln '
 'erscheinen nie im Stundenzettel) und Status ''completed'' mit vollstaendiger '
 'geteilter Uhr; Auftraege, die vor dem Worked-Time-Grenzwert 2026-08-12 '

--- a/supabase/tests/admin_time_correction_foundation.test.sql
+++ b/supabase/tests/admin_time_correction_foundation.test.sql
@@ -495,40 +495,99 @@ select 24, 'Alt-Auftrag bleibt nach Ablehnung unveraendert', 'OK',
 
 
 -- =========================================================
--- TEILKORREKTUR + UEBERSCHREIBEN
+-- TEILKORREKTUR ABGELEHNT + UEBERSCHREIBEN
 -- =========================================================
--- CASE 25: nur Beginn gesetzt -> attendance='started'.
--- CASE 26: eine ZWEITE Korrektur ueberschreibt (kein COALESCE) und legt
---          eine zweite Audit-Zeile an, deren Altwerte die vorherigen
---          Neuwerte sind — die Kette bleibt luecken los nachvollziehbar.
+-- CASE 25: eine Teilkorrektur (nur Beginn ODER nur Ende) wird abgelehnt UND
+--          laesst die bestehenden Zeitstempel unveraendert. Vor der
+--          Verschaerfung des RPC-Vertrags war genau das der gefaehrlichste
+--          Pfad: die Anweisung schreibt beide Spalten unbedingt, ein
+--          einzelner Wert setzte den anderen also auf NULL — und weil
+--          mapEntry nach dem Cutoff BEIDE Werte verlangt, verschwand die
+--          bereits korrekt erfasste, bezahlte Zeile des Mitarbeiters
+--          restlos aus dem Stundenzettel.
+-- CASE 26: eine ZWEITE, VOLLSTAENDIGE Korrektur ueberschreibt (kein
+--          COALESCE) und legt eine zweite Audit-Zeile an, deren Altwerte die
+--          vorherigen Neuwerte sind — die Kette bleibt lueckenlos
+--          nachvollziehbar.
+do $$
+declare
+  v_assignment uuid := current_setting('atc.ahmad_assignment')::uuid;
+  r_nur_beginn boolean := false;
+  r_nur_ende   boolean := false;
+  s_nach timestamptz; e_nach timestamptz;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+
+  begin perform public.admin_correct_assignment_time(
+    v_assignment, timestamptz '2026-08-20 07:30+00', null, 'Nur Beginn bekannt.');
+  exception when others then r_nur_beginn := true; end;
+
+  begin perform public.admin_correct_assignment_time(
+    v_assignment, null, timestamptz '2026-08-20 12:30+00', 'Nur Ende bekannt.');
+  exception when others then r_nur_ende := true; end;
+
+  execute 'reset role';
+
+  select employee_started_at, employee_completed_at into s_nach, e_nach
+  from public.job_assignments where id = v_assignment;
+
+  insert into _atc values
+    (25, 'Teilkorrektur abgelehnt, bestehende Zeiten unveraendert',
+     'nur_beginn=ABGELEHNT/nur_ende=ABGELEHNT/zeiten=08:00-12:00',
+     'nur_beginn=' || (case when r_nur_beginn then 'ABGELEHNT' else 'AKZEPTIERT' end)
+     || '/nur_ende=' || (case when r_nur_ende then 'ABGELEHNT' else 'AKZEPTIERT' end)
+     || '/zeiten='
+     || (case when s_nach = timestamptz '2026-08-20 08:00+00'
+                   and e_nach = timestamptz '2026-08-20 12:00+00'
+              then '08:00-12:00' else 'VERAENDERT' end));
+end $$;
+
+-- Zweite, VOLLSTAENDIGE Korrektur (07:30-12:30).
 do $$
 declare v_assignment uuid := current_setting('atc.ahmad_assignment')::uuid;
 begin
   perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
   execute 'set local role authenticated';
   perform public.admin_correct_assignment_time(
-    v_assignment, timestamptz '2026-08-20 07:30+00', null, 'Nur Beginn bekannt.');
+    v_assignment, timestamptz '2026-08-20 07:30+00', timestamptz '2026-08-20 12:30+00',
+    'Beginn und Ende nachtraeglich bestaetigt.');
   execute 'reset role';
 end $$;
-
-insert into _atc
-select 25, 'Nur Beginn gesetzt -> attendance=started, Ende NULL', 'started/NULL',
-  coalesce((select attendance::text || '/' || coalesce(employee_completed_at::text,'NULL')
-            from public.job_assignments where id = current_setting('atc.ahmad_assignment')::uuid), 'KEINE_ZEILE');
 
 insert into _atc
 select 26, 'Zweite Korrektur ueberschreibt und protokolliert die Altwerte', 'OK',
   case when (select employee_started_at from public.job_assignments
              where id = current_setting('atc.ahmad_assignment')::uuid) = timestamptz '2026-08-20 07:30+00'
+        and (select employee_completed_at from public.job_assignments
+             where id = current_setting('atc.ahmad_assignment')::uuid) = timestamptz '2026-08-20 12:30+00'
         and exists (
           select 1 from public.employee_time_adjustments
           where assignment_id    = current_setting('atc.ahmad_assignment')::uuid
             and old_started_at   = timestamptz '2026-08-20 08:00+00'
             and old_completed_at = timestamptz '2026-08-20 12:00+00'
             and new_started_at   = timestamptz '2026-08-20 07:30+00'
-            and new_completed_at is null
+            and new_completed_at = timestamptz '2026-08-20 12:30+00'
         )
        then 'OK' else 'FALSCH' end;
+
+-- CASE 33: nach der zweiten Korrektur bleibt der Mitarbeiter abrechenbar —
+-- der Nachweis, dass eine vollstaendige Korrektur die Stundenzettel-Zeile
+-- NICHT entfernt (Gegenprobe zu CASE 25). Repliziert den Filter aus
+-- services/timesheets/timesheet.service.ts.
+insert into _atc
+select 33, 'Nach vollstaendiger Korrektur bleibt die Stundenzettel-Zeile bestehen', '1',
+  (select count(*)::text
+     from public.job_assignments ja
+     join public.jobs j on j.id = ja.job_id
+    where ja.employee_id = 'a2000000-0000-0000-0000-0000000000c2'
+      and j.id           = 'a4000000-0000-0000-0000-0000000000c1'
+      and j.status       = 'completed'
+      and j.job_type     = 'single'
+      and j.started_at   is not null
+      and j.completed_at is not null
+      and ja.employee_started_at   is not null
+      and ja.employee_completed_at is not null);
 
 -- CASE 27: die geteilte Uhr ist AUCH nach der zweiten Korrektur unberuehrt.
 insert into _atc

--- a/supabase/tests/admin_time_correction_foundation.test.sql
+++ b/supabase/tests/admin_time_correction_foundation.test.sql
@@ -73,13 +73,22 @@ create temporary table _atc (
 --   J2 = {Ahmad},        Alt-Auftrag, abgeschlossen VOR dem Cutoff
 --   J3 = {Ahmad},        bleibt offen (nicht korrigierbar)
 --   J4 = Firma B, {Bea}, abgeschlossen NACH Cutoff (Firmengrenze)
+--   J5 = RECURRING-PARENT, {Maria}, kuenstlich auf 'completed' gesetzt
+--   J6 = {Ahmad}, abgeschlossen NACH Cutoff, Zuweisung wird anonymisiert
 insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
                          location_address, status, job_type, date, start_time,
                          is_active, created_at, updated_at) values
   ('a4000000-0000-0000-0000-0000000000c1','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Mueller','Unterhaltsreinigung','Hauptstr. 1','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
   ('a4000000-0000-0000-0000-0000000000c2','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Altkunde','Grundreinigung','Altweg 2','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
   ('a4000000-0000-0000-0000-0000000000c3','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Offen','Fensterreinigung','Offenweg 3','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
-  ('a4000000-0000-0000-0000-0000000000c4','a1000000-0000-0000-0000-0000000000c2',null,'a2000000-0000-0000-0000-0000000000c4','Fremd','Glasreinigung','Fremdweg 4','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00');
+  ('a4000000-0000-0000-0000-0000000000c4','a1000000-0000-0000-0000-0000000000c2',null,'a2000000-0000-0000-0000-0000000000c4','Fremd','Glasreinigung','Fremdweg 4','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
+  ('a4000000-0000-0000-0000-0000000000c6','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Anonym','Grundreinigung','Anonymweg 6','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00');
+
+-- J5: Recurring-PARENT-Regel (traegt seit Phase 4 selbst Zuweisungen).
+insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                         location_address, status, job_type, recurring_days, start_time,
+                         is_active, recurrence_start_date, created_at, updated_at) values
+  ('a4000000-0000-0000-0000-0000000000c5','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Dauerkunde','Unterhaltsreinigung','Dauerweg 5','open','recurring',array['mon','tue','wed','thu','fri','sat','sun'],'08:00',true,current_date - 1,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00');
 
 -- Zuweisungen ueber den echten App-Pfad (set_job_assignments).
 do $$
@@ -91,6 +100,11 @@ begin
   perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c2',
     array['a2000000-0000-0000-0000-0000000000c2']::uuid[]);
   perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c3',
+    array['a2000000-0000-0000-0000-0000000000c2']::uuid[]);
+  -- Recurring-PARENT traegt eine Zuweisung als Vorlage (Phase 4).
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c5',
+    array['a2000000-0000-0000-0000-0000000000c3']::uuid[]);
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c6',
     array['a2000000-0000-0000-0000-0000000000c2']::uuid[]);
   execute 'reset role';
 
@@ -128,7 +142,33 @@ begin
   perform public.start_own_job   ('a4000000-0000-0000-0000-0000000000c4', timestamptz '2026-08-20 09:00+00');
   perform public.complete_own_job('a4000000-0000-0000-0000-0000000000c4', timestamptz '2026-08-20 13:00+00');
   execute 'reset role';
+
+  -- J6: Ahmad erledigt, NACH dem Cutoff (Basis fuer die Anonymisierung).
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c2');
+  execute 'set local role authenticated';
+  perform public.start_own_job   ('a4000000-0000-0000-0000-0000000000c6', timestamptz '2026-08-20 09:00+00');
+  perform public.complete_own_job('a4000000-0000-0000-0000-0000000000c6', timestamptz '2026-08-20 12:30+00');
+  execute 'reset role';
 end $$;
+
+-- J5 (Recurring-PARENT) kuenstlich in den korrigierbar AUSSEHENDEN Zustand
+-- bringen: status='completed' + vollstaendige geteilte Uhr NACH dem Cutoff.
+-- Genau dieser Zustand ist real erreichbar — die Policy "admin update jobs
+-- in own company" kennt keine Spalten-/Statusgrenze und
+-- trg_jobs_protect_recurring_history greift nur BEFORE DELETE.
+-- start_own_job/complete_own_job koennen ihn NICHT herstellen (die lehnen
+-- job_type='recurring' ab), deshalb hier direkt.
+update public.jobs
+set status       = 'completed',
+    started_at   = timestamptz '2026-08-20 08:00+00',
+    completed_at = timestamptz '2026-08-20 12:00+00'
+where id = 'a4000000-0000-0000-0000-0000000000c5';
+
+-- J6-Zuweisung anonymisieren, exakt wie eine Kontoloeschung es tut
+-- (ON DELETE SET NULL auf employee_id). Die Zeile bleibt als Nachweis.
+update public.job_assignments
+set employee_id = null
+where job_id = 'a4000000-0000-0000-0000-0000000000c6';
 
 -- CASE 20 (Regression): start_own_job hat geteilte Uhr UND Marias
 -- Eigenzeit gesetzt — unveraendertes Phase-1-Verhalten.
@@ -366,10 +406,13 @@ declare
   v_assignment uuid := current_setting('atc.ahmad_assignment')::uuid;
   r_leer boolean := false; r_blank boolean := false; r_reihenfolge boolean := false;
   r_beide_null boolean := false; r_legacy boolean := false; r_offen boolean := false;
-  v_a2 uuid; v_a3 uuid;
+  r_recurring boolean := false; r_anonym boolean := false;
+  v_a2 uuid; v_a3 uuid; v_a5 uuid; v_a6 uuid;
 begin
   select id into v_a2 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c2';
   select id into v_a3 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c3';
+  select id into v_a5 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c5';
+  select id into v_a6 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c6';
 
   perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
   execute 'set local role authenticated';
@@ -394,6 +437,15 @@ begin
   begin perform public.admin_correct_assignment_time(v_a3, timestamptz '2026-08-20 08:00+00', timestamptz '2026-08-20 12:00+00', 'Offener Auftrag');
   exception when others then r_offen := true; end;
 
+  -- Recurring-PARENT-Regel: sieht vollstaendig korrigierbar aus (completed,
+  -- geteilte Uhr, nach Cutoff), erscheint aber NIE im Stundenzettel.
+  begin perform public.admin_correct_assignment_time(v_a5, timestamptz '2026-08-20 08:00+00', timestamptz '2026-08-20 12:00+00', 'Dauerauftrag-Regel');
+  exception when others then r_recurring := true; end;
+
+  -- Anonymisierte Zuweisung (employee_id IS NULL nach Kontoloeschung).
+  begin perform public.admin_correct_assignment_time(v_a6, timestamptz '2026-08-20 09:00+00', timestamptz '2026-08-20 12:30+00', 'Geloeschtes Konto');
+  exception when others then r_anonym := true; end;
+
   execute 'reset role';
 
   insert into _atc values
@@ -402,8 +454,30 @@ begin
     (17, 'Ende vor/gleich Beginn wird abgelehnt',                    'ABGELEHNT', case when r_reihenfolge then 'ABGELEHNT' else 'AKZEPTIERT' end),
     (18, 'Beide Zeitstempel NULL wird abgelehnt',                    'ABGELEHNT', case when r_beide_null  then 'ABGELEHNT' else 'AKZEPTIERT' end),
     (19, 'Alt-Auftrag vor Phase-1-Cutoff wird abgelehnt',            'ABGELEHNT', case when r_legacy      then 'ABGELEHNT' else 'AKZEPTIERT' end),
-    (22, 'Nicht abgeschlossener Auftrag wird abgelehnt',             'ABGELEHNT', case when r_offen       then 'ABGELEHNT' else 'AKZEPTIERT' end);
+    (22, 'Nicht abgeschlossener Auftrag wird abgelehnt',             'ABGELEHNT', case when r_offen       then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (29, 'Recurring-PARENT-Regel wird abgelehnt (job_type<>single)',  'ABGELEHNT', case when r_recurring   then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (30, 'Anonymisierte Zuweisung (employee_id NULL) wird abgelehnt', 'ABGELEHNT', case when r_anonym      then 'ABGELEHNT' else 'AKZEPTIERT' end);
 end $$;
+
+-- CASE 31: die abgelehnte Parent-Regel ist unveraendert — insbesondere
+-- traegt ihre Zuweisung weiterhin KEINE Eigenzeit.
+insert into _atc
+select 31, 'Parent-Regel-Zuweisung nach Ablehnung ohne Eigenzeit', 'OK',
+  case when (select employee_started_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c5') is null
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c5') is null
+       then 'OK' else 'VERAENDERT' end;
+
+-- CASE 32: die anonymisierte Zeile behaelt die Zeiten, die der Mitarbeiter
+-- vor der Kontoloeschung selbst erfasst hat (Nachweis bleibt unberuehrt).
+insert into _atc
+select 32, 'Anonymisierte Zuweisung nach Ablehnung unveraendert', 'OK',
+  case when (select employee_started_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c6') = timestamptz '2026-08-20 09:00+00'
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c6') = timestamptz '2026-08-20 12:30+00'
+       then 'OK' else 'VERAENDERT' end;
 
 -- CASE 23: Nach allen abgelehnten Versuchen existiert weiterhin GENAU EIN
 -- Audit-Eintrag — kein abgelehnter Aufruf hat geschrieben.

--- a/supabase/tests/admin_time_correction_foundation.test.sql
+++ b/supabase/tests/admin_time_correction_foundation.test.sql
@@ -1,0 +1,492 @@
+-- =========================================================
+-- TEST: admin_correct_assignment_time + employee_time_adjustments
+-- (Migration 20260814000000_admin_time_correction_foundation)
+-- =========================================================
+-- Weist nach:
+--   * Ein Admin korrigiert die Zeit EINES Mitarbeiters; attendance zieht
+--     mit und ein Pruefpfad-Eintrag entsteht.
+--   * Mehrfachzuweisung: die Kollegin bleibt unveraendert, und die
+--     GETEILTE Job-Uhr (jobs.started_at/completed_at) wird NICHT angefasst.
+--   * jobs.updated_at steigt (Realtime-Kette ueber den bestehenden
+--     touch_job_on_assignment_change_trg).
+--   * Sicherheit: Mitarbeiter abgelehnt, fremde Firma abgelehnt,
+--     employee_time_adjustments ohne Schreibrechte und firmenisoliert.
+--   * Validierung: leerer Grund, Ende <= Beginn, beide NULL, nicht
+--     abgeschlossener Auftrag, Alt-Auftrag vor dem Phase-1-Grenzwert.
+--   * Regression: start_own_job/complete_own_job unveraendert.
+--
+-- Aufrufe laufen als 'authenticated' (SET ROLE + request.jwt.claims), also
+-- ueber denselben Pfad wie die App.
+--
+-- AUSFUEHREN lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/admin_time_correction_foundation.test.sql
+-- Legt Testdaten an, macht am Ende ROLLBACK — KEINE Rueckstaende.
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = g1…1 | Admin A = g2…1 | Ahmad = g2…2 | Maria = g2…3
+-- Firma B = g1…2 | Admin B = g2…4 | Bea   = g2…5
+
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data)
+  values
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-0000000000c1','authenticated','authenticated','atc-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-0000000000c2','authenticated','authenticated','atc-ahmad@example.test','{"full_name":"Ahmad"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-0000000000c3','authenticated','authenticated','atc-maria@example.test','{"full_name":"Maria"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-0000000000c4','authenticated','authenticated','atc-adminB@example.test','{"full_name":"Admin B"}'),
+    ('00000000-0000-0000-0000-000000000000','a2000000-0000-0000-0000-0000000000c5','authenticated','authenticated','atc-bea@example.test','{"full_name":"Bea"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('a2000000-0000-0000-0000-0000000000c1','Admin A'),
+  ('a2000000-0000-0000-0000-0000000000c2','Ahmad'),
+  ('a2000000-0000-0000-0000-0000000000c3','Maria'),
+  ('a2000000-0000-0000-0000-0000000000c4','Admin B'),
+  ('a2000000-0000-0000-0000-0000000000c5','Bea')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('a1000000-0000-0000-0000-0000000000c1','ATC Firma A','atc-firma-a-test'),
+  ('a1000000-0000-0000-0000-0000000000c2','ATC Firma B','atc-firma-b-test');
+
+update public.profiles set company_id='a1000000-0000-0000-0000-0000000000c1', role='admin',    is_active=true where id='a2000000-0000-0000-0000-0000000000c1';
+update public.profiles set company_id='a1000000-0000-0000-0000-0000000000c1', role='employee', is_active=true where id in ('a2000000-0000-0000-0000-0000000000c2','a2000000-0000-0000-0000-0000000000c3');
+update public.profiles set company_id='a1000000-0000-0000-0000-0000000000c2', role='admin',    is_active=true where id='a2000000-0000-0000-0000-0000000000c4';
+update public.profiles set company_id='a1000000-0000-0000-0000-0000000000c2', role='employee', is_active=true where id='a2000000-0000-0000-0000-0000000000c5';
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub', uid::text, 'role','authenticated')::text, true);
+end $f$;
+
+create temporary table _atc (
+  case_no int, beschreibung text, erwartet text, ergebnis text
+) on commit drop;
+
+-- Auftraege. updated_at bewusst auf 2020 gesetzt, damit der spaetere
+-- Realtime-Nachweis (updated_at steigt) eindeutig ist.
+--   J1 = {Ahmad, Maria}, wird von Maria gestartet+abgeschlossen (NACH Cutoff)
+--   J2 = {Ahmad},        Alt-Auftrag, abgeschlossen VOR dem Cutoff
+--   J3 = {Ahmad},        bleibt offen (nicht korrigierbar)
+--   J4 = Firma B, {Bea}, abgeschlossen NACH Cutoff (Firmengrenze)
+insert into public.jobs (id, company_id, assigned_to, created_by, customer_name, service_name,
+                         location_address, status, job_type, date, start_time,
+                         is_active, created_at, updated_at) values
+  ('a4000000-0000-0000-0000-0000000000c1','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Mueller','Unterhaltsreinigung','Hauptstr. 1','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
+  ('a4000000-0000-0000-0000-0000000000c2','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Altkunde','Grundreinigung','Altweg 2','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
+  ('a4000000-0000-0000-0000-0000000000c3','a1000000-0000-0000-0000-0000000000c1',null,'a2000000-0000-0000-0000-0000000000c1','Offen','Fensterreinigung','Offenweg 3','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00'),
+  ('a4000000-0000-0000-0000-0000000000c4','a1000000-0000-0000-0000-0000000000c2',null,'a2000000-0000-0000-0000-0000000000c4','Fremd','Glasreinigung','Fremdweg 4','open','single',current_date,'08:00',true,timestamptz '2020-01-01 10:00+00',timestamptz '2020-01-01 10:00+00');
+
+-- Zuweisungen ueber den echten App-Pfad (set_job_assignments).
+do $$
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c1',
+    array['a2000000-0000-0000-0000-0000000000c2','a2000000-0000-0000-0000-0000000000c3']::uuid[]);
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c2',
+    array['a2000000-0000-0000-0000-0000000000c2']::uuid[]);
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c3',
+    array['a2000000-0000-0000-0000-0000000000c2']::uuid[]);
+  execute 'reset role';
+
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c4');
+  execute 'set local role authenticated';
+  perform public.set_job_assignments('a4000000-0000-0000-0000-0000000000c4',
+    array['a2000000-0000-0000-0000-0000000000c5']::uuid[]);
+  execute 'reset role';
+end $$;
+
+-- =========================================================
+-- AUSGANGSLAGE: Maria erfasst korrekt, Ahmad vergisst BEIDES.
+-- Laeuft ueber die echten RPCs — damit ist die Ausgangslage zugleich der
+-- Regressionsnachweis fuer start_own_job/complete_own_job (CASE 20/21).
+-- =========================================================
+do $$
+begin
+  -- J1: Maria startet 08:00 und schliesst 12:00 ab (NACH dem Cutoff).
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c3');
+  execute 'set local role authenticated';
+  perform public.start_own_job   ('a4000000-0000-0000-0000-0000000000c1', timestamptz '2026-08-20 08:00+00');
+  perform public.complete_own_job('a4000000-0000-0000-0000-0000000000c1', timestamptz '2026-08-20 12:00+00');
+  execute 'reset role';
+
+  -- J2: Ahmad hat den Alt-Auftrag selbst erledigt — VOR dem Cutoff.
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c2');
+  execute 'set local role authenticated';
+  perform public.start_own_job   ('a4000000-0000-0000-0000-0000000000c2', timestamptz '2026-07-01 08:00+00');
+  perform public.complete_own_job('a4000000-0000-0000-0000-0000000000c2', timestamptz '2026-07-01 11:00+00');
+  execute 'reset role';
+
+  -- J4 (Firma B): Bea erledigt, NACH dem Cutoff.
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c5');
+  execute 'set local role authenticated';
+  perform public.start_own_job   ('a4000000-0000-0000-0000-0000000000c4', timestamptz '2026-08-20 09:00+00');
+  perform public.complete_own_job('a4000000-0000-0000-0000-0000000000c4', timestamptz '2026-08-20 13:00+00');
+  execute 'reset role';
+end $$;
+
+-- CASE 20 (Regression): start_own_job hat geteilte Uhr UND Marias
+-- Eigenzeit gesetzt — unveraendertes Phase-1-Verhalten.
+insert into _atc
+select 20, 'Regression: start_own_job setzt geteilte Uhr + Eigenzeit des Ausloesers', 'OK',
+  case when (select started_at from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 08:00+00'
+        and (select employee_started_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c3') = timestamptz '2026-08-20 08:00+00'
+       then 'OK' else 'ABWEICHUNG' end;
+
+-- CASE 21 (Regression): complete_own_job ebenso; Ahmad hat als NICHT-Ausloeser
+-- weiterhin KEINE Eigenzeit (genau der Anlass fuer die Korrektur).
+insert into _atc
+select 21, 'Regression: complete_own_job setzt Abschluss; Nicht-Ausloeser bleibt ohne Eigenzeit', 'OK',
+  case when (select completed_at from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 12:00+00'
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c3') = timestamptz '2026-08-20 12:00+00'
+        and (select employee_started_at   from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2') is null
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2') is null
+       then 'OK' else 'ABWEICHUNG' end;
+
+
+-- =========================================================
+-- SZENARIO 1+2: Admin korrigiert AHMAD (08:00–12:00) auf J1.
+-- =========================================================
+do $$
+declare
+  v_assignment uuid;
+  v_before_updated timestamptz;
+begin
+  select id into v_assignment from public.job_assignments
+   where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2';
+
+  select updated_at into v_before_updated from public.jobs where id='a4000000-0000-0000-0000-0000000000c1';
+  perform set_config('atc.before_updated', v_before_updated::text, true);
+  perform set_config('atc.ahmad_assignment', v_assignment::text, true);
+
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+  perform public.admin_correct_assignment_time(
+    v_assignment,
+    timestamptz '2026-08-20 08:00+00',
+    timestamptz '2026-08-20 12:00+00',
+    'Ahmad hat Start und Abschluss vergessen; Zeiten vom Objektleiter bestaetigt.'
+  );
+  execute 'reset role';
+end $$;
+
+-- CASE 1: Ahmads Zeiten stehen jetzt.
+insert into _atc
+select 1, 'Ahmads Eigenzeit wurde gesetzt (08:00-12:00)', 'OK',
+  case when (select employee_started_at   from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2') = timestamptz '2026-08-20 08:00+00'
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2') = timestamptz '2026-08-20 12:00+00'
+       then 'OK' else 'FALSCH' end;
+
+-- CASE 2: attendance ist mitgezogen -> counts_for_timesheet wird true.
+insert into _atc
+select 2, 'attendance=completed und counts_for_timesheet=true nach Korrektur', 'completed/true',
+  coalesce((select attendance::text || '/' || counts_for_timesheet::text
+            from public.job_assignments
+            where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c2'), 'KEINE_ZEILE');
+
+-- CASE 3: Pruefpfad-Eintrag mit Alt-/Neuwerten, Admin und Grund.
+insert into _atc
+select 3, 'Audit-Zeile mit alten NULL-Werten, neuen Zeiten, Admin und Grund', 'OK',
+  case when exists (
+    select 1 from public.employee_time_adjustments
+    where job_id           = 'a4000000-0000-0000-0000-0000000000c1'
+      and employee_id      = 'a2000000-0000-0000-0000-0000000000c2'
+      and old_started_at   is null
+      and old_completed_at is null
+      and new_started_at   = timestamptz '2026-08-20 08:00+00'
+      and new_completed_at = timestamptz '2026-08-20 12:00+00'
+      and changed_by       = 'a2000000-0000-0000-0000-0000000000c1'
+      and length(btrim(reason)) > 0
+  ) then 'OK' else 'FEHLT' end;
+
+-- CASE 4: MARIA ist unveraendert (Kernanforderung Mehrfachzuweisung).
+insert into _atc
+select 4, 'Maria bleibt unveraendert (08:00-12:00, attendance=completed)', 'OK',
+  case when (select employee_started_at   from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c3') = timestamptz '2026-08-20 08:00+00'
+        and (select employee_completed_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c1' and employee_id='a2000000-0000-0000-0000-0000000000c3') = timestamptz '2026-08-20 12:00+00'
+       then 'OK' else 'VERAENDERT' end;
+
+-- CASE 5: Fuer Maria wurde KEIN Pruefpfad-Eintrag erzeugt.
+insert into _atc
+select 5, 'Keine Audit-Zeile fuer die nicht korrigierte Kollegin', '0',
+  (select count(*)::text from public.employee_time_adjustments
+    where employee_id='a2000000-0000-0000-0000-0000000000c3');
+
+-- CASE 6: DIE GETEILTE JOB-UHR IST UNANGETASTET.
+insert into _atc
+select 6, 'jobs.started_at/completed_at unveraendert (geteilte Uhr)', 'OK',
+  case when (select started_at   from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 08:00+00'
+        and (select completed_at from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 12:00+00'
+        and (select status::text from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = 'completed'
+       then 'OK' else 'VERAENDERT' end;
+
+-- CASE 7: Realtime-Kette ueber den bestehenden
+-- touch_job_on_assignment_change_trg (kein zusaetzlicher Schreibvorgang in
+-- der RPC).
+--
+-- WARUM HIER KEIN VORHER/NACHHER-VERGLEICH MOEGLICH IST: now() liefert die
+-- TRANSAKTIONS-Startzeit und ist innerhalb dieses Tests (begin … rollback)
+-- konstant. Der Trigger schreibt updated_at = now() — ein Vergleich
+-- "nachher > vorher" waere deshalb selbst dann gleich, wenn der Trigger
+-- korrekt feuert (verifiziert: er tut es, tgtype 29 enthaelt UPDATE).
+-- Geprueft wird daher beides, was in einer Transaktion aussagekraeftig ist:
+--   a) der Trigger existiert, ist aktiv und feuert auf UPDATE,
+--   b) jobs.updated_at traegt die Transaktionszeit statt des geseedeten
+--      Werts von 2020 — die Zeile wurde also tatsaechlich angefasst.
+insert into _atc
+select 7, 'Realtime: touch-Trigger aktiv auf UPDATE + jobs.updated_at angefasst', 'trigger=1/updated=jetzt',
+  'trigger=' || (select count(*)::text from pg_trigger
+                  where tgrelid = 'public.job_assignments'::regclass
+                    and tgname  = 'touch_job_on_assignment_change_trg'
+                    and tgenabled = 'O'
+                    and (tgtype & 16) = 16)
+  || '/updated=' || (case when (select updated_at from public.jobs
+                                 where id='a4000000-0000-0000-0000-0000000000c1') = now()
+                          then 'jetzt' else 'alt' end);
+
+
+-- =========================================================
+-- SICHERHEIT
+-- =========================================================
+
+-- CASE 8: Ein MITARBEITER darf die RPC nicht aufrufen.
+do $$
+declare abgelehnt boolean := false;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c2');
+  execute 'set local role authenticated';
+  begin
+    perform public.admin_correct_assignment_time(
+      current_setting('atc.ahmad_assignment')::uuid,
+      timestamptz '2026-08-20 06:00+00', timestamptz '2026-08-20 14:00+00', 'Selbstkorrektur');
+  exception when others then
+    abgelehnt := true;
+  end;
+  execute 'reset role';
+
+  insert into _atc values (8, 'Mitarbeiter kann die Korrektur-RPC NICHT aufrufen', 'ABGELEHNT',
+    case when abgelehnt then 'ABGELEHNT' else 'ERLAUBT' end);
+end $$;
+
+-- CASE 9: Admin einer FREMDEN Firma darf nicht korrigieren.
+do $$
+declare abgelehnt boolean := false;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c4');
+  execute 'set local role authenticated';
+  begin
+    perform public.admin_correct_assignment_time(
+      current_setting('atc.ahmad_assignment')::uuid,
+      timestamptz '2026-08-20 06:00+00', timestamptz '2026-08-20 14:00+00', 'Fremdzugriff');
+  exception when others then
+    abgelehnt := true;
+  end;
+  execute 'reset role';
+
+  insert into _atc values (9, 'Admin einer fremden Firma kann NICHT korrigieren', 'ABGELEHNT',
+    case when abgelehnt then 'ABGELEHNT' else 'ERLAUBT' end);
+end $$;
+
+-- CASE 10: Nach den beiden abgelehnten Versuchen stehen Ahmads Zeiten
+-- unveraendert auf dem korrigierten Wert (keine Teilwirkung).
+insert into _atc
+select 10, 'Abgelehnte Versuche haben nichts veraendert', 'OK',
+  case when (select employee_started_at   from public.job_assignments
+             where id = current_setting('atc.ahmad_assignment')::uuid) = timestamptz '2026-08-20 08:00+00'
+        and (select employee_completed_at from public.job_assignments
+             where id = current_setting('atc.ahmad_assignment')::uuid) = timestamptz '2026-08-20 12:00+00'
+       then 'OK' else 'VERAENDERT' end;
+
+-- CASE 11: employee_time_adjustments — RLS an, anon rechtelos,
+-- authenticated ohne jedes Schreibrecht.
+insert into _atc
+select 11, 'Audit-Tabelle: RLS aktiv, anon rechtelos, authenticated nur SELECT', 'rls=true/anon=0/schreib=0',
+  'rls=' || (select relrowsecurity::text from pg_class where oid='public.employee_time_adjustments'::regclass)
+  || '/anon=' || (select count(*)::text from information_schema.role_table_grants
+                   where table_name='employee_time_adjustments' and grantee='anon')
+  || '/schreib=' || (select count(*)::text from information_schema.role_table_grants
+                      where table_name='employee_time_adjustments' and grantee='authenticated'
+                        and privilege_type in ('INSERT','UPDATE','DELETE'));
+
+-- CASE 12: Admin B sieht die Korrekturen von Firma A NICHT (RLS).
+do $$
+declare sichtbar int;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c4');
+  execute 'set local role authenticated';
+  select count(*) into sichtbar from public.employee_time_adjustments;
+  execute 'reset role';
+
+  insert into _atc values (12, 'Admin der Fremdfirma sieht keine Korrekturen von Firma A', '0', sichtbar::text);
+end $$;
+
+-- CASE 13: Admin A sieht seine eigene Korrektur (Gegenprobe zu CASE 12).
+do $$
+declare sichtbar int;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+  select count(*) into sichtbar from public.employee_time_adjustments;
+  execute 'reset role';
+
+  insert into _atc values (13, 'Admin der eigenen Firma sieht seine Korrektur', '1', sichtbar::text);
+end $$;
+
+-- CASE 14: Ein MITARBEITER sieht keine Korrekturen (keine Employee-Policy).
+do $$
+declare sichtbar int;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c2');
+  execute 'set local role authenticated';
+  select count(*) into sichtbar from public.employee_time_adjustments;
+  execute 'reset role';
+
+  insert into _atc values (14, 'Mitarbeiter sieht keine Korrektur-Eintraege', '0', sichtbar::text);
+end $$;
+
+
+-- =========================================================
+-- VALIDIERUNG
+-- =========================================================
+do $$
+declare
+  v_assignment uuid := current_setting('atc.ahmad_assignment')::uuid;
+  r_leer boolean := false; r_blank boolean := false; r_reihenfolge boolean := false;
+  r_beide_null boolean := false; r_legacy boolean := false; r_offen boolean := false;
+  v_a2 uuid; v_a3 uuid;
+begin
+  select id into v_a2 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c2';
+  select id into v_a3 from public.job_assignments where job_id='a4000000-0000-0000-0000-0000000000c3';
+
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+
+  begin perform public.admin_correct_assignment_time(v_assignment, timestamptz '2026-08-20 08:00+00', timestamptz '2026-08-20 12:00+00', '');
+  exception when others then r_leer := true; end;
+
+  begin perform public.admin_correct_assignment_time(v_assignment, timestamptz '2026-08-20 08:00+00', timestamptz '2026-08-20 12:00+00', '    ');
+  exception when others then r_blank := true; end;
+
+  begin perform public.admin_correct_assignment_time(v_assignment, timestamptz '2026-08-20 12:00+00', timestamptz '2026-08-20 08:00+00', 'Ende vor Beginn');
+  exception when others then r_reihenfolge := true; end;
+
+  begin perform public.admin_correct_assignment_time(v_assignment, null, null, 'Beide leer');
+  exception when others then r_beide_null := true; end;
+
+  -- Alt-Auftrag: abgeschlossen am 2026-07-01, also VOR dem Cutoff.
+  begin perform public.admin_correct_assignment_time(v_a2, timestamptz '2026-07-01 08:00+00', timestamptz '2026-07-01 11:00+00', 'Alt-Auftrag');
+  exception when others then r_legacy := true; end;
+
+  -- Noch offener Auftrag (nie gestartet/abgeschlossen).
+  begin perform public.admin_correct_assignment_time(v_a3, timestamptz '2026-08-20 08:00+00', timestamptz '2026-08-20 12:00+00', 'Offener Auftrag');
+  exception when others then r_offen := true; end;
+
+  execute 'reset role';
+
+  insert into _atc values
+    (15, 'Leerer Grund wird abgelehnt',                              'ABGELEHNT', case when r_leer        then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (16, 'Grund aus reinen Leerzeichen wird abgelehnt',              'ABGELEHNT', case when r_blank       then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (17, 'Ende vor/gleich Beginn wird abgelehnt',                    'ABGELEHNT', case when r_reihenfolge then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (18, 'Beide Zeitstempel NULL wird abgelehnt',                    'ABGELEHNT', case when r_beide_null  then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (19, 'Alt-Auftrag vor Phase-1-Cutoff wird abgelehnt',            'ABGELEHNT', case when r_legacy      then 'ABGELEHNT' else 'AKZEPTIERT' end),
+    (22, 'Nicht abgeschlossener Auftrag wird abgelehnt',             'ABGELEHNT', case when r_offen       then 'ABGELEHNT' else 'AKZEPTIERT' end);
+end $$;
+
+-- CASE 23: Nach allen abgelehnten Versuchen existiert weiterhin GENAU EIN
+-- Audit-Eintrag — kein abgelehnter Aufruf hat geschrieben.
+insert into _atc
+select 23, 'Abgelehnte Aufrufe erzeugen keinen Audit-Eintrag', '1',
+  (select count(*)::text from public.employee_time_adjustments);
+
+-- CASE 24: Alt-Auftrag J2 traegt weiterhin Ahmads urspruengliche Eigenzeit
+-- (die Ablehnung hat nichts veraendert).
+insert into _atc
+select 24, 'Alt-Auftrag bleibt nach Ablehnung unveraendert', 'OK',
+  case when (select employee_started_at from public.job_assignments
+             where job_id='a4000000-0000-0000-0000-0000000000c2') = timestamptz '2026-07-01 08:00+00'
+       then 'OK' else 'VERAENDERT' end;
+
+
+-- =========================================================
+-- TEILKORREKTUR + UEBERSCHREIBEN
+-- =========================================================
+-- CASE 25: nur Beginn gesetzt -> attendance='started'.
+-- CASE 26: eine ZWEITE Korrektur ueberschreibt (kein COALESCE) und legt
+--          eine zweite Audit-Zeile an, deren Altwerte die vorherigen
+--          Neuwerte sind — die Kette bleibt luecken los nachvollziehbar.
+do $$
+declare v_assignment uuid := current_setting('atc.ahmad_assignment')::uuid;
+begin
+  perform pg_temp.act_as('a2000000-0000-0000-0000-0000000000c1');
+  execute 'set local role authenticated';
+  perform public.admin_correct_assignment_time(
+    v_assignment, timestamptz '2026-08-20 07:30+00', null, 'Nur Beginn bekannt.');
+  execute 'reset role';
+end $$;
+
+insert into _atc
+select 25, 'Nur Beginn gesetzt -> attendance=started, Ende NULL', 'started/NULL',
+  coalesce((select attendance::text || '/' || coalesce(employee_completed_at::text,'NULL')
+            from public.job_assignments where id = current_setting('atc.ahmad_assignment')::uuid), 'KEINE_ZEILE');
+
+insert into _atc
+select 26, 'Zweite Korrektur ueberschreibt und protokolliert die Altwerte', 'OK',
+  case when (select employee_started_at from public.job_assignments
+             where id = current_setting('atc.ahmad_assignment')::uuid) = timestamptz '2026-08-20 07:30+00'
+        and exists (
+          select 1 from public.employee_time_adjustments
+          where assignment_id    = current_setting('atc.ahmad_assignment')::uuid
+            and old_started_at   = timestamptz '2026-08-20 08:00+00'
+            and old_completed_at = timestamptz '2026-08-20 12:00+00'
+            and new_started_at   = timestamptz '2026-08-20 07:30+00'
+            and new_completed_at is null
+        )
+       then 'OK' else 'FALSCH' end;
+
+-- CASE 27: die geteilte Uhr ist AUCH nach der zweiten Korrektur unberuehrt.
+insert into _atc
+select 27, 'Geteilte Job-Uhr auch nach zweiter Korrektur unveraendert', 'OK',
+  case when (select started_at   from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 08:00+00'
+        and (select completed_at from public.jobs where id='a4000000-0000-0000-0000-0000000000c1') = timestamptz '2026-08-20 12:00+00'
+       then 'OK' else 'VERAENDERT' end;
+
+-- CASE 28: job_assignments hat weiterhin KEINE UPDATE-Rechte fuer Clients
+-- (das Sicherheitsmodell aus Phase 3 ist unveraendert).
+insert into _atc
+select 28, 'job_assignments weiterhin ohne Client-Schreibrechte', '0',
+  (select count(*)::text from information_schema.role_table_grants
+    where table_name='job_assignments' and grantee='authenticated'
+      and privilege_type in ('INSERT','UPDATE','DELETE'));
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _atc order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _atc where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'ADMIN TIME CORRECTION TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE FAELLE PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase A of the Admin Time Correction feature — **database/backend only**. No UI, no changes to the timesheet calculation, `WorkedTimeCard`, or any screen.

## What this adds

**`public.employee_time_adjustments`** — append-only audit log. One row per correction event: `assignment_id`, `job_id`, `employee_id`, old/new start+completion, `changed_by`, mandatory `reason`, `created_at`. RLS on; admins may `SELECT` within their own company (via the existing `job_in_current_company()` helper — no new helper, no `company_id` column). No INSERT/UPDATE/DELETE policy or grant, matching the append-only posture of `job_comments`/`job_photos`.

**`public.admin_correct_assignment_time(assignment_id, new_started_at, new_completed_at, reason)`** — `SECURITY DEFINER`, admin-only, company-scoped. Writes **only** the target `job_assignments` row (`employee_started_at`, `employee_completed_at`, `attendance`) and inserts the audit row in the same transaction.

## Key invariant

`jobs.started_at` / `jobs.completed_at` are **never written**. The shared job clock is the one official execution time and applies to all assignees (Phase 7); touching it would change every colleague's billed duration — and on pre-Phase-1 jobs it would be immediately visible, since `mapEntry()` falls back to exactly those columns. Tests assert this explicitly (CASE 6, 27).

## Design notes

- **Lock order is job → assignment**, not assignment-first as originally sketched. `set_job_assignments` locks `jobs` first, and `touch_job_on_assignment_change_trg` takes a `jobs` lock *after* each assignment write — locking assignment-first would invert that and open a real deadlock window between a concurrent assign and a correct.
- **Realtime requirement is already satisfied** by the existing `touch_job_on_assignment_change_trg` (fires on UPDATE, verified `tgtype 29`). No explicit `update jobs set updated_at` — that would be a redundant write and a second realtime event for one change.
- **`attendance` is carried forward** (`completed`, or `started` when only a start is given). No new enum value — provenance lives in the audit table. This matters because `counts_for_timesheet` is a *generated* column over `attendance`/`review`: leaving it at `assigned` would make every corrected row invisible to any future billing-authorization feature.
- **Overwrites, not `COALESCE`** — unlike `start_own_job`/`complete_own_job` ("first wins"), a correction must be able to replace a wrong value.
- **Gated to completed, post-cutoff jobs.** The timesheet filters server-side on `j.status='completed' AND j.started_at IS NOT NULL AND j.completed_at IS NOT NULL`; correcting anything else would change the row but be a **silent no-op in the Stundenzettel**. Pre-`2026-08-12` jobs are rejected because writing own-times there flips `mapEntry()` out of the legacy branch and silently changes the basis of an already-closed period. Same constant as `PHASE1_CUTOFF_ISO`.

## Security

`job_assignments` gets **no** UPDATE policy — the Phase 3 model (client has SELECT only; all writes via `SECURITY DEFINER` RPC) is unchanged, asserted by CASE 28.

One real bug was caught by the tests and fixed: Supabase's `ALTER DEFAULT PRIVILEGES` grants `ALL` on new public-schema tables to `authenticated`, so a bare `grant select` left INSERT/UPDATE/DELETE in place. The migration now revokes from `anon, authenticated` **before** granting SELECT (CASE 11).

## Test results

New suite `supabase/tests/admin_time_correction_foundation.test.sql` — **28/28 PASS** against a clean `supabase db reset`. Covers: forgotten-start correction + audit row; multi-assignee isolation (Ahmad corrected, Maria untouched, shared clock untouched); employee rejected; cross-company admin rejected; empty/whitespace reason, reversed order, both-null, non-completed job, pre-cutoff legacy job all rejected with no partial writes; RLS visibility for admin/foreign-admin/employee; partial correction → `attendance='started'`; second correction overwrites and chains old→new values; `start_own_job`/`complete_own_job` regression.

Regression on existing suites (all against the new migration): `job_assignments` 26/26, `job_assignments_rls` 31/31, `job_assignments_dual_write` 37/37, `occurrence_assignment_inheritance` 33/33, `non_destructive_update_job_occurrences` 20/20.

`npx tsc --noEmit` clean · `npm run lint` clean (no TS changed in this phase).

Two **pre-existing** SQL test failures on main are unrelated and were verified by stashing this migration and reproducing them identically: `employee_read_via_assignments` CASE 17 (superseded by Phase 7) and `shared_job_time_multi_assignment` CASE 24 (superseded by Phase 1). Flagged separately; not touched here.

## Open product decisions (deliberately deferred)

1. **Future-dated timestamps are not rejected.** I'd recommended this check; it wasn't in the spec's validation list, so it's left out rather than added unasked. A `2027` typo would currently be accepted.
2. **Both-null is rejected** (treated as erasure, not correction — no defined `attendance` state for it). Confirm that's wanted.
3. **Only-completion correction** (no start) sets `attendance='completed'`, following `complete_own_job`'s precedent. Note such a row still yields **no timesheet entry**, because `mapEntry` requires both timestamps — existing behavior, unchanged here.
4. **No export/lock concept exists yet**, so corrections after a payroll export are currently allowed.
5. Employees cannot see correction records (`reason` may hold internal notes); they do see the corrected time in their own timesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)