### PR TITLE
feat(timesheets): Admin-Zeitkorrektur im Stundenzettel und am Auftrag (Phase B1)

### DIFF
--- a/features/jobs/JobDetailScreen.tsx
+++ b/features/jobs/JobDetailScreen.tsx
@@ -27,6 +27,10 @@ import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
 import RecurringRuleDetailScreen from "@/features/jobs/RecurringRuleDetailScreen";
 import { AssignedEmployeesCard } from "@/features/jobs/components/AssignedEmployeesCard";
+import {
+  TimeCorrectionSheet,
+  type TimeCorrectionTarget,
+} from "@/features/timesheets/components/TimeCorrectionSheet";
 import { JobActionFooter } from "@/features/jobs/components/JobActionFooter";
 import { JobComments } from "@/features/jobs/components/JobComments";
 import { JobDetailHeader } from "@/features/jobs/components/JobDetailHeader";
@@ -95,7 +99,14 @@ export default function JobDetailScreen() {
     online,
     pendingActions,
     markJobCommentsAsRead,
+    refreshJobs,
   } = useJobs();
+
+  // Ziel des Korrektur-Sheets (Phase B1). Nur Admins können es öffnen — die
+  // Karte blendet die Aktion sonst gar nicht ein, und die RPC prüft die Rolle
+  // zusätzlich serverseitig.
+  const [correctionTarget, setCorrectionTarget] =
+    useState<TimeCorrectionTarget | null>(null);
 
   // Cache-first: zuerst aus dem (ggf. begrenzten) Context-Fenster.
   const cachedJob = useMemo(() => jobs.find((j) => j.id === id), [jobs, id]);
@@ -112,6 +123,17 @@ export default function JobDetailScreen() {
     setFetchedJob(null);
     setFetchAttempted(false);
   }, [id]);
+
+  // Nach einer Zeitkorrektur beide Quellen auffrischen (Phase B1):
+  // refreshJobs deckt den Context-Cache ab, das Zurücksetzen von
+  // fetchAttempted den Direktabruf-Zweig. Ohne Letzteres bliebe ein per
+  // Deep-Link geöffneter Auftrag (nicht im Ladefenster) mit den ALTEN Zeiten
+  // stehen, obwohl die Korrektur gespeichert wurde.
+  const handleCorrected = useCallback(() => {
+    setFetchedJob(null);
+    setFetchAttempted(false);
+    void refreshJobs();
+  }, [refreshJobs]);
 
   useEffect(() => {
     if (!id || cachedJob || fetchAttempted) return;
@@ -370,10 +392,27 @@ export default function JobDetailScreen() {
         />
 
         {/* 3 — Zugewiesene Mitarbeitende */}
-        <AssignedEmployeesCard job={job} />
+        <AssignedEmployeesCard
+          job={job}
+          isAdmin={isAdmin}
+          onCorrectTime={(assignee) =>
+            setCorrectionTarget({
+              assignmentId: assignee.assignmentId,
+              employeeName: assignee.fullName,
+              customerName: job.customerName,
+              remark: job.service,
+              employeeStartedAt: assignee.employeeStartedAt,
+              employeeCompletedAt: assignee.employeeCompletedAt,
+              // Vorschlag aus der GETEILTEN Auftragszeit — im Sheet
+              // ausdrücklich als solcher beschriftet, nie als Arbeitszeit.
+              sharedStartedAt: job.startedAt,
+              sharedCompletedAt: job.completedAt,
+            })
+          }
+        />
 
         {/* 4 — Zeitlicher Verlauf (Start/Ende/Akteure/Dauer bzw. geplant) */}
-        <JobTimelineCard job={job} showPlaceholder />
+        <JobTimelineCard job={job} showPlaceholder isAdmin={isAdmin} />
 
         {/* 5 — Service + Terminierung */}
         <JobServiceDetailsCard service={job.service} />
@@ -418,6 +457,13 @@ export default function JobDetailScreen() {
         onEdit={handleEdit}
       />
       </KeyboardAvoidingView>
+
+      <TimeCorrectionSheet
+        visible={!!correctionTarget}
+        target={correctionTarget}
+        onClose={() => setCorrectionTarget(null)}
+        onCorrected={handleCorrected}
+      />
     </SafeAreaView>
   );
 }

--- a/features/jobs/components/AssignedEmployeesCard.tsx
+++ b/features/jobs/components/AssignedEmployeesCard.tsx
@@ -2,25 +2,62 @@
 // Zuweisungsmenge eines Auftrags als lesbare Zeilen (Avatar + Name).
 // Nutzt ausschließlich die bestehenden Zuweisungs-Helfer (utils/jobAssignees)
 // und Job.assignees — keine eigene Zuweisungslogik, kein Kürzen von Namen.
+//
+// PHASE B1 — ADMIN-SICHT: zusätzlich der Status der INDIVIDUELLEN Arbeitszeit
+// je Person plus Einstieg in die Zeitkorrektur. Das ist der sekundäre
+// Einstiegspunkt („mir fällt beim Auftrag auf, dass Ahmad keine Zeit hat");
+// der primäre liegt im Stundenzettel, wo die Lücke beim Abrechnen auffällt.
+//
+// MITARBEITER-SICHT BLEIBT UNVERÄNDERT: nur Avatar + Name. Die individuellen
+// Zeiten der KollegInnen sind Personaldaten und gehen Mitarbeitende nichts an —
+// auch wenn RLS das Lesen der Zuweisungszeilen technisch erlaubt.
 
 import { Card, InitialsAvatar } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
-import type { Job } from "@/types/job";
+import type { Job, JobAssignee } from "@/types/job";
+import { formatTimeHHmm } from "@/utils/date";
 import {
   DELETED_SUFFIX,
   UNASSIGNED_LABEL,
   getAssignees,
+  isCorrectableAssignment,
 } from "@/utils/jobAssignees";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 type Props = {
   job: Pick<Job, "assignees">;
+  /**
+   * Admin-Sicht: Zeitstatus + Korrektur-Aktion einblenden. Default false,
+   * damit jede bestehende Aufrufstelle unverändert weiterläuft.
+   */
+  isAdmin?: boolean;
+  /** Wird mit der gewählten Zuweisung gerufen (öffnet das Korrektur-Sheet). */
+  onCorrectTime?: (assignee: JobAssignee) => void;
 };
 
-export function AssignedEmployeesCard({ job }: Props) {
+// "08:00 – 12:00" / "ab 08:00" / "bis 12:00" / null, wenn nichts erfasst ist.
+function ownTimeLabel(assignee: JobAssignee): string | null {
+  const start = assignee.employeeStartedAt
+    ? formatTimeHHmm(new Date(assignee.employeeStartedAt))
+    : null;
+  const end = assignee.employeeCompletedAt
+    ? formatTimeHHmm(new Date(assignee.employeeCompletedAt))
+    : null;
+
+  if (start && end) return `${start} – ${end}`;
+  if (start) return `ab ${start}`;
+  if (end) return `bis ${end}`;
+  return null;
+}
+
+export function AssignedEmployeesCard({
+  job,
+  isAdmin = false,
+  onCorrectTime,
+}: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
@@ -46,6 +83,17 @@ export function AssignedEmployeesCard({ job }: Props) {
             const displayName = assignee.isDeleted
               ? `${assignee.fullName}${DELETED_SUFFIX}`
               : assignee.fullName;
+
+            const timeLabel = ownTimeLabel(assignee);
+            const isComplete =
+              !!assignee.employeeStartedAt && !!assignee.employeeCompletedAt;
+            // Korrigierbar heißt hier nur: die Zeile taugt als RPC-Eingabe.
+            // Ob der AUFTRAG korrigierbar ist (single, abgeschlossen, nach
+            // Cutoff), entscheidet die RPC — ein Fehlversuch endet mit einer
+            // verständlichen Meldung statt mit einer stillen Nulloperation.
+            const showAction =
+              isAdmin && !!onCorrectTime && isCorrectableAssignment(assignee);
+
             return (
               <View
                 key={assignee.assignmentId}
@@ -54,7 +102,38 @@ export function AssignedEmployeesCard({ job }: Props) {
                 accessibilityLabel={displayName}
               >
                 <InitialsAvatar name={assignee.fullName} size={36} />
-                <Text style={styles.name}>{displayName}</Text>
+
+                <View style={styles.nameWrap}>
+                  <Text style={styles.name}>{displayName}</Text>
+
+                  {/* Zeitstatus nur für Admins (siehe Kopf-Kommentar). */}
+                  {isAdmin ? (
+                    isComplete ? (
+                      <Text style={styles.timeOk}>{timeLabel}</Text>
+                    ) : (
+                      <Text style={styles.timeMissing}>
+                        {timeLabel
+                          ? `${timeLabel} · unvollständig`
+                          : "Keine eigene Zeit erfasst"}
+                      </Text>
+                    )
+                  ) : null}
+                </View>
+
+                {showAction ? (
+                  <TouchableOpacity
+                    onPress={() => onCorrectTime?.(assignee)}
+                    style={styles.actionBtn}
+                    activeOpacity={0.75}
+                    accessibilityLabel={`Zeit korrigieren für ${assignee.fullName}`}
+                  >
+                    <Ionicons
+                      name="create-outline"
+                      size={16}
+                      color={theme.colors.onPrimaryContainer}
+                    />
+                  </TouchableOpacity>
+                ) : null}
               </View>
             );
           })}
@@ -94,13 +173,35 @@ function createStyles(theme: AppTheme) {
       alignItems: "center",
       gap: theme.spacing.sm,
     },
-    name: {
+    nameWrap: {
       flex: 1,
+      gap: 2,
+    },
+    name: {
       fontSize: theme.typography.size.sm,
       fontFamily: theme.typography.family.medium,
       fontWeight: theme.typography.weight.medium,
       color: theme.colors.onSurface,
       flexWrap: "wrap",
+    },
+    timeOk: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    timeMissing: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.error,
+    },
+    actionBtn: {
+      width: 36,
+      height: 36,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.primaryContainer,
+      alignItems: "center",
+      justifyContent: "center",
     },
   });
 }

--- a/features/jobs/components/AssignedEmployeesCard.tsx
+++ b/features/jobs/components/AssignedEmployeesCard.tsx
@@ -23,12 +23,15 @@ import {
   getAssignees,
   isCorrectableAssignment,
 } from "@/utils/jobAssignees";
+import { isCorrectableJob } from "@/utils/jobCorrection";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 type Props = {
-  job: Pick<Job, "assignees">;
+  // status/startedAt/completedAt sind für die Korrektur-Sichtbarkeit nötig
+  // (siehe jobIsCorrectable unten) — NICHT für die Zuweisungsanzeige selbst.
+  job: Pick<Job, "assignees" | "status" | "startedAt" | "completedAt">;
   /**
    * Admin-Sicht: Zeitstatus + Korrektur-Aktion einblenden. Default false,
    * damit jede bestehende Aufrufstelle unverändert weiterläuft.
@@ -64,6 +67,23 @@ export function AssignedEmployeesCard({
   const assignees = getAssignees(job);
   const label = assignees.length > 1 ? "Mitarbeitende" : "Mitarbeiter";
 
+  // ENTSCHEIDET ÜBER DEN GESAMTEN ADMIN-ZUSATZ (Status-Zeile UND Aktion).
+  //
+  // Ohne diese Prüfung meldete die Karte an JEDEM offenen Auftrag rot „Keine
+  // eigene Zeit erfasst" — was dort kein Mangel ist, sondern der Normalfall:
+  // der Auftrag wurde schlicht noch nicht ausgeführt. In der Produktions-
+  // datenbank betraf das ~93 % aller Zuweisungen; das rote Signal wäre damit
+  // der Regelzustand gewesen und für die wenigen echten Lücken wertlos.
+  // Ebenso bei laufenden Aufträgen (Beginn erfasst, Ende erwartungsgemäß
+  // offen) und bei Alt-Aufträgen vor dem Phase-1-Grenzwert, für die der
+  // Stundenzettel weiterhin über die geteilte Job-Uhr abrechnet — dort ist
+  // eine fehlende Eigenzeit weder Mangel noch korrigierbar.
+  //
+  // Deckungsgleich mit admin_correct_assignment_time: was hier sichtbar ist,
+  // kann die RPC auch tatsächlich annehmen.
+  const jobIsCorrectable = isCorrectableJob(job);
+  const showAdminTimeInfo = isAdmin && jobIsCorrectable;
+
   return (
     <Card padding={theme.spacing.lg} style={styles.card}>
       <View style={styles.labelRow}>
@@ -87,12 +107,13 @@ export function AssignedEmployeesCard({
             const timeLabel = ownTimeLabel(assignee);
             const isComplete =
               !!assignee.employeeStartedAt && !!assignee.employeeCompletedAt;
-            // Korrigierbar heißt hier nur: die Zeile taugt als RPC-Eingabe.
-            // Ob der AUFTRAG korrigierbar ist (single, abgeschlossen, nach
-            // Cutoff), entscheidet die RPC — ein Fehlversuch endet mit einer
-            // verständlichen Meldung statt mit einer stillen Nulloperation.
+            // Zwei Ebenen: der AUFTRAG muss korrigierbar sein
+            // (showAdminTimeInfo, siehe oben) UND die ZEILE als RPC-Eingabe
+            // taugen — Legacy-/anonymisierte Zeilen fallen hier heraus.
             const showAction =
-              isAdmin && !!onCorrectTime && isCorrectableAssignment(assignee);
+              showAdminTimeInfo &&
+              !!onCorrectTime &&
+              isCorrectableAssignment(assignee);
 
             return (
               <View
@@ -106,8 +127,9 @@ export function AssignedEmployeesCard({
                 <View style={styles.nameWrap}>
                   <Text style={styles.name}>{displayName}</Text>
 
-                  {/* Zeitstatus nur für Admins (siehe Kopf-Kommentar). */}
-                  {isAdmin ? (
+                  {/* Zeitstatus nur für Admins UND nur an korrigierbaren
+                      Aufträgen (siehe jobIsCorrectable oben). */}
+                  {showAdminTimeInfo ? (
                     isComplete ? (
                       <Text style={styles.timeOk}>{timeLabel}</Text>
                     ) : (

--- a/features/jobs/components/JobTimelineCard.tsx
+++ b/features/jobs/components/JobTimelineCard.tsx
@@ -41,14 +41,16 @@ type Props = {
    * WorkedTimeCard (siehe Kopfkommentar).
    */
   showPlaceholder: boolean;
+  /** Durchgereicht an WorkedTimeCard: individuelle Zeiten nur für Admins. */
+  isAdmin?: boolean;
 };
 
-export function JobTimelineCard({ job, showPlaceholder }: Props) {
+export function JobTimelineCard({ job, showPlaceholder, isAdmin }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   if (job.startedAt) {
-    return <WorkedTimeCard job={job} />;
+    return <WorkedTimeCard job={job} isAdmin={isAdmin} />;
   }
 
   if (!showPlaceholder) return null;

--- a/features/jobs/components/WorkedTimeCard.tsx
+++ b/features/jobs/components/WorkedTimeCard.tsx
@@ -1,7 +1,20 @@
 // features/jobs/components/WorkedTimeCard.tsx
-// Premium-Karte für die Arbeitszeit eines Jobs — Start/Ende + große
-// Gesamtdauer als visueller Fokus. Ersetzt die schlichte "Arbeitszeit"-
-// InfoRow im JobDetailScreen.
+// Premium-Karte für die GESAMTZEIT DES AUFTRAGS — Start/Ende + große
+// Gesamtdauer als visueller Fokus.
+//
+// TITEL UND TEXT SIND BEWUSST EINDEUTIG (Phase B1): diese Karte zeigt die
+// GETEILTE Job-Uhr (jobs.started_at/completed_at), also wie lange der Auftrag
+// insgesamt lief — NICHT die individuelle Arbeitszeit einer Person. Seit der
+// Admin-Zeitkorrektur können beide auseinanderfallen: der Stundenzettel
+// rechnet mit job_assignments.employee_started_at/employee_completed_at, und
+// eine Korrektur ändert nur diese. Hieß die Karte weiterhin nur
+// „Arbeitszeit", läse ein Mitarbeiter hier eine andere Zahl als in seinem
+// eigenen Stundenzettel — ohne Erklärung.
+//
+// SICHTEN:
+//  • Admin        — zusätzlich die individuellen Zeiten je zugewiesener Person.
+//  • Mitarbeiter  — nur die Auftrags-Gesamtzeit (plus ggf. die EIGENE Zeit).
+//    Fremde Individualzeiten sind Personaldaten und werden nicht angezeigt.
 //
 // Reine Präsentationskomponente: die gesamte Berechnung/Ticking-Logik
 // kommt aus useJobWorkedTime (derselbe Hook, den auch JobCard nutzt) —
@@ -28,6 +41,12 @@ type Props = {
     | "completedBy"
     | "assignees"
   >;
+  /**
+   * Admin-Sicht: individuelle Arbeitszeiten aller Zugewiesenen einblenden.
+   * Default false — Mitarbeitende sehen nur die Auftrags-Gesamtzeit und
+   * höchstens ihre eigene Zeit (siehe Kopf-Kommentar).
+   */
+  isAdmin?: boolean;
 };
 
 /**
@@ -67,7 +86,7 @@ function formatBlockDate(iso: string | null | undefined): string | null {
   });
 }
 
-export function WorkedTimeCard({ job }: Props) {
+export function WorkedTimeCard({ job, isAdmin = false }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { profile } = useAuth();
@@ -112,6 +131,33 @@ export function WorkedTimeCard({ job }: Props) {
   // unten relevant; bei einem einzigen Mitarbeiter wäre er Ballast.
   const isShared = (job.assignees ?? []).length > 1;
 
+  // Individuelle Zeiten: Admin sieht alle, Mitarbeiter ausschließlich sich
+  // selbst. Zeilen ohne jede eigene Zeit erscheinen mit klarem Hinweis statt
+  // mit einer erfundenen Zahl — die geteilte Uhr wird hier NIE eingesetzt.
+  const individualRows = (job.assignees ?? [])
+    .filter((a) => (isAdmin ? true : !!profile?.id && a.employeeId === profile.id))
+    .map((a) => {
+      const start = a.employeeStartedAt
+        ? formatTimeHHmm(new Date(a.employeeStartedAt))
+        : null;
+      const end = a.employeeCompletedAt
+        ? formatTimeHHmm(new Date(a.employeeCompletedAt))
+        : null;
+      const complete = !!start && !!end;
+      return {
+        assignmentId: a.assignmentId,
+        fullName: a.fullName,
+        complete,
+        timeLabel: complete
+          ? `${start} – ${end}`
+          : start
+            ? `ab ${start} · unvollständig`
+            : end
+              ? `bis ${end} · unvollständig`
+              : "nicht erfasst",
+      };
+    });
+
   const startedByName = actorName(job.startedBy, job.assignees, profile?.id);
   const completedByName = actorName(
     job.completedBy,
@@ -137,7 +183,7 @@ export function WorkedTimeCard({ job }: Props) {
           <View style={styles.headerIconWrap}>
             <Ionicons name="time-outline" size={16} color={theme.colors.primary} />
           </View>
-          <Text style={styles.headerTitle}>Arbeitszeit</Text>
+          <Text style={styles.headerTitle}>Gesamtzeit Auftrag</Text>
         </View>
         {/* Kanonischer Wortlaut (Offen/In Arbeit/Erledigt). Die frühere
             labels-Prop beschriftete `completed` hier als „Abgeschlossen" —
@@ -201,6 +247,29 @@ export function WorkedTimeCard({ job }: Props) {
         <Text style={styles.highlightSubtitle}>{minutes} Minuten</Text>
       </View>
 
+      {/* ── Individuelle Zeiten ──
+          Admin: alle Zugewiesenen. Mitarbeiter: nur die EIGENE Zeile —
+          fremde Individualzeiten sind Personaldaten (siehe Kopf-Kommentar). */}
+      {individualRows.length > 0 ? (
+        <View style={styles.individualBox}>
+          <Text style={styles.individualHeading}>
+            {isAdmin ? "INDIVIDUELLE ARBEITSZEIT" : "DEINE ARBEITSZEIT"}
+          </Text>
+          {individualRows.map((row) => (
+            <View key={row.assignmentId} style={styles.individualRow}>
+              <Text style={styles.individualName} numberOfLines={1}>
+                {row.fullName}
+              </Text>
+              <Text
+                style={row.complete ? styles.individualTime : styles.individualMissing}
+              >
+                {row.timeLabel}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
       {/* ── Hinweis ── */}
       <View style={styles.infoBox}>
         <Ionicons
@@ -209,11 +278,10 @@ export function WorkedTimeCard({ job }: Props) {
           color={theme.colors.outline}
         />
         <Text style={styles.infoText}>
-          Die Arbeitszeit wird automatisch aus Start- und Endzeit berechnet.
+          Dies ist die Gesamtlaufzeit des Auftrags — sie kann von der
+          individuellen Arbeitszeit einzelner Mitarbeitender abweichen.
           {isShared
-            ? // Geteilte Job-Uhr (Phase 7): erklärt, warum jemand Zeit
-              // erhält, die ein Kollege gestartet hat.
-              " Sie gilt für alle zugewiesenen Mitarbeitenden — unabhängig davon, wer Start und Abschluss gedrückt hat."
+            ? " Sie wird aus Start und Abschluss des Auftrags berechnet, unabhängig davon, wer sie gedrückt hat."
             : ""}
         </Text>
       </View>
@@ -339,6 +407,45 @@ function createStyles(theme: AppTheme) {
       fontFamily: theme.typography.family.medium,
       fontWeight: theme.typography.weight.medium,
       color: theme.colors.onSurfaceVariant,
+    },
+
+    // Individuelle Arbeitszeiten (Phase B1)
+    individualBox: {
+      gap: 6,
+      backgroundColor: theme.colors.surfaceContainer,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.md,
+    },
+    individualHeading: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.outline,
+      letterSpacing: theme.typography.letterSpacing.wider,
+    },
+    individualRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    individualName: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+    individualTime: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    individualMissing: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.error,
     },
 
     // Info-Hinweis

--- a/features/timesheets/TimesheetScreen.tsx
+++ b/features/timesheets/TimesheetScreen.tsx
@@ -24,10 +24,15 @@ import {
 } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useAuth } from "@/context/AuthContext";
+import {
+  TimeCorrectionSheet,
+  type TimeCorrectionTarget,
+} from "@/features/timesheets/components/TimeCorrectionSheet";
 import { useTimesheet } from "@/features/timesheets/hooks/useTimesheet";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import type { TimesheetGap } from "@/types/timesheet";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   ActivityIndicator,
   ScrollView,
@@ -69,9 +74,31 @@ export default function TimesheetScreen() {
     exporting,
     exportError,
     exportPdf,
+    reload,
   } = useTimesheet(selfEmployee);
 
   const hasEntries = !!data && data.entries.length > 0;
+
+  // Korrektur-Ziel des offenen Sheets. Nur Admins bekommen die Liste
+  // überhaupt zu sehen (siehe unten) — die RPC prüft die Rolle zusätzlich
+  // serverseitig und lehnt Mitarbeitende mit 42501 ab.
+  const [correctionTarget, setCorrectionTarget] =
+    useState<TimeCorrectionTarget | null>(null);
+
+  const gaps: TimesheetGap[] = isAdmin ? (data?.needsAttention ?? []) : [];
+
+  const openCorrection = (gap: TimesheetGap) => {
+    setCorrectionTarget({
+      assignmentId: gap.assignmentId,
+      employeeName: gap.employeeName,
+      customerName: gap.customerName,
+      remark: gap.remark,
+      employeeStartedAt: gap.employeeStartedAt,
+      employeeCompletedAt: gap.employeeCompletedAt,
+      sharedStartedAt: gap.sharedStartedAt,
+      sharedCompletedAt: gap.sharedCompletedAt,
+    });
+  };
 
   return (
     <SafeAreaView style={styles.safe} edges={["top"]}>
@@ -181,6 +208,53 @@ export default function TimesheetScreen() {
         </Card>
       </View>
 
+      {/* ── Zeitkorrekturen erforderlich (nur Admin) ──
+          Bewusst ÜBER der Vorschau: diese Zuweisungen erzeugen keinen Eintrag
+          und fehlen daher in der Summe darunter. Wer erst die Summe sieht,
+          hält sie für vollständig. */}
+      {isAdmin && gaps.length > 0 ? (
+        <View style={styles.section}>
+          <SectionHeader
+            title="Zeitkorrekturen erforderlich"
+            subtitle="Diese Aufträge zählen noch nicht zur Arbeitszeit"
+          />
+          <Card padding={0}>
+            {gaps.map((gap, idx) => (
+              <View
+                key={gap.assignmentId}
+                style={[styles.gapRow, idx > 0 && styles.rowDivider]}
+              >
+                <View style={styles.gapIconWrap}>
+                  <Ionicons
+                    name="alert-circle-outline"
+                    size={18}
+                    color={theme.colors.error}
+                  />
+                </View>
+                <View style={styles.gapInfo}>
+                  <Text style={styles.gapCustomer} numberOfLines={1}>
+                    {formatDayShort(gap.date)} · {gap.customerName}
+                  </Text>
+                  <Text style={styles.gapProblem}>{gap.reasonLabel}</Text>
+                  {gap.remark ? (
+                    <Text style={styles.gapMeta} numberOfLines={1}>
+                      {gap.remark}
+                    </Text>
+                  ) : null}
+                </View>
+                <TouchableOpacity
+                  style={styles.gapButton}
+                  onPress={() => openCorrection(gap)}
+                  activeOpacity={0.75}
+                >
+                  <Text style={styles.gapButtonText}>Zeit korrigieren</Text>
+                </TouchableOpacity>
+              </View>
+            ))}
+          </Card>
+        </View>
+      ) : null}
+
       {/* ── Vorschau ── */}
       <View style={styles.section}>
         <SectionHeader
@@ -286,6 +360,13 @@ export default function TimesheetScreen() {
 
       <View style={{ height: theme.spacing.xxl }} />
       </ScrollView>
+
+      <TimeCorrectionSheet
+        visible={!!correctionTarget}
+        target={correctionTarget}
+        onClose={() => setCorrectionTarget(null)}
+        onCorrected={reload}
+      />
     </SafeAreaView>
   );
 }
@@ -454,6 +535,54 @@ function createStyles(theme: AppTheme) {
 
     exportBtn: {
       marginTop: theme.spacing.lg,
+    },
+
+    // ── Zeitkorrekturen erforderlich (Phase B1)
+    gapRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      padding: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    gapIconWrap: {
+      width: 28,
+      alignItems: "center",
+    },
+    gapInfo: {
+      flex: 1,
+      gap: 2,
+    },
+    gapCustomer: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    gapProblem: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.error,
+    },
+    gapMeta: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    gapButton: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 8,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.primaryContainer,
+      minHeight: 36,
+      justifyContent: "center",
+    },
+    gapButtonText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimaryContainer,
     },
   });
 }

--- a/features/timesheets/components/TimeCorrectionSheet.tsx
+++ b/features/timesheets/components/TimeCorrectionSheet.tsx
@@ -1,0 +1,471 @@
+// features/timesheets/components/TimeCorrectionSheet.tsx
+// Wiederverwendbares Korrektur-Formular für die Arbeitszeit EINER Zuweisung
+// (Phase B1). Wird sowohl vom Stundenzettel als auch von der Auftrags-Detail-
+// Seite genutzt — deshalb bewusst ohne eigene Datenbeschaffung: alles, was
+// angezeigt wird, kommt über Props.
+//
+// ZWEI SCHRITTE, BEWUSST:
+//   1. Formular  — Beginn, Ende, Grund
+//   2. Bestätigen — Alt → Neu im Klartext, erst dann wird gespeichert
+// Eine Abrechnungskorrektur soll nie ein einzelner Tap sein.
+//
+// GETEILTE AUFTRAGSZEIT IST NUR EIN VORSCHLAG: sie wird ausdrücklich als
+// „Vorgeschlagene Zeit aus Auftragszeit" beschriftet und nie als Arbeitszeit
+// des Mitarbeiters dargestellt. Übernehmen muss der Admin aktiv.
+
+import { Button, Card, ErrorBanner, Input } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import {
+  correctAssignmentTime,
+  validateCorrection,
+} from "@/services/timesheets/timeCorrection.service";
+import { formatDateTimeDE } from "@/utils/date";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+export type TimeCorrectionTarget = {
+  assignmentId: string;
+  employeeName: string;
+  customerName: string;
+  /** Zusatzinfo (Service · Ort), optional. */
+  remark?: string;
+  /** Aktuell erfasste Eigenzeit (ISO) — jeweils null, wenn nicht erfasst. */
+  employeeStartedAt: string | null;
+  employeeCompletedAt: string | null;
+  /** Geteilte Auftragszeit (ISO) als Vorschlag — optional. */
+  sharedStartedAt?: string | null;
+  sharedCompletedAt?: string | null;
+};
+
+type Props = {
+  visible: boolean;
+  target: TimeCorrectionTarget | null;
+  onClose: () => void;
+  /** Wird nach erfolgreicher Korrektur gerufen (z. B. zum Neuladen). */
+  onCorrected: () => void;
+};
+
+function parseIso(iso: string | null | undefined): Date | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function timeLabel(iso: string | null | undefined): string {
+  return formatDateTimeDE(iso) ?? "—";
+}
+
+export function TimeCorrectionSheet({
+  visible,
+  target,
+  onClose,
+  onCorrected,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [start, setStart] = useState<Date | null>(null);
+  const [end, setEnd] = useState<Date | null>(null);
+  const [reason, setReason] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Beim Öffnen mit der bereits erfassten Eigenzeit vorbelegen. Die geteilte
+  // Auftragszeit wird NICHT automatisch übernommen — dafür gibt es den
+  // ausdrücklichen Vorschlag-Button unten.
+  useEffect(() => {
+    if (!visible || !target) return;
+    setStart(parseIso(target.employeeStartedAt));
+    setEnd(parseIso(target.employeeCompletedAt));
+    setReason("");
+    setConfirming(false);
+    setSubmitting(false);
+    setError(null);
+  }, [visible, target]);
+
+  if (!target) return null;
+
+  const validationError = validateCorrection({
+    newStartedAt: start,
+    newCompletedAt: end,
+    reason,
+  });
+  const canSubmit = validationError === null && !submitting;
+
+  const hasSuggestion =
+    !!target.sharedStartedAt && !!target.sharedCompletedAt;
+
+  const applySuggestion = () => {
+    setStart(parseIso(target.sharedStartedAt));
+    setEnd(parseIso(target.sharedCompletedAt));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    if (!start || !end) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await correctAssignmentTime({
+        assignmentId: target.assignmentId,
+        newStartedAt: start.toISOString(),
+        newCompletedAt: end.toISOString(),
+        reason,
+      });
+      onCorrected();
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Die Zeitkorrektur konnte nicht gespeichert werden.",
+      );
+      setConfirming(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.kav}
+        >
+          <View style={styles.sheet}>
+            {/* ── Kopf ── */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Zeit korrigieren</Text>
+              <TouchableOpacity
+                onPress={onClose}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityLabel="Schließen"
+              >
+                <Ionicons
+                  name="close"
+                  size={22}
+                  color={theme.colors.onSurfaceVariant}
+                />
+              </TouchableOpacity>
+            </View>
+
+            <ScrollView
+              contentContainerStyle={styles.scroll}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              {/* ── Kontext ── */}
+              <Card padding={theme.spacing.md} style={styles.contextCard}>
+                <Text style={styles.contextLabel}>MITARBEITER</Text>
+                <Text style={styles.contextValue}>{target.employeeName}</Text>
+                <View style={styles.contextDivider} />
+                <Text style={styles.contextLabel}>AUFTRAG</Text>
+                <Text style={styles.contextValue}>{target.customerName}</Text>
+                {target.remark ? (
+                  <Text style={styles.contextMeta}>{target.remark}</Text>
+                ) : null}
+                <View style={styles.contextDivider} />
+                <Text style={styles.contextLabel}>AKTUELL ERFASST</Text>
+                <Text style={styles.contextValue}>
+                  {target.employeeStartedAt || target.employeeCompletedAt
+                    ? `${timeLabel(target.employeeStartedAt)} → ${timeLabel(target.employeeCompletedAt)}`
+                    : "Keine eigene Zeit erfasst"}
+                </Text>
+              </Card>
+
+              {confirming ? (
+                /* ── Schritt 2: Bestätigen ── */
+                <View style={styles.confirmBlock}>
+                  <Text style={styles.confirmIntro}>
+                    Bitte prüfen und bestätigen:
+                  </Text>
+
+                  <Card padding={theme.spacing.md} style={styles.diffCard}>
+                    <Text style={styles.diffLabel}>ALT</Text>
+                    <Text style={styles.diffOld}>
+                      {target.employeeStartedAt || target.employeeCompletedAt
+                        ? `${timeLabel(target.employeeStartedAt)} → ${timeLabel(target.employeeCompletedAt)}`
+                        : "Keine eigene Zeit erfasst"}
+                    </Text>
+
+                    <View style={styles.contextDivider} />
+
+                    <Text style={styles.diffLabel}>NEU</Text>
+                    <Text style={styles.diffNew}>
+                      {formatDateTimeDE(start?.toISOString())} →{" "}
+                      {formatDateTimeDE(end?.toISOString())}
+                    </Text>
+
+                    <View style={styles.contextDivider} />
+
+                    <Text style={styles.diffLabel}>GRUND</Text>
+                    <Text style={styles.diffReason}>{reason.trim()}</Text>
+                  </Card>
+
+                  {error ? <ErrorBanner message={error} /> : null}
+
+                  <Button
+                    label="Korrektur speichern"
+                    onPress={handleSave}
+                    loading={submitting}
+                    disabled={submitting}
+                  />
+                  <TouchableOpacity
+                    style={styles.secondaryBtn}
+                    onPress={() => setConfirming(false)}
+                    disabled={submitting}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={styles.secondaryBtnText}>Zurück</Text>
+                  </TouchableOpacity>
+                </View>
+              ) : (
+                /* ── Schritt 1: Formular ── */
+                <View style={styles.formBlock}>
+                  {hasSuggestion ? (
+                    <TouchableOpacity
+                      style={styles.suggestion}
+                      onPress={applySuggestion}
+                      activeOpacity={0.75}
+                    >
+                      <Ionicons
+                        name="bulb-outline"
+                        size={16}
+                        color={theme.colors.primary}
+                      />
+                      <View style={styles.suggestionTextWrap}>
+                        <Text style={styles.suggestionTitle}>
+                          Vorgeschlagene Zeit aus Auftragszeit
+                        </Text>
+                        <Text style={styles.suggestionValue}>
+                          {timeLabel(target.sharedStartedAt)} →{" "}
+                          {timeLabel(target.sharedCompletedAt)}
+                        </Text>
+                        <Text style={styles.suggestionHint}>
+                          Gesamtzeit des Auftrags — nicht zwingend die
+                          Arbeitszeit dieser Person. Zum Übernehmen tippen.
+                        </Text>
+                      </View>
+                    </TouchableOpacity>
+                  ) : null}
+
+                  <DateTimeField
+                    label="Beginn *"
+                    placeholder="Datum und Uhrzeit auswählen..."
+                    value={start}
+                    onChange={setStart}
+                  />
+
+                  <DateTimeField
+                    label="Ende *"
+                    placeholder="Datum und Uhrzeit auswählen..."
+                    value={end}
+                    onChange={setEnd}
+                  />
+
+                  <Input
+                    label="Grund *"
+                    placeholder="z. B. Start vergessen, Zeiten vom Objektleiter bestätigt"
+                    value={reason}
+                    onChangeText={setReason}
+                    multiline
+                    numberOfLines={3}
+                  />
+
+                  {error ? <ErrorBanner message={error} /> : null}
+
+                  {/* Hinweis zeigt genau den Grund, warum Weiter gesperrt ist. */}
+                  {validationError ? (
+                    <Text style={styles.validationHint}>{validationError}</Text>
+                  ) : null}
+
+                  <Button
+                    label="Weiter"
+                    onPress={() => setConfirming(true)}
+                    disabled={!canSubmit}
+                  />
+                </View>
+              )}
+            </ScrollView>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    overlay: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.55)",
+      justifyContent: "flex-end",
+    },
+    kav: {
+      width: "100%",
+    },
+    sheet: {
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: theme.radius.lg,
+      borderTopRightRadius: theme.radius.lg,
+      maxHeight: "92%",
+      paddingBottom: theme.spacing.lg,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingHorizontal: theme.spacing.lg,
+      paddingTop: theme.spacing.lg,
+      paddingBottom: theme.spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.outlineVariant,
+    },
+    title: {
+      fontSize: theme.typography.size.lg,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+    },
+    scroll: {
+      padding: theme.spacing.lg,
+      gap: theme.spacing.md,
+    },
+
+    // ── Kontext
+    contextCard: {
+      gap: 2,
+    },
+    contextLabel: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.outline,
+      letterSpacing: theme.typography.letterSpacing.wider,
+    },
+    contextValue: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    contextMeta: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    contextDivider: {
+      height: 1,
+      backgroundColor: theme.colors.outlineVariant,
+      marginVertical: theme.spacing.sm,
+    },
+
+    // ── Formular
+    formBlock: {
+      gap: theme.spacing.md,
+    },
+    suggestion: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+      alignItems: "flex-start",
+      backgroundColor: theme.colors.primaryContainer,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.md,
+    },
+    suggestionTextWrap: {
+      flex: 1,
+      gap: 2,
+    },
+    suggestionTitle: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimaryContainer,
+    },
+    suggestionValue: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onPrimaryContainer,
+    },
+    suggestionHint: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onPrimaryContainer,
+    },
+    validationHint: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+
+    // ── Bestätigen
+    confirmBlock: {
+      gap: theme.spacing.md,
+    },
+    confirmIntro: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    diffCard: {
+      gap: 2,
+    },
+    diffLabel: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.outline,
+      letterSpacing: theme.typography.letterSpacing.wider,
+    },
+    diffOld: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      textDecorationLine: "line-through",
+    },
+    diffNew: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+    },
+    diffReason: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+    secondaryBtn: {
+      alignItems: "center",
+      justifyContent: "center",
+      paddingVertical: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    secondaryBtnText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/timesheets/hooks/useTimesheet.ts
+++ b/features/timesheets/hooks/useTimesheet.ts
@@ -33,6 +33,8 @@ export type UseTimesheetResult = {
   exporting: boolean;
   exportError: string | null;
   exportPdf: () => Promise<void>;
+  /** Lädt den aktuellen Monat neu — z. B. nach einer Zeitkorrektur (Phase B1). */
+  reload: () => void;
 };
 
 // Erster Tag des Monats von `date` (lokal, auf Mitternacht normalisiert).
@@ -83,6 +85,12 @@ export function useTimesheet(
 
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+
+  // Zähler als Lade-Auslöser: nach einer Korrektur muss derselbe Monat für
+  // denselben Mitarbeiter neu geladen werden — ohne dass sich eine der
+  // bestehenden Dependencies ändert.
+  const [reloadToken, setReloadToken] = useState(0);
+  const reload = useCallback(() => setReloadToken((n) => n + 1), []);
 
   const monthLabel = useMemo(
     () =>
@@ -160,7 +168,7 @@ export function useTimesheet(
     return () => {
       cancelled = true;
     };
-  }, [selectedEmployeeId, monthDate, employees, selfId, selfName]);
+  }, [selectedEmployeeId, monthDate, employees, selfId, selfName, reloadToken]);
 
   const exportPdf = useCallback(async () => {
     if (!data || data.entries.length === 0) return;
@@ -192,5 +200,6 @@ export function useTimesheet(
     exporting,
     exportError,
     exportPdf,
+    reload,
   };
 }

--- a/services/jobs/jobs.service.ts
+++ b/services/jobs/jobs.service.ts
@@ -37,6 +37,9 @@ type JobAssignmentRow = {
   employee_id: string | null;
   employee_name_snapshot: string | null;
   assigned_at: string | null;
+  // Individuelle Arbeitszeit (Phase 1 Worked Time) — Anzeige seit Phase B1.
+  employee_started_at: string | null;
+  employee_completed_at: string | null;
   profiles?:
   | { id: string; full_name: string | null }
   | { id: string; full_name: string | null }[]
@@ -272,6 +275,8 @@ const JOB_SELECT = `
     employee_id,
     employee_name_snapshot,
     assigned_at,
+    employee_started_at,
+    employee_completed_at,
     profiles:employee_id (
       id,
       full_name
@@ -313,6 +318,10 @@ function mapAssignees(rows: JobAssignmentRow[] | null | undefined): JobAssignee[
           employeeId: row.employee_id,
           fullName: livingName?.trim() || snapshot || "Unbekannt",
           isDeleted: row.employee_id === null,
+          // 1:1 aus der Zuweisungszeile — NIE aus der geteilten Job-Uhr
+          // abgeleitet (siehe types/job.ts).
+          employeeStartedAt: row.employee_started_at,
+          employeeCompletedAt: row.employee_completed_at,
         } satisfies JobAssignee,
       };
     })

--- a/services/timesheets/timeCorrection.service.ts
+++ b/services/timesheets/timeCorrection.service.ts
@@ -1,0 +1,165 @@
+// services/timesheets/timeCorrection.service.ts
+// Admin-Zeitkorrektur: dünner Client-Wrapper um die RPC
+// admin_correct_assignment_time (Phase A, Migration 20260814000000).
+//
+// EINZIGER SCHREIBPFAD. Es gibt bewusst KEIN direktes UPDATE auf
+// job_assignments: authenticated hat dort ausschließlich SELECT (Phase 3,
+// 20260727000000). Die RPC ist SECURITY DEFINER und prüft Rolle, Firma und
+// alle fachlichen Vorbedingungen selbst — dieser Wrapper ist reine
+// Bequemlichkeit für die UI, keine zweite Sicherheitsebene.
+//
+// GETEILTE JOB-UHR: jobs.started_at/completed_at werden hier NIRGENDS
+// angefasst. Die Korrektur betrifft ausschließlich die eigene
+// Zuweisungszeile des Mitarbeiters.
+
+import { supabase } from "@/lib/supabase";
+import { toUserMessage } from "@/utils/userMessages";
+
+export type CorrectAssignmentTimeInput = {
+  /** PK der job_assignments-Zeile. */
+  assignmentId: string;
+  /** Neuer Beginn (ISO). Pflicht. */
+  newStartedAt: string;
+  /** Neues Ende (ISO). Pflicht. */
+  newCompletedAt: string;
+  /** Begründung. Pflicht, darf nicht leer sein. */
+  reason: string;
+};
+
+// Fachliche Ablehnungen der RPC kommen mit SQLSTATE 22023 bzw. 23514 und
+// englischem Text. 22023 ist in utils/userMessages NICHT abgebildet (dort
+// stehen die generischen Postgres-Codes), und die Originaltexte richten sich
+// an Entwickler. Deshalb hier eine gezielte Übersetzung: der Admin soll
+// erfahren, WARUM eine Korrektur nicht möglich ist, statt eine technische
+// Meldung zu sehen.
+const RPC_MESSAGE_MAP: { match: string; message: string }[] = [
+  {
+    match: "Only admins can correct",
+    message: "Nur Admins dürfen Arbeitszeiten korrigieren.",
+  },
+  {
+    match: "Assignment not found or not accessible",
+    message:
+      "Diese Zuweisung wurde nicht gefunden oder gehört nicht zu deiner Firma.",
+  },
+  {
+    match: "Only single jobs can be corrected",
+    message:
+      "Daueraufträge (Regeln) können nicht korrigiert werden — nur einzelne Termine erscheinen im Stundenzettel.",
+  },
+  {
+    match: "Cannot correct an anonymised assignment",
+    message:
+      "Diese Zuweisung gehört zu einem gelöschten Mitarbeiterkonto und kann nicht mehr korrigiert werden.",
+  },
+  {
+    match: "Only completed jobs can be corrected",
+    message:
+      "Nur abgeschlossene Aufträge können korrigiert werden. Dieser Auftrag ist noch nicht abgeschlossen.",
+  },
+  {
+    match: "cannot be corrected",
+    message:
+      "Dieser Auftrag wurde vor der Umstellung auf individuelle Arbeitszeiten abgeschlossen und kann nicht korrigiert werden.",
+  },
+  {
+    match: "Both new_started_at and new_completed_at are required",
+    message: "Bitte Beginn UND Ende angeben.",
+  },
+  {
+    match: "new_completed_at must be after new_started_at",
+    message: "Das Ende muss nach dem Beginn liegen.",
+  },
+  {
+    match: "A reason is required",
+    message: "Bitte einen Grund für die Korrektur angeben.",
+  },
+];
+
+function translateRpcError(err: unknown): string {
+  const raw =
+    typeof err === "object" && err !== null && "message" in err
+      ? String((err as { message?: unknown }).message ?? "")
+      : "";
+
+  const hit = RPC_MESSAGE_MAP.find((entry) => raw.includes(entry.match));
+  if (hit) return hit.message;
+
+  // Netzwerk-/Offline-/generische Postgres-Codes deckt der zentrale Helfer ab.
+  return toUserMessage(err, "Die Zeitkorrektur konnte nicht gespeichert werden.");
+}
+
+/**
+ * Prüft die Eingabe clientseitig, BEVOR die RPC gerufen wird.
+ *
+ * Bewusst dieselben Regeln wie serverseitig (die RPC bleibt die maßgebliche
+ * Instanz) — hier geht es nur darum, dem Admin sofortiges Feedback im Formular
+ * zu geben, statt ihn in einen Serverfehler laufen zu lassen.
+ *
+ * ZUSÄTZLICH clientseitig: keine Zeitstempel in der Zukunft. Die RPC lässt
+ * diese derzeit zu (bewusst offene Produktentscheidung aus PR #90); ein
+ * Vertipper wie "2027" wäre dort also unbemerkt durchgegangen. Solange das
+ * serverseitig nicht entschieden ist, fängt es wenigstens das Formular ab.
+ *
+ * @returns Fehlermeldung oder null, wenn die Eingabe gültig ist.
+ */
+export function validateCorrection(input: {
+  newStartedAt: Date | null;
+  newCompletedAt: Date | null;
+  reason: string;
+  now?: Date;
+}): string | null {
+  const { newStartedAt, newCompletedAt, reason } = input;
+  const now = input.now ?? new Date();
+
+  if (!newStartedAt || !newCompletedAt) {
+    return "Bitte Beginn UND Ende angeben.";
+  }
+  if (newCompletedAt.getTime() <= newStartedAt.getTime()) {
+    return "Das Ende muss nach dem Beginn liegen.";
+  }
+  if (
+    newStartedAt.getTime() > now.getTime() ||
+    newCompletedAt.getTime() > now.getTime()
+  ) {
+    return "Zeiten dürfen nicht in der Zukunft liegen.";
+  }
+  if (!reason.trim()) {
+    return "Bitte einen Grund für die Korrektur angeben.";
+  }
+  return null;
+}
+
+/**
+ * Speichert eine Zeitkorrektur über die RPC.
+ *
+ * Wirft mit einer bereits nutzerlesbaren, deutschen Meldung — Aufrufer können
+ * sie direkt anzeigen und brauchen kein eigenes Error-Mapping.
+ */
+export async function correctAssignmentTime(
+  input: CorrectAssignmentTimeInput,
+): Promise<void> {
+  const reason = input.reason.trim();
+
+  // Letzte Absicherung: niemals eine Teilkorrektur senden. Die RPC lehnt sie
+  // ohnehin ab (sie würde den jeweils anderen Wert auf NULL setzen und damit
+  // die Stundenzettel-Zeile löschen), aber ein solcher Aufruf soll gar nicht
+  // erst das Gerät verlassen.
+  if (!input.newStartedAt || !input.newCompletedAt) {
+    throw new Error("Bitte Beginn UND Ende angeben.");
+  }
+  if (!reason) {
+    throw new Error("Bitte einen Grund für die Korrektur angeben.");
+  }
+
+  const { error } = await supabase.rpc("admin_correct_assignment_time", {
+    assignment_id_input: input.assignmentId,
+    new_started_at: input.newStartedAt,
+    new_completed_at: input.newCompletedAt,
+    reason_input: reason,
+  });
+
+  if (error) {
+    throw new Error(translateRpcError(error));
+  }
+}

--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -51,6 +51,7 @@ import {
   formatDurationHm,
   formatTimeHHmm,
 } from "@/utils/date";
+import { isLegacyJob } from "@/utils/jobCorrection";
 import * as Print from "expo-print";
 import * as Sharing from "expo-sharing";
 
@@ -106,13 +107,13 @@ const JOB_EMBED = `,j:jobs!inner(id,customer_name,service_name,location_address,
 // würden dann auch Aufträge, die nach diesem Zeitpunkt real abgeschlossen
 // wurden, ohne Eintrag bleiben, bis die Migration nachgezogen ist. Die
 // Migration muss deshalb vor dem Rollout dieses PRs angewendet werden.
-const PHASE1_CUTOFF_ISO = "2026-08-12T00:00:00.000Z";
-
-// true, wenn dieser Auftrag VOR Phase 1 abgeschlossen wurde — nur für solche
-// Aufträge ist der Fallback auf die geteilte Job-Uhr laut Regel 2 erlaubt.
-function isLegacyJob(jobCompletedAtIso: string): boolean {
-  return new Date(jobCompletedAtIso).getTime() < Date.parse(PHASE1_CUTOFF_ISO);
-}
+//
+// KONSTANTE UND PRÄDIKAT LIEGEN SEIT PHASE B1 IN utils/jobCorrection.ts —
+// unverändert in Wert und Verhalten, nur verschoben: auch die UI braucht den
+// Grenzwert (darf die Korrektur-Aktion überhaupt erscheinen?). Ein
+// abrechnungsrelevanter Schwellwert darf nicht zweimal im Code stehen, sonst
+// laufen Stundenzettel und Oberfläche irgendwann auseinander.
+// → isLegacyJob wird oben importiert.
 
 // Baut die Bemerkung aus Service + Ort: "Fensterreinigung · Hauptstr. 1".
 function buildRemark(service: string | null, location: string | null): string {

--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -39,7 +39,12 @@
 
 import { supabase } from "@/lib/supabase";
 import { buildTimesheetHtml } from "@/services/timesheets/timesheetHtml";
-import type { TimesheetData, TimesheetEntry } from "@/types/timesheet";
+import type {
+  TimesheetData,
+  TimesheetEntry,
+  TimesheetGap,
+  TimesheetGapReason,
+} from "@/types/timesheet";
 import {
   diffInMinutes,
   formatDateISO,
@@ -55,6 +60,8 @@ import * as Sharing from "expo-sharing";
 // `unique (job_id, employee_id)` (Migration 20260725000000) höchstens eine
 // Zeile, ein Auftrag erscheint damit weiterhin nie doppelt.
 type TimesheetAssignmentRow = {
+  /** PK der Zuweisung — Eingabe für admin_correct_assignment_time (Phase B1). */
+  id: string;
   employee_started_at: string | null;
   employee_completed_at: string | null;
   j: {
@@ -166,6 +173,71 @@ function mapEntry(row: TimesheetAssignmentRow): TimesheetEntry | null {
   };
 }
 
+// Lesbare Kurzbeschreibung je Lücken-Art (deutsch, für die Admin-Liste).
+const GAP_LABELS: Record<TimesheetGapReason, string> = {
+  no_time: "Keine eigene Zeit erfasst",
+  start_only: "Beginn erfasst, Abschluss fehlt",
+  end_only: "Abschluss erfasst, Beginn fehlt",
+};
+
+/**
+ * Wandelt eine Zeile, die KEINEN Eintrag ergibt, in einen Korrektur-Hinweis um
+ * (Phase B1). Gibt `null` zurück, wenn die Zeile abrechenbar ist — die
+ * Fallunterscheidung ist damit exakt die Umkehrung von `mapEntry`, ohne dessen
+ * Logik zu duplizieren:
+ *
+ *   mapEntry != null  → abrechenbar          → KEINE Lücke
+ *   mapEntry == null  → nicht abrechenbar    → Lücke
+ *
+ * Erreichbar ist dieser Zweig ausschließlich für Aufträge NACH dem Phase-1-
+ * Cutoff ohne vollständiges eigenes Zeitpaar (Regel 3 im Kopf-Kommentar):
+ * Alt-Aufträge liefern über den Legacy-Fallback immer einen Eintrag und
+ * landen deshalb nie hier — was auch richtig ist, denn korrigierbar sind sie
+ * ohnehin nicht (admin_correct_assignment_time lehnt sie ab).
+ *
+ * WICHTIG: die GETEILTE Auftragszeit wird hier zwar mitgegeben, aber
+ * ausdrücklich als `shared*` benannt. Sie ist ein VORSCHLAG für die Korrektur,
+ * niemals die Arbeitszeit dieses Mitarbeiters — genau diese Verwechslung
+ * verhindert Regel 3.
+ */
+function mapGap(
+  row: TimesheetAssignmentRow,
+  employeeId: string,
+  employeeName: string,
+): TimesheetGap | null {
+  const hasStart = !!row.employee_started_at;
+  const hasEnd = !!row.employee_completed_at;
+
+  // Vollständiges eigenes Paar → abrechenbar, keine Lücke.
+  if (hasStart && hasEnd) return null;
+  // Alt-Auftrag → mapEntry liefert den Fallback-Eintrag, keine Lücke.
+  if (isLegacyJob(row.j.completed_at)) return null;
+
+  const reason: TimesheetGapReason = hasStart
+    ? "start_only"
+    : hasEnd
+      ? "end_only"
+      : "no_time";
+
+  const startedAt = new Date(row.j.started_at);
+
+  return {
+    assignmentId: row.id,
+    employeeId,
+    employeeName,
+    jobId: row.j.id,
+    customerName: row.j.customer_name,
+    remark: buildRemark(row.j.service_name, row.j.location_address),
+    date: formatDateISO(startedAt) ?? row.j.started_at.slice(0, 10),
+    employeeStartedAt: row.employee_started_at,
+    employeeCompletedAt: row.employee_completed_at,
+    sharedStartedAt: row.j.started_at,
+    sharedCompletedAt: row.j.completed_at,
+    reason,
+    reasonLabel: GAP_LABELS[reason],
+  };
+}
+
 /**
  * Lädt die abgeschlossenen Zuweisungen eines Mitarbeiters für einen Monat
  * und baut daraus den vollständigen Stundenzettel.
@@ -241,7 +313,7 @@ export async function getTimesheet(params: {
 
   const { data, error } = await supabase
     .from("job_assignments")
-    .select(`employee_started_at,employee_completed_at` + JOB_EMBED)
+    .select(`id,employee_started_at,employee_completed_at` + JOB_EMBED)
     .eq("employee_id", employeeId)
     .eq("j.status", "completed")
     .eq("j.job_type", "single")
@@ -254,12 +326,18 @@ export async function getTimesheet(params: {
     throw error;
   }
 
+  const rows = (data ?? []) as unknown as TimesheetAssignmentRow[];
+
   // mapEntry liefert null für Zeilen ohne belastbare Dauer (Regel 3, siehe
-  // oben) — diese werden hier herausgefiltert, nicht als 0:00-Zeile gezeigt.
+  // oben) — diese werden weiterhin NICHT als 0:00-Zeile gezeigt. Neu (Phase B1):
+  // statt sie stillschweigend fallen zu lassen, werden genau diese Zeilen über
+  // mapGap als Korrektur-Hinweis mitgeliefert. `entries` und damit der gesamte
+  // PDF-Export bleiben dadurch unverändert — dieselbe Berechnung, dieselbe
+  // Sortierung, dieselbe Summe.
   // Client-seitige Sortierung nach der individuellen Zeitquelle —
   // "YYYY-MM-DD" + "HH:mm" ist lexikographisch chronologisch sortierbar.
-  const entries = (data ?? [])
-    .map((row) => mapEntry(row as unknown as TimesheetAssignmentRow))
+  const entries = rows
+    .map((row) => mapEntry(row))
     .filter((entry): entry is TimesheetEntry => entry !== null)
     .sort((a, b) =>
       a.date + a.beginLabel < b.date + b.beginLabel
@@ -268,6 +346,12 @@ export async function getTimesheet(params: {
           ? 1
           : 0,
     );
+
+  const needsAttention = rows
+    .map((row) => mapGap(row, employeeId, employeeName))
+    .filter((gap): gap is TimesheetGap => gap !== null)
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
   const totalMinutes = entries.reduce((sum, e) => sum + e.durationMinutes, 0);
 
   const monthLabel = monthStart.toLocaleDateString("de-DE", {
@@ -286,6 +370,7 @@ export async function getTimesheet(params: {
     totalMinutes,
     totalLabel: formatDurationHm(totalMinutes),
     jobCount: entries.length,
+    needsAttention,
   };
 }
 

--- a/types/job.ts
+++ b/types/job.ts
@@ -22,6 +22,24 @@ export type JobAssignee = {
   fullName: string;
   /** true, wenn das Konto gelöscht wurde (employeeId === null). */
   isDeleted: boolean;
+
+  /**
+   * INDIVIDUELLE Arbeitszeit dieses Mitarbeiters an diesem Auftrag
+   * (job_assignments.employee_started_at/employee_completed_at, Phase B1).
+   *
+   * Diese Felder waren bewusst entfernt, solange es keinen Konsumenten gab
+   * (siehe Kommentar oben). Mit der Admin-Zeitkorrektur gibt es ihn: die
+   * Auftrags-Detailseite muss zeigen, WER noch keine eigene Zeit erfasst hat.
+   *
+   * NIEMALS aus der geteilten Job-Uhr ableiten. `null` heißt genau eine
+   * Sache — dieser Mitarbeiter hat den Übergang nicht selbst ausgelöst — und
+   * ist damit das Signal, das eine Korrektur überhaupt erst auslöst. Ein
+   * erfundener Wert würde daraus stillschweigend bezahlte Arbeitszeit machen.
+   * Der Legacy-Fallback (buildLegacyAssignees) setzt sie deshalb hart auf
+   * null.
+   */
+  employeeStartedAt: string | null;
+  employeeCompletedAt: string | null;
 };
 
 export type Job = {

--- a/types/timesheet.ts
+++ b/types/timesheet.ts
@@ -26,6 +26,49 @@ export type TimesheetEntry = {
 };
 
 /**
+ * Warum eine Zuweisung KEINEN abrechenbaren Eintrag erzeugt.
+ * Reine Klassifizierung der vorhandenen Zeitstempel — keine Bewertung.
+ */
+export type TimesheetGapReason = "no_time" | "start_only" | "end_only";
+
+/**
+ * Eine Zuweisung, die im gewählten Monat KEINEN Stundenzettel-Eintrag ergibt,
+ * obwohl der Auftrag abgeschlossen ist (Phase B1).
+ *
+ * WARUM ES DIESEN TYP GIBT: `mapEntry` verwirft solche Zeilen bewusst (siehe
+ * timesheet.service.ts) — der Mitarbeiter verschwindet dadurch komplett aus
+ * dem Stundenzettel, ohne dass der Admin merkt, dass etwas fehlt. Genau diese
+ * verworfenen Zeilen werden hier sichtbar gemacht, damit sie korrigiert
+ * werden können.
+ *
+ * WICHTIG: `sharedStartedAt`/`sharedCompletedAt` sind die GETEILTE Auftragszeit
+ * und ausschließlich ein VORSCHLAG für die Korrektur. Sie sind NICHT die
+ * Arbeitszeit dieses Mitarbeiters und dürfen nirgends als solche angezeigt
+ * oder summiert werden.
+ */
+export type TimesheetGap = {
+  /** PK der job_assignments-Zeile — Eingabe für admin_correct_assignment_time. */
+  assignmentId: string;
+  employeeId: string;
+  employeeName: string;
+  jobId: string;
+  customerName: string;
+  /** Service ggf. mit Ort — gleiche Bauform wie TimesheetEntry.remark. */
+  remark: string;
+  /** Arbeitstag "YYYY-MM-DD", abgeleitet aus der GETEILTEN Startzeit. */
+  date: string;
+  /** Aktuell erfasste Eigenzeit (mindestens eine davon ist null). */
+  employeeStartedAt: string | null;
+  employeeCompletedAt: string | null;
+  /** Geteilte Auftragszeit — NUR Korrektur-Vorschlag, nie Arbeitszeit. */
+  sharedStartedAt: string;
+  sharedCompletedAt: string;
+  reason: TimesheetGapReason;
+  /** Lesbare Kurzbeschreibung des Problems (deutsch). */
+  reasonLabel: string;
+};
+
+/**
  * Vollständiger Stundenzettel für einen Mitarbeiter + Monat.
  * Wird aus den Einträgen im Hook zusammengesetzt und an den PDF-Builder übergeben.
  */
@@ -46,4 +89,10 @@ export type TimesheetData = {
   totalLabel: string;
   /** Anzahl abgeschlossener Jobs (= Anzahl Einträge). */
   jobCount: number;
+  /**
+   * Zuweisungen im Zeitraum, die KEINEN Eintrag erzeugen konnten (Phase B1).
+   * Fließen bewusst NICHT in `entries`, `totalMinutes` oder den PDF-Export ein —
+   * sie sind nicht abrechenbar, solange sie nicht korrigiert wurden.
+   */
+  needsAttention: TimesheetGap[];
 };

--- a/utils/jobAssignees.ts
+++ b/utils/jobAssignees.ts
@@ -152,6 +152,32 @@ export function canRunJobActions(
  *    existiert keine echte job_assignments-ID. Wird nur als React-Key genutzt
  *    und ist am Präfix als abgeleitet erkennbar.
  */
+/**
+ * Darf für diese Zuweisung eine Admin-Zeitkorrektur angeboten werden?
+ * (Phase B1 — spiegelt die Vorbedingungen von admin_correct_assignment_time,
+ * soweit sie auf der Zuweisung selbst erkennbar sind.)
+ *
+ * Zwei Ausschlüsse:
+ *  1. LEGACY-Zeilen aus buildLegacyAssignees tragen eine synthetische
+ *     `legacy:<jobId>:<employeeId>`-Kennung statt einer echten UUID. Ein
+ *     Aufruf damit wäre ein Typfehler auf der RPC, kein fachlicher Fehler —
+ *     der Button darf dort gar nicht erst erscheinen.
+ *  2. Anonymisierte Zeilen (gelöschtes Konto, employeeId === null) lehnt die
+ *     RPC ausdrücklich ab: eine Korrektur könnte für niemanden im
+ *     Stundenzettel erscheinen.
+ *
+ * Die Auftrags-Bedingungen (job_type='single', abgeschlossen, nach dem
+ * Phase-1-Cutoff) prüft weiterhin allein die RPC — sie sind hier nicht
+ * zuverlässig bekannt.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isCorrectableAssignment(assignee: JobAssignee): boolean {
+  if (!assignee.employeeId) return false;
+  return UUID_RE.test(assignee.assignmentId);
+}
+
 export function buildLegacyAssignees(
   job: Pick<Job, "id" | "employeeId" | "employeeName">,
 ): JobAssignee[] {
@@ -163,6 +189,14 @@ export function buildLegacyAssignees(
       employeeId: job.employeeId,
       fullName: job.employeeName?.trim() || "Unbekannt",
       isDeleted: false,
+      // HART null (Phase B1): dieser Zweig kennt die echte Zuweisungszeile
+      // nicht. Die geteilte Job-Uhr hier einzusetzen würde einem Mitarbeiter
+      // eine individuelle Arbeitszeit andichten, die er nie erfasst hat —
+      // genau die Abrechnungs-Falle, die types/job.ts beschreibt.
+      // Folge: die Korrektur-Aktion bleibt für solche Zeilen ausgeblendet
+      // (die synthetische assignmentId ist ohnehin keine echte UUID).
+      employeeStartedAt: null,
+      employeeCompletedAt: null,
     },
   ];
 }

--- a/utils/jobCorrection.ts
+++ b/utils/jobCorrection.ts
@@ -1,0 +1,57 @@
+// utils/jobCorrection.ts
+// Ist ein Auftrag überhaupt für eine Admin-Zeitkorrektur zugänglich?
+//
+// WARUM EIGENE DATEI: der Grenzwert PHASE1_CUTOFF_ISO wird an zwei Stellen
+// gebraucht — im Stundenzettel (welche Zeitquelle gilt?) und in der UI (darf
+// die Korrektur-Aktion überhaupt erscheinen?). Er ist abrechnungsrelevant und
+// darf deshalb NICHT zweimal im Code stehen. Diese Datei ist die einzige
+// Quelle; services/timesheets/timesheet.service.ts importiert ihn von hier.
+//
+// Die Prädikate spiegeln die Vorbedingungen von admin_correct_assignment_time
+// (Migration 20260814000000), soweit sie am Job erkennbar sind. Maßgeblich
+// bleibt die RPC — hier geht es nur darum, dem Admin gar nicht erst eine
+// Aktion anzubieten, die serverseitig zwingend abgelehnt würde.
+
+import type { Job } from "@/types/job";
+
+/**
+ * Zeitpunkt, ab dem start_own_job/complete_own_job die individuellen
+ * Zeitstempel (job_assignments.employee_started_at/employee_completed_at)
+ * überhaupt schreiben — entspricht Migration 20260812000000 ("Phase 1
+ * Worked Time"). Aufträge, die davor abgeschlossen wurden, kennen keine
+ * individuelle Zeit; der Stundenzettel rechnet dort mit der geteilten
+ * Job-Uhr.
+ */
+export const PHASE1_CUTOFF_ISO = "2026-08-12T00:00:00.000Z";
+
+/**
+ * true, wenn dieser Auftrag VOR Phase 1 abgeschlossen wurde — dann gilt im
+ * Stundenzettel der Fallback auf die geteilte Job-Uhr.
+ */
+export function isLegacyJob(jobCompletedAtIso: string): boolean {
+  return new Date(jobCompletedAtIso).getTime() < Date.parse(PHASE1_CUTOFF_ISO);
+}
+
+/**
+ * Darf für diesen AUFTRAG eine Zeitkorrektur angeboten werden?
+ *
+ * Drei Bedingungen, alle deckungsgleich mit der RPC:
+ *  1. abgeschlossen — an offenen/laufenden Aufträgen ist eine fehlende
+ *     Eigenzeit KEIN Fehler, sondern der Normalzustand.
+ *  2. vollständige geteilte Uhr — ohne sie liefert der Stundenzettel für
+ *     diesen Auftrag ohnehin keine Zeile (serverseitiger Filter).
+ *  3. nach dem Phase-1-Grenzwert — für Alt-Aufträge gilt der Legacy-Fallback:
+ *     der Mitarbeiter bekommt dort bereits Stunden gutgeschrieben, eine
+ *     fehlende Eigenzeit ist also weder ein Mangel noch korrigierbar.
+ *
+ * BEWUSST NICHT geprüft: job_type='single'. Diese Karte rendert für
+ * Recurring-Parent-Regeln ohnehin ohne Admin-Zusätze (RecurringRuleDetailScreen
+ * übergibt kein isAdmin), und die RPC lehnt sie zuverlässig ab.
+ */
+export function isCorrectableJob(
+  job: Pick<Job, "status" | "startedAt" | "completedAt">,
+): boolean {
+  if (job.status !== "completed") return false;
+  if (!job.startedAt || !job.completedAt) return false;
+  return !isLegacyJob(job.completedAt);
+}


### PR DESCRIPTION
Phase B1 of Admin Time Correction — **client only**. No migration, no new RPC, no new table.

## The problem this fixes

When an employee forgets Start (or a colleague completes the job for them), `mapEntry` discards the assignment and **the employee vanishes from the Stundenzettel entirely** — the admin just sees a shorter list with no hint anything is missing. There was literally no row to attach a "correct" action to.

## What changed

**Detection — reuses the existing query.** `getTimesheet` now also returns `needsAttention[]`, built from exactly the rows `mapEntry` already loads and previously threw away. No second round-trip, no new RPC. `entries`, `totalMinutes` and the **entire PDF export are byte-identical** — `buildTimesheetHtml` only ever reads `entries`.

`mapGap` is the strict inverse of `mapEntry` (billable → no gap; not billable → gap), so the two cannot drift. Legacy pre-cutoff jobs never become gaps: they still produce a fallback entry, and they aren't correctable anyway.

**Service wrapper** `correctAssignmentTime()` around the existing `admin_correct_assignment_time`, with German translation of the RPC's business rejections — `SQLSTATE 22023` is not mapped in `utils/userMessages`, so those would otherwise have surfaced as raw English developer text.

**`TimeCorrectionSheet`** — reusable, two-step: form → confirm showing **old → new** plus the reason in plain text. Both timestamps and a reason are mandatory; "Weiter" stays disabled with an inline explanation of what's missing. A partial correction can never leave the device (it would null the other column and delete the timesheet row — the exact trap fixed in #90).

The shared job clock appears **only** as an explicitly labelled *"Vorgeschlagene Zeit aus Auftragszeit"* suggestion the admin must tap to apply — never auto-filled, never presented as the employee's time.

**Timesheet integration** — "Zeitkorrekturen erforderlich" section, admin-gated, placed **above** the preview: these assignments are missing from the total below, so seeing the total first would give false confidence.

**Job Detail integration** — `AssignedEmployeesCard` shows admins per-person time status + a correction entry point. Employee rendering is unchanged.

**WorkedTimeCard** (required in this phase) — now titled **"Gesamtzeit Auftrag"** and states that job runtime may differ from individual working times. Admins see all individual times; employees see only their own. Colleagues' individual times are personal data and stay hidden even though RLS technically permits reading them.

## Safety details worth reviewing

- `JobAssignee` regains `employeeStartedAt`/`employeeCompletedAt` — it now has a real consumer. `buildLegacyAssignees` sets both to **hard `null`**; deriving them from the shared clock would invent paid time, which is exactly the trap `types/job.ts` warns about.
- `isCorrectableAssignment()` hides the action for legacy rows (synthetic `legacy:<jobId>:<empId>` id — not a valid UUID, would be a type error at the RPC) and for anonymised rows (deleted account — the RPC rejects them).
- Job-level preconditions (`single`, completed, post-cutoff) stay solely with the RPC; a rejected attempt now surfaces a readable German reason instead of failing silently.
- `handleCorrected` refreshes **both** job sources — without resetting `fetchAttempted`, a deep-linked job outside the context window would keep showing stale times after a successful save.
- Client-side guard added against **future-dated** timestamps. The RPC still accepts them (known open decision from #90); with no UI that was inert, but a date picker makes it reachable.

## Test plan

- [x] `npx tsc --noEmit` clean — this also proves every `JobAssignee` construction site was updated
- [x] `npm run lint` clean
- [x] No SQL/migration files touched (`git status` over `supabase/` is empty)
- [x] PDF path verified untouched — `timesheetHtml.ts` consumes only `entries`
- [ ] Manual QA by reviewer: employee forgot Start on a multi-assignee job → appears under "Zeitkorrekturen erforderlich" → correct → row moves into the billable table, colleague unchanged, `Gesamtzeit Auftrag` unchanged

No JS test runner exists in this repo (`package.json` has no `test` script), and no SQL changed, so the pgTAP suites are unaffected.

## Explicitly out of scope

No correction-history UI, no payroll export lock, no company-wide dashboard, no PDF changes, no employee self-correction.

## Known consideration

`JOB_SELECT` now fetches the two timestamp columns for **all** assignees of a job, including for employee clients that never render colleagues' values. RLS already permitted this (the select previously fetched colleagues' `employee_name_snapshot` the same way), so it is not a new exposure — but if strict data minimisation is wanted, it would need a separate, role-aware select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)