### PR TITLE
feat(absences): DB foundation for Urlaub/Krankheit (Phase A)

### DIFF
--- a/supabase/migrations/20260816000000_absences_foundation.sql
+++ b/supabase/migrations/20260816000000_absences_foundation.sql
@@ -46,6 +46,17 @@
 --   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
 --   ausfuehren (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
 --   Produktionsdatenbank ausgefuehrt.
+--
+-- KORREKTUR (noch vor jeder Anwendung, PR-Review):
+--   Eine fruehere Version dieser Migration hatte ein CHECK-Constraint
+--   chk_employee_absences_review_pair ((reviewed_by is null) = (reviewed_at
+--   is null)). Es kollidierte mit reviewed_by ON DELETE SET NULL: die
+--   Loeschung eines Admin-Profils, das irgendeine Zeile reviewed hatte,
+--   schlug fehl (23514), weil die FK-Aktion nur reviewed_by nullt und
+--   reviewed_at unangetastet laesst. Entfernt — siehe Kommentar bei den
+--   Spalten reviewed_by/reviewed_at fuer die Begruendung, warum die
+--   Konsistenz stattdessen ausschliesslich durch die beiden schreibenden
+--   RPCs (admin_review_vacation, admin_create_absence) garantiert wird.
 -- =========================================================
 
 
@@ -119,6 +130,25 @@ create table if not exists public.employee_absences (
   -- telefonische Krankmeldung, ausserhalb der App vereinbarter Urlaub).
   created_by uuid references public.profiles(id) on delete set null,
 
+  -- reviewed_by/reviewed_at werden IMMER gemeinsam von den Review-RPCs
+  -- gesetzt (admin_review_vacation, admin_create_absence) — es gibt
+  -- absichtlich KEIN CHECK-Constraint, das dieses Gleichschritt-Paar
+  -- erzwingt. Ein solcher Constraint (chk_employee_absences_review_pair,
+  -- Vorversion dieser Migration) kollidiert mit reviewed_by ON DELETE SET
+  -- NULL: loescht man das Profil eines Admins, der irgendeine Zeile
+  -- reviewed hat, setzt Postgres NUR reviewed_by auf NULL — reviewed_at
+  -- bleibt unangetastet stehen. Genau dieses "nur eine Spalte des Paares
+  -- wird genullt" verletzt einen Gleichschritt-Constraint und macht die
+  -- Konto-Loeschung fehlschlagen (23514) — derselbe Fehler-Typ wie der
+  -- historische job_photos.uploaded_by-Vorfall (RESTRICT+NOT NULL
+  -- blockierte Kontoloeschung, siehe 20260722000000/...0001), nur ueber
+  -- einen CHECK statt eine FK-Aktion ausgeloest. Da jeder Schreibpfad
+  -- ausschliesslich ueber die beiden Review-RPCs laeuft (siehe unten —
+  -- keine INSERT/UPDATE-Policy existiert), ist die Konsistenz dort
+  -- garantiert; nach einer Kontoloeschung ist reviewed_at=<Zeitpunkt> bei
+  -- reviewed_by=NULL bewusst der gueltige Endzustand ("wurde reviewt,
+  -- aber von wem ist nicht mehr rekonstruierbar" — reviewed_at bleibt als
+  -- Nachweis DASS und WANN reviewt wurde).
   reviewed_by uuid references public.profiles(id) on delete set null,
   reviewed_at timestamptz,
 
@@ -129,11 +159,6 @@ create table if not exists public.employee_absences (
   -- chk_job_assignments_name_snapshot.
   constraint chk_employee_absences_name_snapshot
     check (length(btrim(employee_name_snapshot)) > 0),
-
-  -- reviewed_by und reviewed_at muessen im Gleichschritt gesetzt/NULL sein
-  -- — gleiche Bauform wie chk_job_assignments_review_pair.
-  constraint chk_employee_absences_review_pair
-    check ((reviewed_by is null) = (reviewed_at is null)),
 
   -- Datumsregeln (Abschnitt 3 der Spezifikation):
   --   Urlaub: end_date PFLICHT, end_date >= start_date.
@@ -758,9 +783,11 @@ begin
     v_company_id, employee_id_input, coalesce(nullif(btrim(v_full_name), ''), 'Unbekannt'),
     type_input, v_status, start_date_input, end_date_input, note_input, auth.uid(),
     -- Urlaub geht direkt auf 'approved' -> der erfassende Admin ist damit
-    -- auch der Pruefende. Krankheit hat keinen Genehmigungsschritt, also
-    -- bleibt reviewed_by/at dort NULL (chk_employee_absences_review_pair
-    -- erlaubt genau diese Kombination fuer beide Faelle).
+    -- auch der Pruefende, BEIDE Spalten gemeinsam gesetzt. Krankheit hat
+    -- keinen Genehmigungsschritt, also bleiben reviewed_by/at dort BEIDE
+    -- NULL — die RPC ist die einzige Stelle, die dieses Paar schreibt, und
+    -- haelt es hier bewusst im Gleichschritt (siehe Kommentar bei der
+    -- Spaltendefinition oben, warum das nicht per CHECK erzwungen wird).
     case when type_input = 'vacation' then auth.uid() else null end,
     case when type_input = 'vacation' then now() else null end
   )

--- a/supabase/migrations/20260816000000_absences_foundation.sql
+++ b/supabase/migrations/20260816000000_absences_foundation.sql
@@ -1,0 +1,806 @@
+-- =========================================================
+-- MIGRATION: Abwesenheiten — Grundlage (Phase A)
+-- Datum: 2026-08-16
+-- =========================================================
+-- ZWECK
+--   Urlaub und Krankheit sind Beta-relevante Features (siehe Architektur-
+--   Audit "Abwesenheiten"). Diese Migration legt AUSSCHLIESSLICH die
+--   Datenschicht: eine Tabelle (employee_absences), zwei Enums, RLS
+--   (nur SELECT fuer Clients) und sieben SECURITY-DEFINER-RPCs fuer den
+--   kompletten Schreibpfad (Mitarbeiter-Selbstbedienung + Admin-Review/
+--   manuelle Erfassung).
+--
+-- EIN TABELLE, TYPDISKRIMINIERT
+--   Urlaub und Krankheit teilen sich Firma/Mitarbeiter/Datumsbereich/Notizen/
+--   Pruefpfad — nur der Workflow unterscheidet sich. Ein CHECK-Constraint
+--   (chk_employee_absences_status_matches_type) macht ungueltige
+--   Typ/Status-Kombinationen strukturell unmoeglich, exakt wie
+--   chk_job_assignments_review_pair es fuer job_assignments tut. Zwei
+--   getrennte Tabellen wuerden jede RLS-Policy, jeden Index und jede
+--   kuenftige Kalender-/Stundenzettel-Abfrage verdoppeln, ohne dass ein
+--   Feld tatsaechlich typ-spezifisch waere.
+--
+-- BEWUSST NICHT TEIL DIESER MIGRATION
+--   * KEINE Aenderung an notification_outbox/notification_deliveries oder
+--     an supabase/functions/dispatch-notifications. Benachrichtigungen
+--     folgen in einem eigenen PR, NACHDEM der Abwesenheits-Workflow selbst
+--     bewiesen ist — das bestehende, funktionierende Job-Push-System soll
+--     hier keinem Risiko ausgesetzt werden.
+--   * KEINE Aenderung an jobs, job_assignments, services/timesheets/* oder
+--     irgendeiner UI. Phase A ist reine Datenschicht.
+--   * KEINE gespeicherten Stunden/Minuten auf employee_absences (keine
+--     paid_hours/planned_hours/duration-Spalte). Die kuenftige "geplante
+--     Abwesenheits-Zeit" (siehe Beispiel im Audit: Krankheit an einem Tag
+--     mit einer Recurring-Occurrence, planned_duration_minutes=240) MUSS
+--     dynamisch aus jobs.planned_duration_minutes der tatsaechlichen
+--     Occurrence berechnet werden (join ueber date-Bereich + Zuweisung),
+--     NICHT aus einer hier gespeicherten Kopie — sonst entsteht genau die
+--     "stale duplicated data"-Falle, vor der der Auftrag warnt. Recurring
+--     Jobs sind bereits ueber generate_job_occurrences/update_job_occurrences
+--     als echte jobs-Zeilen (job_type='single', parent_job_id gesetzt)
+--     materialisiert; getScheduleOccurrences() liest sie bereits so. Eine
+--     kuenftige Stundenzettel-Berechnung kann also ohne Schemaaenderung auf
+--     genau diesem Weg aufsetzen.
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md). Diese Migration wurde NICHT auf der
+--   Produktionsdatenbank ausgefuehrt.
+-- =========================================================
+
+
+-- ---------------------------------------------------------
+-- 1. Enums
+-- ---------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'absence_type') then
+    create type public.absence_type as enum ('vacation', 'sickness');
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'absence_status') then
+    -- 'cancelled' wird von beiden Typen genutzt. 'requested'/'approved'/
+    -- 'rejected' sind Urlaub-exklusiv, 'reported' ist Krankheit-exklusiv —
+    -- durchgesetzt ueber chk_employee_absences_status_matches_type, NICHT
+    -- ueber zwei Enums (ein Enum pro Typ waere hier Overkill fuer eine
+    -- einzige gemeinsame Spalte).
+    create type public.absence_status as enum (
+      'requested', 'approved', 'rejected', 'cancelled', 'reported'
+    );
+  end if;
+end $$;
+
+
+-- ---------------------------------------------------------
+-- 2. Tabelle
+-- ---------------------------------------------------------
+-- ON-DELETE-Strategie je Spalte:
+--   * company_id -> CASCADE. Verschwindet eine Firma, verschwinden alle
+--     ihre Daten (bestehendes Muster ueberall, z. B. jobs.company_id).
+--   * employee_id -> SET NULL. Ein Mitarbeiterkonto muss loeschbar bleiben,
+--     OHNE dass die Abwesenheits-Historie verschwindet — exakt das Muster
+--     von job_assignments.employee_id/employee_name_snapshot (Phase 1) und
+--     employee_time_adjustments.employee_id (Phase 8). NICHT CASCADE: der
+--     historische Produktionsfehler von job_photos.uploaded_by (RESTRICT +
+--     NOT NULL blockierte Kontoloeschung, siehe 20260722000000/...0001)
+--     wird hier nicht wiederholt, und CASCADE waere der andere fehlerhafte
+--     Extremfall (Historie geht verloren).
+--   * created_by / reviewed_by -> SET NULL. Gleicher Grund: der Admin, der
+--     erfasst/geprueft hat, kann sein Konto ebenfalls loeschen, ohne den
+--     Pruefpfad zu zerstoeren.
+create table if not exists public.employee_absences (
+  id uuid primary key default gen_random_uuid(),
+
+  company_id uuid not null references public.companies(id) on delete cascade,
+
+  -- NULL = das Mitarbeiterkonto wurde geloescht (Anonymisierung).
+  employee_id uuid references public.profiles(id) on delete set null,
+  -- Schnappschuss des Namens zum Erfassungszeitpunkt — ueberlebt eine
+  -- Kontoloeschung, exakt wie job_assignments.employee_name_snapshot.
+  employee_name_snapshot text not null,
+
+  type public.absence_type not null,
+  status public.absence_status not null,
+
+  start_date date not null,
+  end_date date,
+
+  employee_note text,
+  admin_note text,
+
+  -- Ersteller der Zeile. Bei Selbstbedienung ist created_by = employee_id
+  -- (der Mitarbeiter erfasst seine eigene Abwesenheit). Bei manueller
+  -- Admin-Erfassung (admin_create_absence) ist created_by der Admin und
+  -- WEICHT VON employee_id AB — genau dieses Auseinanderfallen ist das
+  -- Signal "von einem Admin im Namen des Mitarbeiters erfasst" (z. B.
+  -- telefonische Krankmeldung, ausserhalb der App vereinbarter Urlaub).
+  created_by uuid references public.profiles(id) on delete set null,
+
+  reviewed_by uuid references public.profiles(id) on delete set null,
+  reviewed_at timestamptz,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- Name-Schnappschuss darf nicht leer sein — gleiche Bauform wie
+  -- chk_job_assignments_name_snapshot.
+  constraint chk_employee_absences_name_snapshot
+    check (length(btrim(employee_name_snapshot)) > 0),
+
+  -- reviewed_by und reviewed_at muessen im Gleichschritt gesetzt/NULL sein
+  -- — gleiche Bauform wie chk_job_assignments_review_pair.
+  constraint chk_employee_absences_review_pair
+    check ((reviewed_by is null) = (reviewed_at is null)),
+
+  -- Datumsregeln (Abschnitt 3 der Spezifikation):
+  --   Urlaub: end_date PFLICHT, end_date >= start_date.
+  --   Krankheit: end_date darf NULL sein (laufende Krankmeldung ohne
+  --     bekanntes Ende); ist es gesetzt, muss end_date >= start_date gelten.
+  -- Nur ganztaegige Abwesenheiten fuer Beta — start_date/end_date sind date,
+  -- keine timestamptz, damit Teiltage strukturell nicht darstellbar sind.
+  constraint chk_employee_absences_dates check (
+    (type = 'vacation' and end_date is not null and end_date >= start_date)
+    or
+    (type = 'sickness' and (end_date is null or end_date >= start_date))
+  ),
+
+  -- Verhindert strukturell ungueltige Typ/Status-Kombinationen (Abschnitt 2
+  -- der Spezifikation). Urlaub und Krankheit teilen NIE einen ungueltigen
+  -- Zustand.
+  constraint chk_employee_absences_status_matches_type check (
+    (type = 'vacation' and status in ('requested', 'approved', 'rejected', 'cancelled'))
+    or
+    (type = 'sickness' and status in ('reported', 'cancelled'))
+  )
+);
+
+comment on table public.employee_absences is
+'Urlaub/Krankheit je Mitarbeiter. Ein Typ-diskriminiertes Modell (type +'
+'status, siehe chk_employee_absences_status_matches_type) statt zweier '
+'Tabellen, weil beide Abwesenheitsarten dieselbe Struktur teilen. Traegt '
+'BEWUSST KEINE Stunden-/Minutenspalte — geplante Abwesenheitszeit wird '
+'kuenftig dynamisch aus jobs.planned_duration_minutes der betroffenen '
+'Occurrences berechnet, nie hier dupliziert. Schreibzugriff ausschliesslich '
+'ueber die RPCs in dieser Migration (request_own_vacation, '
+'report_own_sickness, cancel_own_vacation, cancel_own_sickness, '
+'update_own_sickness_end, admin_review_vacation, admin_create_absence) — '
+'es gibt keine INSERT/UPDATE/DELETE-Policy.';
+
+comment on column public.employee_absences.employee_id is
+'NULL = Mitarbeiterkonto wurde geloescht (ON DELETE SET NULL). Die Zeile '
+'bleibt als Historie erhalten, siehe employee_name_snapshot.';
+
+comment on column public.employee_absences.created_by is
+'Ersteller der Zeile. created_by = employee_id bei Selbstbedienung; '
+'created_by <> employee_id signalisiert eine manuelle Admin-Erfassung '
+'(admin_create_absence).';
+
+
+-- ---------------------------------------------------------
+-- 3. Indizes
+-- ---------------------------------------------------------
+-- Firmen-/Bereichsabfragen ("wer ist in diesem Kalenderbereich abwesend?",
+-- "ueberschneidet sich diese Abwesenheit mit diesem Job-/Occurrence-Datum?").
+-- end_date kann NULL sein (laufende Krankmeldung) — ein Btree-Index behandelt
+-- NULL wie einen eigenen (hoechsten) Sortierwert und unterstuetzt sowohl
+-- Range- als auch "end_date IS NULL"-Praedikate ueber denselben Index.
+create index if not exists idx_employee_absences_company_range
+  on public.employee_absences (company_id, start_date, end_date);
+
+-- Mitarbeiter-Historie (Employee-Detail, "Meine Abwesenheiten") UND
+-- gleichzeitig der FK-Rueckwaertsindex fuer employee_id (ON DELETE SET
+-- NULL) — employee_id ist die fuehrende Spalte, daher deckt dieser eine
+-- Index beide Zugriffsmuster ab, kein zusaetzlicher Einzelspalten-Index
+-- noetig.
+create index if not exists idx_employee_absences_employee_history
+  on public.employee_absences (employee_id, start_date)
+  where employee_id is not null;
+
+-- FK-Rueckwaertsindizes fuer die beiden weiteren ON-DELETE-SET-NULL-Spalten,
+-- gleiche Bauform wie idx_employee_time_adjustments_changed_by.
+create index if not exists idx_employee_absences_created_by
+  on public.employee_absences (created_by)
+  where created_by is not null;
+
+create index if not exists idx_employee_absences_reviewed_by
+  on public.employee_absences (reviewed_by)
+  where reviewed_by is not null;
+
+
+-- ---------------------------------------------------------
+-- 4. Zugriff: RLS an, NUR SELECT fuer Clients
+-- ---------------------------------------------------------
+-- REIHENFOLGE IST SICHERHEITSRELEVANT (siehe wiederholte Kommentare in
+-- lib/schema.sql): ALTER DEFAULT PRIVILEGES vergibt an neue Tabellen im
+-- public-Schema automatisch ALLE Rechte an anon/authenticated. Erst
+-- vollstaendig entziehen, dann gezielt SELECT vergeben.
+alter table public.employee_absences enable row level security;
+
+revoke all on public.employee_absences from anon, authenticated;
+grant select on public.employee_absences to authenticated;
+
+-- Mitarbeiter: nur eigene Zeilen, firmenskopiert (Verteidigung in der
+-- Tiefe — employee_id impliziert bereits dieselbe Firma, aber jede andere
+-- Policy in diesem Schema prueft company_id explizit mit).
+drop policy if exists "employee read own absences" on public.employee_absences;
+create policy "employee read own absences"
+on public.employee_absences
+for select
+to authenticated
+using (
+  employee_id = auth.uid()
+  and company_id = public.current_user_company_id()
+);
+
+-- Admin: alle Zeilen der eigenen Firma.
+drop policy if exists "admin read company absences" on public.employee_absences;
+create policy "admin read company absences"
+on public.employee_absences
+for select
+to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and company_id = public.current_user_company_id()
+);
+
+-- KEINE INSERT-, UPDATE- oder DELETE-Policy. Beabsichtigt — jeder
+-- Schreibvorgang laeuft ueber die SECURITY-DEFINER-RPCs unten.
+
+
+-- ---------------------------------------------------------
+-- 5. RPC: request_own_vacation
+-- ---------------------------------------------------------
+create or replace function public.request_own_vacation(
+  start_date_input date,
+  end_date_input date,
+  employee_note_input text default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company_id uuid;
+  v_full_name  text;
+  v_new_id     uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  -- current_user_role()/current_user_company_id() liefern NULL fuer ein
+  -- inaktives oder firmenloses Profil (siehe lib/schema.sql) — IS DISTINCT
+  -- FROM statt <>, damit der Guard fuer ein deaktiviertes Konto nicht still
+  -- uebersprungen wird.
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can request their own vacation'
+      using errcode = '42501';
+  end if;
+
+  v_company_id := public.current_user_company_id();
+  if v_company_id is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if start_date_input is null or end_date_input is null then
+    raise exception 'start_date and end_date are required'
+      using errcode = '23514';
+  end if;
+
+  if end_date_input < start_date_input then
+    raise exception 'end_date must not be before start_date'
+      using errcode = '23514';
+  end if;
+
+  -- Ueberlappung: eine neue Anfrage darf sich nicht mit einer bereits
+  -- angefragten oder genehmigten eigenen Abwesenheit ueberschneiden.
+  -- 'rejected'/'cancelled' zaehlen bewusst NICHT — sie belegen den
+  -- Zeitraum nicht mehr.
+  if exists (
+    select 1 from public.employee_absences ea
+    where ea.employee_id = auth.uid()
+      and ea.type = 'vacation'
+      and ea.status in ('requested', 'approved')
+      and ea.start_date <= end_date_input
+      and ea.end_date   >= start_date_input
+  ) then
+    raise exception 'Overlaps an existing vacation request'
+      using errcode = '23514';
+  end if;
+
+  select full_name into v_full_name from public.profiles where id = auth.uid();
+
+  insert into public.employee_absences (
+    company_id, employee_id, employee_name_snapshot,
+    type, status, start_date, end_date, employee_note, created_by
+  )
+  values (
+    v_company_id, auth.uid(), coalesce(nullif(btrim(v_full_name), ''), 'Unbekannt'),
+    'vacation', 'requested', start_date_input, end_date_input, employee_note_input, auth.uid()
+  )
+  returning id into v_new_id;
+
+  return query select * from public.employee_absences where id = v_new_id;
+end;
+$$;
+
+comment on function public.request_own_vacation(date, date, text) is
+'Mitarbeiter beantragt eigenen Urlaub (status=requested). Lehnt eine '
+'Ueberschneidung mit einer eigenen angefragten/genehmigten Abwesenheit ab.';
+
+revoke all on function public.request_own_vacation(date, date, text) from public, anon;
+grant execute on function public.request_own_vacation(date, date, text) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 6. RPC: report_own_sickness
+-- ---------------------------------------------------------
+create or replace function public.report_own_sickness(
+  start_date_input date,
+  end_date_input date default null,
+  employee_note_input text default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company_id uuid;
+  v_full_name  text;
+  v_new_id     uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can report their own sickness'
+      using errcode = '42501';
+  end if;
+
+  v_company_id := public.current_user_company_id();
+  if v_company_id is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if start_date_input is null then
+    raise exception 'start_date is required' using errcode = '23514';
+  end if;
+
+  if end_date_input is not null and end_date_input < start_date_input then
+    raise exception 'end_date must not be before start_date'
+      using errcode = '23514';
+  end if;
+
+  -- Ueberlappung: hoechstens eine aktive ('reported') Krankmeldung
+  -- gleichzeitig je Mitarbeiter — haelt das Modell fuer Beta einfach
+  -- (Spezifikation Abschnitt 7). 'infinity'::date ist der Sentinel fuer ein
+  -- offenes Ende (sowohl auf der neuen als auch auf bestehenden Zeilen), so
+  -- dass NULL-Enddaten korrekt "bis auf Weiteres" bedeuten.
+  if exists (
+    select 1 from public.employee_absences ea
+    where ea.employee_id = auth.uid()
+      and ea.type = 'sickness'
+      and ea.status = 'reported'
+      and ea.start_date <= coalesce(end_date_input, 'infinity'::date)
+      and coalesce(ea.end_date, 'infinity'::date) >= start_date_input
+  ) then
+    raise exception 'Overlaps an existing active sickness report'
+      using errcode = '23514';
+  end if;
+
+  select full_name into v_full_name from public.profiles where id = auth.uid();
+
+  insert into public.employee_absences (
+    company_id, employee_id, employee_name_snapshot,
+    type, status, start_date, end_date, employee_note, created_by
+  )
+  values (
+    v_company_id, auth.uid(), coalesce(nullif(btrim(v_full_name), ''), 'Unbekannt'),
+    'sickness', 'reported', start_date_input, end_date_input, employee_note_input, auth.uid()
+  )
+  returning id into v_new_id;
+
+  return query select * from public.employee_absences where id = v_new_id;
+end;
+$$;
+
+comment on function public.report_own_sickness(date, date, text) is
+'Mitarbeiter meldet eigene Krankheit (status=reported, sofort aktiv, keine '
+'Admin-Genehmigung noetig). end_date darf NULL sein (Ende noch unbekannt). '
+'Lehnt eine Ueberschneidung mit einer bereits aktiven eigenen Krankmeldung ab.';
+
+revoke all on function public.report_own_sickness(date, date, text) from public, anon;
+grant execute on function public.report_own_sickness(date, date, text) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 7. RPC: cancel_own_vacation
+-- ---------------------------------------------------------
+create or replace function public.cancel_own_vacation(
+  absence_id_input uuid
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can cancel their own vacation'
+      using errcode = '42501';
+  end if;
+
+  -- Nur zukuenftiger Urlaub ist selbst stornierbar (Spezifikation
+  -- Abschnitt 5): start_date muss noch in der Zukunft liegen. Bereits
+  -- begonnener/vergangener Urlaub bleibt unveraendert stehen — eine
+  -- Korrektur nachtraeglich waere eine Admin-Angelegenheit, nicht Teil von
+  -- Phase A (siehe Abschnitt 6 der Spezifikation: kein
+  -- admin_correct_absence ohne konkreten Bedarf).
+  update public.employee_absences
+  set status = 'cancelled', updated_at = now()
+  where id = absence_id_input
+    and employee_id = auth.uid()
+    and type = 'vacation'
+    and status in ('requested', 'approved')
+    and start_date > current_date;
+
+  if not found then
+    raise exception 'Vacation not found, not yours, or no longer cancellable'
+      using errcode = '42501';
+  end if;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.cancel_own_vacation(uuid) is
+'Mitarbeiter storniert eigenen, noch nicht begonnenen Urlaub '
+'(status requested/approved, start_date > heute).';
+
+revoke all on function public.cancel_own_vacation(uuid) from public, anon;
+grant execute on function public.cancel_own_vacation(uuid) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 8. RPC: cancel_own_sickness
+-- ---------------------------------------------------------
+create or replace function public.cancel_own_sickness(
+  absence_id_input uuid
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can cancel their own sickness report'
+      using errcode = '42501';
+  end if;
+
+  update public.employee_absences
+  set status = 'cancelled', updated_at = now()
+  where id = absence_id_input
+    and employee_id = auth.uid()
+    and type = 'sickness'
+    and status = 'reported';
+
+  if not found then
+    raise exception 'Sickness report not found, not yours, or already closed'
+      using errcode = '42501';
+  end if;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.cancel_own_sickness(uuid) is
+'Mitarbeiter storniert eigene Krankmeldung (z. B. faelschlich erfasst).';
+
+revoke all on function public.cancel_own_sickness(uuid) from public, anon;
+grant execute on function public.cancel_own_sickness(uuid) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 9. RPC: update_own_sickness_end
+-- ---------------------------------------------------------
+create or replace function public.update_own_sickness_end(
+  absence_id_input uuid,
+  new_end_date_input date
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_start_date date;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can update their own sickness report'
+      using errcode = '42501';
+  end if;
+
+  select start_date into v_start_date
+  from public.employee_absences
+  where id = absence_id_input
+    and employee_id = auth.uid()
+    and type = 'sickness'
+    and status = 'reported';
+
+  if not found then
+    raise exception 'Sickness report not found, not yours, or already closed'
+      using errcode = '42501';
+  end if;
+
+  -- new_end_date_input darf NULL sein (zurueck auf "Ende noch unbekannt").
+  -- Ist es gesetzt, muss es weiterhin auf/nach start_date liegen.
+  if new_end_date_input is not null and new_end_date_input < v_start_date then
+    raise exception 'end_date must not be before start_date'
+      using errcode = '23514';
+  end if;
+
+  -- Setzt das Enddatum auf DERSELBEN Zeile — erzeugt bewusst KEINE zweite
+  -- Krankmeldung (Spezifikation Abschnitt 5).
+  update public.employee_absences
+  set end_date = new_end_date_input, updated_at = now()
+  where id = absence_id_input;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.update_own_sickness_end(uuid, date) is
+'Mitarbeiter setzt/aendert das Enddatum der eigenen aktiven Krankmeldung, '
+'ohne eine zweite Zeile anzulegen. new_end_date_input=NULL macht sie wieder '
+'offen-endig.';
+
+revoke all on function public.update_own_sickness_end(uuid, date) from public, anon;
+grant execute on function public.update_own_sickness_end(uuid, date) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 10. RPC: admin_review_vacation
+-- ---------------------------------------------------------
+create or replace function public.admin_review_vacation(
+  absence_id_input uuid,
+  decision_input text,
+  admin_note_input text default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_status public.absence_status;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can review vacation requests'
+      using errcode = '42501';
+  end if;
+
+  if decision_input not in ('approved', 'rejected') then
+    raise exception 'decision must be ''approved'' or ''rejected'''
+      using errcode = '22023';
+  end if;
+  v_status := decision_input::public.absence_status;
+
+  -- Firmenscoping direkt im UPDATE (Verteidigung in der Tiefe: current_
+  -- user_company_id() ist bereits firmenskopiert, die WHERE-Klausel prueft
+  -- zusaetzlich explizit mit, gleiche Bauform wie in job-bezogenen RPCs).
+  -- Nur aus status='requested' heraus reviewbar — verhindert ein erneutes
+  -- Ueberschreiben einer bereits entschiedenen Anfrage.
+  update public.employee_absences
+  set status = v_status,
+      admin_note = admin_note_input,
+      reviewed_by = auth.uid(),
+      reviewed_at = now(),
+      updated_at = now()
+  where id = absence_id_input
+    and company_id = public.current_user_company_id()
+    and type = 'vacation'
+    and status = 'requested';
+
+  if not found then
+    raise exception 'Vacation request not found, not in your company, or already reviewed'
+      using errcode = '42501';
+  end if;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.admin_review_vacation(uuid, text, text) is
+'Admin genehmigt/lehnt eine Urlaubsanfrage der eigenen Firma ab (nur aus '
+'status=requested). Krankmeldungen sind hierueber NICHT review-faehig — es '
+'gibt fuer sie keinen Genehmigungs-Workflow.';
+
+revoke all on function public.admin_review_vacation(uuid, text, text) from public, anon;
+grant execute on function public.admin_review_vacation(uuid, text, text) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 11. RPC: admin_create_absence
+-- ---------------------------------------------------------
+-- Manuelle Erfassung durch einen Admin (Telefonanruf, ausserhalb der App
+-- vereinbarter Urlaub, vergessene Krankmeldung — siehe Spezifikation
+-- Abschnitt 6/10). Geht bei Urlaub DIREKT auf 'approved', bei Krankheit
+-- DIREKT auf 'reported' — der Admin ist bereits die entscheidende Instanz,
+-- ein zusaetzlicher Genehmigungsschritt fuer die eigene Erfassung waere
+-- sinnlos.
+create or replace function public.admin_create_absence(
+  employee_id_input uuid,
+  type_input public.absence_type,
+  start_date_input date,
+  end_date_input date default null,
+  note_input text default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company_id uuid;
+  v_full_name  text;
+  v_status     public.absence_status;
+  v_new_id     uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can manually record an absence'
+      using errcode = '42501';
+  end if;
+
+  v_company_id := public.current_user_company_id();
+  if v_company_id is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  -- Mitarbeiter muss in derselben Firma sein. BEWUSST OHNE is_active-
+  -- Bedingung: ein Admin muss eine historische Abwesenheit auch fuer einen
+  -- inzwischen deaktivierten Mitarbeiter nachtragen koennen (z. B.
+  -- Krankmeldung kurz vor Austritt), ohne dass ein Datensatz verloren geht.
+  -- Das entspricht dem Muster von admin_correct_assignment_time, das
+  -- ebenfalls keine is_active-Bedingung an der betroffenen Person kennt.
+  select full_name into v_full_name
+  from public.profiles
+  where id = employee_id_input
+    and company_id = v_company_id;
+
+  if not found then
+    raise exception 'Employee not found in your company'
+      using errcode = '42501';
+  end if;
+
+  if start_date_input is null then
+    raise exception 'start_date is required' using errcode = '23514';
+  end if;
+
+  if type_input = 'vacation' then
+    if end_date_input is null then
+      raise exception 'end_date is required for vacation'
+        using errcode = '23514';
+    end if;
+    if end_date_input < start_date_input then
+      raise exception 'end_date must not be before start_date'
+        using errcode = '23514';
+    end if;
+
+    if exists (
+      select 1 from public.employee_absences ea
+      where ea.employee_id = employee_id_input
+        and ea.type = 'vacation'
+        and ea.status in ('requested', 'approved')
+        and ea.start_date <= end_date_input
+        and ea.end_date   >= start_date_input
+    ) then
+      raise exception 'Overlaps an existing vacation request'
+        using errcode = '23514';
+    end if;
+
+    v_status := 'approved';
+  elsif type_input = 'sickness' then
+    if end_date_input is not null and end_date_input < start_date_input then
+      raise exception 'end_date must not be before start_date'
+        using errcode = '23514';
+    end if;
+
+    if exists (
+      select 1 from public.employee_absences ea
+      where ea.employee_id = employee_id_input
+        and ea.type = 'sickness'
+        and ea.status = 'reported'
+        and ea.start_date <= coalesce(end_date_input, 'infinity'::date)
+        and coalesce(ea.end_date, 'infinity'::date) >= start_date_input
+    ) then
+      raise exception 'Overlaps an existing active sickness report'
+        using errcode = '23514';
+    end if;
+
+    v_status := 'reported';
+  else
+    raise exception 'Unknown absence type' using errcode = '22023';
+  end if;
+
+  insert into public.employee_absences (
+    company_id, employee_id, employee_name_snapshot,
+    type, status, start_date, end_date, admin_note, created_by,
+    reviewed_by, reviewed_at
+  )
+  values (
+    v_company_id, employee_id_input, coalesce(nullif(btrim(v_full_name), ''), 'Unbekannt'),
+    type_input, v_status, start_date_input, end_date_input, note_input, auth.uid(),
+    -- Urlaub geht direkt auf 'approved' -> der erfassende Admin ist damit
+    -- auch der Pruefende. Krankheit hat keinen Genehmigungsschritt, also
+    -- bleibt reviewed_by/at dort NULL (chk_employee_absences_review_pair
+    -- erlaubt genau diese Kombination fuer beide Faelle).
+    case when type_input = 'vacation' then auth.uid() else null end,
+    case when type_input = 'vacation' then now() else null end
+  )
+  returning id into v_new_id;
+
+  return query select * from public.employee_absences where id = v_new_id;
+end;
+$$;
+
+comment on function public.admin_create_absence(uuid, public.absence_type, date, date, text) is
+'Admin erfasst eine Abwesenheit manuell fuer einen Mitarbeiter der eigenen '
+'Firma (Telefon-Krankmeldung, ausserhalb der App vereinbarter Urlaub). '
+'Urlaub landet direkt bei status=approved (reviewed_by/at = der erfassende '
+'Admin), Krankheit direkt bei status=reported (kein Genehmigungsschritt). '
+'created_by <> employee_id markiert die Zeile als manuell erfasst. Erlaubt '
+'auch fuer inzwischen deaktivierte Mitarbeiter (historische Nacherfassung).';
+
+revoke all on function public.admin_create_absence(uuid, public.absence_type, date, date, text) from public, anon;
+grant execute on function public.admin_create_absence(uuid, public.absence_type, date, date, text) to authenticated;
+
+
+-- =========================================================
+-- ABWAERTSKOMPATIBILITAET
+-- =========================================================
+-- Rein additiv. Keine bestehende Tabelle, Spalte, Policy, Funktion,
+-- notification_outbox/dispatch-notifications oder UI wurde veraendert.
+-- Alte Clients im Feld rufen die neuen RPCs schlicht nie auf.
+--
+-- ROLLBACK:
+--   drop function if exists public.admin_create_absence(uuid, public.absence_type, date, date, text);
+--   drop function if exists public.admin_review_vacation(uuid, text, text);
+--   drop function if exists public.update_own_sickness_end(uuid, date);
+--   drop function if exists public.cancel_own_sickness(uuid);
+--   drop function if exists public.cancel_own_vacation(uuid);
+--   drop function if exists public.report_own_sickness(date, date, text);
+--   drop function if exists public.request_own_vacation(date, date, text);
+--   drop policy if exists "admin read company absences" on public.employee_absences;
+--   drop policy if exists "employee read own absences" on public.employee_absences;
+--   drop table if exists public.employee_absences;
+--   drop type if exists public.absence_status;
+--   drop type if exists public.absence_type;
+-- Gefahrlos: kein Bestandsobjekt haengt an Tabelle, Typen oder Funktionen.
+-- =========================================================

--- a/supabase/tests/absences_foundation.test.sql
+++ b/supabase/tests/absences_foundation.test.sql
@@ -1,0 +1,740 @@
+-- =========================================================
+-- TEST: Abwesenheiten — Grundlage (Phase A)
+-- (Migration 20260816000000_absences_foundation)
+-- =========================================================
+-- Prueft Schema-Constraints, RLS (Lese-Policies + fehlende Schreibrechte)
+-- und alle sieben SECURITY-DEFINER-RPCs (Mitarbeiter-Selbstbedienung +
+-- Admin-Review/manuelle Erfassung), inklusive Ueberlappungsregeln und
+-- Bewahrung der Historie nach Kontoloeschung.
+--
+-- Alle RPC-Aufrufe laufen als echte Rolle (SET LOCAL ROLE + request.jwt.
+-- claims), also ueber denselben Pfad wie die App ueber PostgREST.
+--
+-- HINWEIS ZU „VERWEIGERT"-PFADEN (siehe job_assignments_rls.test.sql):
+-- der lokale Supabase-Container stuerzt bei einem echten permission-denied-
+-- Fehler (fehlendes GRANT) ab. Faelle, deren Verweigerung ueber ein
+-- fehlendes Privileg laeuft (direkte Client-Schreibversuche auf die
+-- Tabelle), werden deshalb ueber role_table_grants nachgewiesen statt durch
+-- einen echten Aufruf. Verweigerungen ueber RLS (gefilterte Zeilen) oder
+-- ueber eine RPC-interne Ausnahme (raise exception) loesen KEINEN
+-- permission-denied-Fehler aus und werden ganz normal ausgefuehrt.
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende, keine
+-- Produktionsdaten. Ausfuehren lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/absences_foundation.test.sql
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma E = e1…1 | Firma F (fremd) = e1…2
+-- Admin E   = e2…1
+-- Mitarbeiter A (Haupt-Akteur) = e2…2
+-- Mitarbeiter B (Cross-Employee-Angriffe) = e2…3
+-- Mitarbeiter C (inaktiv) = e2…4
+-- Mitarbeiter D (wird geloescht) = e2…5
+-- Admin F (fremde Firma) = e2…6
+-- Mitarbeiter F (fremde Firma) = e2…7
+do $$
+begin
+  insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000001','authenticated','authenticated','abs-adminE@example.test','{"full_name":"Admin E"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000002','authenticated','authenticated','abs-a@example.test','{"full_name":"Anna A"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000003','authenticated','authenticated','abs-b@example.test','{"full_name":"Bert B"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000004','authenticated','authenticated','abs-c-inaktiv@example.test','{"full_name":"Cora Inaktiv"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000005','authenticated','authenticated','abs-d-del@example.test','{"full_name":"Dirk Loeschbar"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000006','authenticated','authenticated','abs-adminF@example.test','{"full_name":"Admin F"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000007','authenticated','authenticated','abs-f@example.test','{"full_name":"Finn Fremd"}');
+end $$;
+
+insert into public.profiles (id, full_name) values
+  ('e2000000-0000-0000-0000-000000000001','Admin E'),
+  ('e2000000-0000-0000-0000-000000000002','Anna A'),
+  ('e2000000-0000-0000-0000-000000000003','Bert B'),
+  ('e2000000-0000-0000-0000-000000000004','Cora Inaktiv'),
+  ('e2000000-0000-0000-0000-000000000005','Dirk Loeschbar'),
+  ('e2000000-0000-0000-0000-000000000006','Admin F'),
+  ('e2000000-0000-0000-0000-000000000007','Finn Fremd')
+on conflict (id) do nothing;
+
+insert into public.companies (id, name, slug) values
+  ('e1000000-0000-0000-0000-000000000001','Abs Firma E','abs-firma-e-test'),
+  ('e1000000-0000-0000-0000-000000000002','Abs Firma F','abs-firma-f-test');
+
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='e2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id in ('e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000005');
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='e2000000-0000-0000-0000-000000000004';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='admin',    is_active=true  where id='e2000000-0000-0000-0000-000000000006';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='employee', is_active=true  where id='e2000000-0000-0000-0000-000000000007';
+
+create temporary table _abs (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+create temporary table _state (k text primary key, v text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub', uid::text, 'role','authenticated')::text, true);
+end $f$;
+
+create or replace function pg_temp.remember(p_key text, p_val uuid) returns void language sql as $f$
+  insert into _state values (p_key, p_val::text) on conflict (k) do update set v = excluded.v;
+$f$;
+
+create or replace function pg_temp.recall(p_key text) returns uuid language sql as $f$
+  select v::uuid from _state where k = p_key;
+$f$;
+
+
+-- =========================================================
+-- A. SCHEMA-CONSTRAINTS
+-- =========================================================
+-- Direkte INSERTs als postgres (Superuser, umgeht RLS) — geprueft wird
+-- ausschliesslich der CHECK-Constraint, nicht der RPC-Pfad.
+
+-- CASE 1: gueltiger Urlaub-Zustand wird akzeptiert.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','requested', current_date+10, current_date+12, 'e2000000-0000-0000-0000-000000000002');
+    v := 'OK';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  insert into _abs values (1,'Gueltiger Urlaub-Zustand (requested) wird akzeptiert','OK',v);
+  raise notice 'CASE 1 -> %', v;
+end $$;
+
+-- CASE 2: ungueltige Typ/Status-Kombination (Urlaub + reported) wird abgelehnt.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','reported', current_date+20, current_date+21, 'e2000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (2,'Ungueltige Kombination vacation/reported wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 2 -> %', v;
+end $$;
+
+-- CASE 3: ungueltige Typ/Status-Kombination (Krankheit + approved) wird abgelehnt.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','sickness','approved', current_date, 'e2000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (3,'Ungueltige Kombination sickness/approved wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 3 -> %', v;
+end $$;
+
+-- CASE 4: Krankheit mit end_date NULL ist gueltig.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','sickness','reported', current_date, null, 'e2000000-0000-0000-0000-000000000002');
+    v := 'OK';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  insert into _abs values (4,'Krankheit mit end_date=NULL ist gueltig','OK',v);
+  raise notice 'CASE 4 -> %', v;
+end $$;
+
+-- CASE 5: Urlaub mit end_date NULL wird abgelehnt.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','requested', current_date+30, null, 'e2000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (5,'Urlaub mit end_date=NULL wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 5 -> %', v;
+end $$;
+
+-- CASE 6: end_date vor start_date wird abgelehnt (Urlaub).
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','requested', current_date+40, current_date+39, 'e2000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (6,'end_date vor start_date wird abgelehnt (Urlaub)','ABGELEHNT',v);
+  raise notice 'CASE 6 -> %', v;
+end $$;
+
+-- CASE 7: end_date vor start_date wird abgelehnt (Krankheit, end_date gesetzt).
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','sickness','reported', current_date+40, current_date+39, 'e2000000-0000-0000-0000-000000000002');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (7,'end_date vor start_date wird abgelehnt (Krankheit)','ABGELEHNT',v);
+  raise notice 'CASE 7 -> %', v;
+end $$;
+
+-- CASE 8: reviewed_by/reviewed_at muessen im Gleichschritt gesetzt sein.
+do $$
+declare v text;
+begin
+  begin
+    insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by, reviewed_by)
+    values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','approved', current_date+50, current_date+51, 'e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000001');
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  insert into _abs values (8,'reviewed_by ohne reviewed_at wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 8 -> %', v;
+end $$;
+
+-- Testdaten aus Schema-Sektion wieder entfernen, damit sie die
+-- RPC-Ueberlappungspruefungen unten nicht verfaelschen.
+delete from public.employee_absences where employee_id = 'e2000000-0000-0000-0000-000000000002';
+
+
+-- =========================================================
+-- B. RLS — LESE-POLICIES UND FEHLENDE SCHREIBRECHTE
+-- =========================================================
+
+-- Fixtur: je eine Urlaubszeile fuer Mitarbeiter A (Firma E) und Mitarbeiter F (Firma F).
+insert into public.employee_absences (id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+values
+  ('e4000000-0000-0000-0000-000000000001','e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','requested', current_date+60, current_date+61, 'e2000000-0000-0000-0000-000000000002'),
+  ('e4000000-0000-0000-0000-000000000002','e1000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000007','Finn Fremd','vacation','requested', current_date+60, current_date+61, 'e2000000-0000-0000-0000-000000000007');
+
+-- CASE 9: Mitarbeiter A sieht nur die eigene Zeile.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences;
+  reset role;
+  insert into _abs values (9,'Mitarbeiter sieht nur eigene Abwesenheiten','1',v);
+  raise notice 'CASE 9 -> %', v;
+end $$;
+
+-- CASE 10: Mitarbeiter B (gleiche Firma, andere Person) sieht die Zeile von A nicht.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences where id = 'e4000000-0000-0000-0000-000000000001';
+  reset role;
+  insert into _abs values (10,'Mitarbeiter B sieht die Zeile von Mitarbeiter A nicht','0',v);
+  raise notice 'CASE 10 -> %', v;
+end $$;
+
+-- CASE 11: Admin E sieht alle Zeilen der eigenen Firma (nur die von A, nicht die fremde).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences where company_id = 'e1000000-0000-0000-0000-000000000001';
+  reset role;
+  insert into _abs values (11,'Admin sieht alle Abwesenheiten der eigenen Firma','1',v);
+  raise notice 'CASE 11 -> %', v;
+end $$;
+
+-- CASE 12: Admin E sieht die Zeile der fremden Firma F nicht (Cross-Company).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences where id = 'e4000000-0000-0000-0000-000000000002';
+  reset role;
+  insert into _abs values (12,'Admin E sieht die Abwesenheit der fremden Firma F nicht','0',v);
+  raise notice 'CASE 12 -> %', v;
+end $$;
+
+-- CASE 13: authenticated hat KEIN direktes INSERT/UPDATE/DELETE-Recht
+-- (nachgewiesen ueber die Rechtevergabe, nicht ueber einen echten Aufruf —
+-- siehe Kopf-Hinweis zu permission-denied).
+do $$
+declare v text;
+begin
+  select count(*)::text into v
+  from information_schema.role_table_grants
+  where table_name = 'employee_absences'
+    and grantee = 'authenticated'
+    and privilege_type in ('INSERT','UPDATE','DELETE');
+  insert into _abs values (13,'authenticated hat keine INSERT/UPDATE/DELETE-Rechte auf employee_absences','0',v);
+  raise notice 'CASE 13 -> %', v;
+end $$;
+
+delete from public.employee_absences where id in ('e4000000-0000-0000-0000-000000000001','e4000000-0000-0000-0000-000000000002');
+
+
+-- =========================================================
+-- C. MITARBEITER-RPCS
+-- =========================================================
+
+-- CASE 14: request_own_vacation legt eine Zeile im richtigen Zustand an.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+10, current_date+12, 'Familienurlaub');
+  reset role;
+  perform pg_temp.remember('vac_a', v_id);
+  select 'type='||type::text||'/status='||status::text||'/emp='||employee_id::text||'/name='||employee_name_snapshot||'/created_by='||created_by::text
+    into v
+  from public.employee_absences where id = v_id;
+  insert into _abs values (14,'request_own_vacation legt requested-Zeile mit Snapshot an',
+    'type=vacation/status=requested/emp=e2000000-0000-0000-0000-000000000002/name=Anna A/created_by=e2000000-0000-0000-0000-000000000002', v);
+  raise notice 'CASE 14 -> %', v;
+end $$;
+
+-- CASE 15: eine ueberlappende zweite Urlaubsanfrage wird abgelehnt.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  begin
+    perform public.request_own_vacation(current_date+11, current_date+13, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (15,'Ueberlappende zweite Urlaubsanfrage wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 15 -> %', v;
+end $$;
+
+-- CASE 16: eine NICHT ueberlappende zweite Urlaubsanfrage wird akzeptiert.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  begin
+    select id into v_id from public.request_own_vacation(current_date+20, current_date+21, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  if v = 'AKZEPTIERT' then
+    delete from public.employee_absences where id = v_id;
+  end if;
+  insert into _abs values (16,'Nicht ueberlappende zweite Urlaubsanfrage wird akzeptiert','AKZEPTIERT',v);
+  raise notice 'CASE 16 -> %', v;
+end $$;
+
+-- CASE 17: report_own_sickness mit end_date=NULL legt eine offene Krankmeldung an.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.report_own_sickness(current_date, null, 'Grippe');
+  reset role;
+  perform pg_temp.remember('sick_a', v_id);
+  select 'type='||type::text||'/status='||status::text||'/end='||coalesce(end_date::text,'NULL')
+    into v
+  from public.employee_absences where id = v_id;
+  insert into _abs values (17,'report_own_sickness mit end_date=NULL legt offene Krankmeldung an',
+    'type=sickness/status=reported/end=NULL', v);
+  raise notice 'CASE 17 -> %', v;
+end $$;
+
+-- CASE 18: eine zweite aktive Krankmeldung derselben Person wird abgelehnt.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  begin
+    perform public.report_own_sickness(current_date+1, current_date+2, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (18,'Zweite aktive Krankmeldung derselben Person wird abgelehnt','ABGELEHNT',v);
+  raise notice 'CASE 18 -> %', v;
+end $$;
+
+-- CASE 19: update_own_sickness_end setzt das Enddatum auf DERSELBEN Zeile (keine zweite Zeile).
+do $$
+declare v text; v_id uuid; v_count int;
+begin
+  v_id := pg_temp.recall('sick_a');
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  perform public.update_own_sickness_end(v_id, current_date+3);
+  reset role;
+  select count(*) into v_count from public.employee_absences where employee_id = 'e2000000-0000-0000-0000-000000000002' and type = 'sickness';
+  select 'end='||end_date::text||'/zeilen='||v_count::text into v from public.employee_absences where id = v_id;
+  insert into _abs values (19,'update_own_sickness_end aendert end_date ohne neue Zeile',
+    'end='||(current_date+3)::text||'/zeilen=1', v);
+  raise notice 'CASE 19 -> %', v;
+end $$;
+
+-- CASE 20: cancel_own_sickness storniert die eigene aktive Krankmeldung.
+do $$
+declare v text; v_id uuid;
+begin
+  v_id := pg_temp.recall('sick_a');
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  perform public.cancel_own_sickness(v_id);
+  reset role;
+  select status::text into v from public.employee_absences where id = v_id;
+  insert into _abs values (20,'cancel_own_sickness storniert die eigene Krankmeldung','cancelled',v);
+  raise notice 'CASE 20 -> %', v;
+end $$;
+
+-- CASE 21: cancel_own_vacation lehnt bereits begonnenen/vergangenen Urlaub ab.
+do $$
+declare v text; v_id uuid;
+begin
+  insert into public.employee_absences (id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+  values ('e4000000-0000-0000-0000-000000000010','e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','approved', current_date-2, current_date+1, 'e2000000-0000-0000-0000-000000000002');
+  v_id := 'e4000000-0000-0000-0000-000000000010';
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  begin
+    perform public.cancel_own_vacation(v_id);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (21,'cancel_own_vacation lehnt bereits begonnenen Urlaub ab','ABGELEHNT',v);
+  raise notice 'CASE 21 -> %', v;
+end $$;
+
+-- CASE 22: cancel_own_vacation storniert noch nicht begonnenen (zukuenftigen) Urlaub.
+do $$
+declare v text; v_id uuid;
+begin
+  v_id := pg_temp.recall('vac_a');
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  perform public.cancel_own_vacation(v_id);
+  reset role;
+  select status::text into v from public.employee_absences where id = v_id;
+  insert into _abs values (22,'cancel_own_vacation storniert zukuenftigen Urlaub','cancelled',v);
+  raise notice 'CASE 22 -> %', v;
+end $$;
+
+-- CASE 23: Mitarbeiter B kann die Krankmeldung von Mitarbeiter A NICHT stornieren (Cross-Employee-Angriff).
+do $$
+declare v text; v_id uuid;
+begin
+  insert into public.employee_absences (id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by)
+  values ('e4000000-0000-0000-0000-000000000011','e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','sickness','reported', current_date+5, current_date+6, 'e2000000-0000-0000-0000-000000000002');
+  v_id := 'e4000000-0000-0000-0000-000000000011';
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  set local role authenticated;
+  begin
+    perform public.cancel_own_sickness(v_id);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  select 'aufruf='||v||'/status_unveraendert='||(status='reported')::text into v from public.employee_absences where id = v_id;
+  insert into _abs values (23,'Mitarbeiter B kann Krankmeldung von A nicht stornieren (Cross-Employee)','aufruf=ABGELEHNT/status_unveraendert=true',v);
+  raise notice 'CASE 23 -> %', v;
+end $$;
+
+-- CASE 24: Mitarbeiter B kann fuer sich selbst KEINEN absence_id manipulieren, der A gehoert,
+-- ueber update_own_sickness_end (weiterer Cross-Employee-Angriffsvektor).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000003');
+  set local role authenticated;
+  begin
+    perform public.update_own_sickness_end('e4000000-0000-0000-0000-000000000011', current_date+30);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (24,'Mitarbeiter B kann Enddatum der Krankmeldung von A nicht aendern','ABGELEHNT',v);
+  raise notice 'CASE 24 -> %', v;
+end $$;
+
+-- CASE 25: ein deaktivierter Mitarbeiter kann keine RPC aufrufen
+-- (current_user_role() liefert NULL fuer inaktive Profile).
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000004');
+  set local role authenticated;
+  begin
+    perform public.request_own_vacation(current_date+70, current_date+72, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (25,'Deaktivierter Mitarbeiter kann request_own_vacation nicht aufrufen','ABGELEHNT',v);
+  raise notice 'CASE 25 -> %', v;
+end $$;
+
+delete from public.employee_absences where employee_id in ('e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003');
+
+
+-- =========================================================
+-- D. ADMIN-RPCS
+-- =========================================================
+
+-- CASE 26: admin_review_vacation genehmigt eine Anfrage.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+80, current_date+82, null);
+  reset role;
+  perform pg_temp.remember('vac_review', v_id);
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  perform public.admin_review_vacation(v_id, 'approved', 'Passt.');
+  reset role;
+
+  select 'status='||status::text||'/reviewed_by='||reviewed_by::text||'/note='||admin_note into v
+  from public.employee_absences where id = v_id;
+  insert into _abs values (26,'admin_review_vacation genehmigt eine Anfrage',
+    'status=approved/reviewed_by=e2000000-0000-0000-0000-000000000001/note=Passt.', v);
+  raise notice 'CASE 26 -> %', v;
+end $$;
+
+-- CASE 27: eine bereits entschiedene Anfrage kann nicht erneut reviewt werden.
+do $$
+declare v text; v_id uuid;
+begin
+  v_id := pg_temp.recall('vac_review');
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  begin
+    perform public.admin_review_vacation(v_id, 'rejected', null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (27,'Bereits entschiedene Anfrage kann nicht erneut reviewt werden','ABGELEHNT',v);
+  raise notice 'CASE 27 -> %', v;
+end $$;
+
+-- CASE 28: admin_review_vacation lehnt eine neue Anfrage korrekt ab (status=rejected).
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+90, current_date+92, null);
+  reset role;
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  perform public.admin_review_vacation(v_id, 'rejected', 'Zu viele Kollegen gleichzeitig weg.');
+  reset role;
+
+  select status::text into v from public.employee_absences where id = v_id;
+  insert into _abs values (28,'admin_review_vacation lehnt eine Anfrage ab','rejected',v);
+  raise notice 'CASE 28 -> %', v;
+end $$;
+
+-- CASE 29: admin_review_vacation kann keine Krankmeldung reviewen (type-Filter).
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.report_own_sickness(current_date+100, null, null);
+  reset role;
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  begin
+    perform public.admin_review_vacation(v_id, 'approved', null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (29,'admin_review_vacation kann keine Krankmeldung reviewen','ABGELEHNT',v);
+  raise notice 'CASE 29 -> %', v;
+end $$;
+
+-- CASE 30: Admin F (fremde Firma) kann die Urlaubsanfrage von Firma E nicht reviewen.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+110, current_date+112, null);
+  reset role;
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000006');
+  set local role authenticated;
+  begin
+    perform public.admin_review_vacation(v_id, 'approved', null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (30,'Admin fremder Firma kann Urlaubsanfrage nicht reviewen (Cross-Company)','ABGELEHNT',v);
+  raise notice 'CASE 30 -> %', v;
+end $$;
+
+delete from public.employee_absences where employee_id = 'e2000000-0000-0000-0000-000000000002';
+
+-- CASE 31: admin_create_absence legt Urlaub direkt als 'approved' an, mit Review-Feldern.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  select id into v_id from public.admin_create_absence(
+    'e2000000-0000-0000-0000-000000000002','vacation', current_date+120, current_date+122, 'Telefonisch vereinbart');
+  reset role;
+  select 'status='||status::text||'/created_by='||created_by::text||'/reviewed_by='||reviewed_by::text||'/emp='||employee_id::text
+    into v from public.employee_absences where id = v_id;
+  insert into _abs values (31,'admin_create_absence legt Urlaub direkt genehmigt an',
+    'status=approved/created_by=e2000000-0000-0000-0000-000000000001/reviewed_by=e2000000-0000-0000-0000-000000000001/emp=e2000000-0000-0000-0000-000000000002', v);
+  raise notice 'CASE 31 -> %', v;
+end $$;
+
+-- CASE 32: admin_create_absence legt Krankheit direkt als 'reported' an, ohne Review-Felder.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  select id into v_id from public.admin_create_absence(
+    'e2000000-0000-0000-0000-000000000003','sickness', current_date, null, 'Telefonische Krankmeldung');
+  reset role;
+  select 'status='||status::text||'/reviewed_by='||coalesce(reviewed_by::text,'NULL')||'/end='||coalesce(end_date::text,'NULL')
+    into v from public.employee_absences where id = v_id;
+  insert into _abs values (32,'admin_create_absence legt Krankheit direkt gemeldet an, ohne Review',
+    'status=reported/reviewed_by=NULL/end=NULL', v);
+  raise notice 'CASE 32 -> %', v;
+end $$;
+
+-- CASE 33: admin_create_absence funktioniert auch fuer einen inaktiven Mitarbeiter
+-- (bewusste Design-Entscheidung: historische Nacherfassung soll moeglich bleiben).
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  begin
+    select id into v_id from public.admin_create_absence(
+      'e2000000-0000-0000-0000-000000000004','sickness', current_date-5, current_date-3, 'Nachtrag');
+    v := 'OK';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
+  end;
+  reset role;
+  insert into _abs values (33,'admin_create_absence erlaubt Nacherfassung fuer inaktiven Mitarbeiter','OK',v);
+  raise notice 'CASE 33 -> %', v;
+end $$;
+
+-- CASE 34: admin_create_absence lehnt einen Mitarbeiter fremder Firma ab.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  begin
+    perform public.admin_create_absence(
+      'e2000000-0000-0000-0000-000000000007','vacation', current_date+130, current_date+131, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (34,'admin_create_absence lehnt Mitarbeiter fremder Firma ab','ABGELEHNT',v);
+  raise notice 'CASE 34 -> %', v;
+end $$;
+
+-- CASE 35: eine Employee-Rolle darf admin_create_absence nicht aufrufen.
+do $$
+declare v text;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  begin
+    perform public.admin_create_absence(
+      'e2000000-0000-0000-0000-000000000003','vacation', current_date+140, current_date+141, null);
+    v := 'AKZEPTIERT';
+  exception when others then v := 'ABGELEHNT';
+  end;
+  reset role;
+  insert into _abs values (35,'Employee darf admin_create_absence nicht aufrufen','ABGELEHNT',v);
+  raise notice 'CASE 35 -> %', v;
+end $$;
+
+delete from public.employee_absences where employee_id in ('e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000004');
+
+
+-- =========================================================
+-- E. HISTORIE NACH KONTOLOESCHUNG
+-- =========================================================
+
+-- CASE 36: Konto-Loeschung anonymisiert die Abwesenheit statt sie zu loeschen.
+do $$
+declare v text; v_id uuid;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000005');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+150, current_date+152, 'Vor Kontoloeschung');
+  reset role;
+
+  begin
+    delete from auth.users where id = 'e2000000-0000-0000-0000-000000000005';
+    v := 'DELETED';
+  exception when others then v := 'BLOCKED('||sqlstate||')';
+  end;
+
+  if v = 'DELETED' then
+    select 'rows='||count(*)::text
+           ||'/emp='||coalesce(max(employee_id::text),'NULL')
+           ||'/name='||max(employee_name_snapshot)
+           ||'/status='||max(status::text)
+      into v
+    from public.employee_absences where id = v_id;
+  end if;
+
+  insert into _abs values (36,'Konto-Loeschung anonymisiert die Abwesenheit statt sie zu loeschen',
+    'rows=1/emp=NULL/name=Dirk Loeschbar/status=requested', v);
+  raise notice 'CASE 36 -> %', v;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisuebersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _abs order by case_no;
+
+do $$
+declare fails int;
+begin
+  select count(*) into fails from _abs where ergebnis is distinct from erwartet;
+  if fails > 0 then
+    raise exception 'ABSENCES FOUNDATION TEST: % Fall/Faelle FEHLGESCHLAGEN', fails;
+  end if;
+  raise notice 'ALLE FAELLE PASS';
+end $$;
+
+rollback;

--- a/supabase/tests/absences_foundation.test.sql
+++ b/supabase/tests/absences_foundation.test.sql
@@ -36,6 +36,7 @@ begin;
 -- Mitarbeiter D (wird geloescht) = e2…5
 -- Admin F (fremde Firma) = e2…6
 -- Mitarbeiter F (fremde Firma) = e2…7
+-- Admin H (reviewt und wird DANACH geloescht, Regressionsfall reviewed_by) = e2…8
 do $$
 begin
   insert into auth.users (instance_id, id, aud, role, email, raw_user_meta_data) values
@@ -45,7 +46,8 @@ begin
     ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000004','authenticated','authenticated','abs-c-inaktiv@example.test','{"full_name":"Cora Inaktiv"}'),
     ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000005','authenticated','authenticated','abs-d-del@example.test','{"full_name":"Dirk Loeschbar"}'),
     ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000006','authenticated','authenticated','abs-adminF@example.test','{"full_name":"Admin F"}'),
-    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000007','authenticated','authenticated','abs-f@example.test','{"full_name":"Finn Fremd"}');
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000007','authenticated','authenticated','abs-f@example.test','{"full_name":"Finn Fremd"}'),
+    ('00000000-0000-0000-0000-000000000000','e2000000-0000-0000-0000-000000000008','authenticated','authenticated','abs-adminH-del@example.test','{"full_name":"Admin H"}');
 end $$;
 
 insert into public.profiles (id, full_name) values
@@ -55,14 +57,15 @@ insert into public.profiles (id, full_name) values
   ('e2000000-0000-0000-0000-000000000004','Cora Inaktiv'),
   ('e2000000-0000-0000-0000-000000000005','Dirk Loeschbar'),
   ('e2000000-0000-0000-0000-000000000006','Admin F'),
-  ('e2000000-0000-0000-0000-000000000007','Finn Fremd')
+  ('e2000000-0000-0000-0000-000000000007','Finn Fremd'),
+  ('e2000000-0000-0000-0000-000000000008','Admin H')
 on conflict (id) do nothing;
 
 insert into public.companies (id, name, slug) values
   ('e1000000-0000-0000-0000-000000000001','Abs Firma E','abs-firma-e-test'),
   ('e1000000-0000-0000-0000-000000000002','Abs Firma F','abs-firma-f-test');
 
-update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id='e2000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='admin',    is_active=true  where id in ('e2000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000008');
 update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=true  where id in ('e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000003','e2000000-0000-0000-0000-000000000005');
 update public.profiles set company_id='e1000000-0000-0000-0000-000000000001', role='employee', is_active=false where id='e2000000-0000-0000-0000-000000000004';
 update public.profiles set company_id='e1000000-0000-0000-0000-000000000002', role='admin',    is_active=true  where id='e2000000-0000-0000-0000-000000000006';
@@ -189,17 +192,25 @@ begin
   raise notice 'CASE 7 -> %', v;
 end $$;
 
--- CASE 8: reviewed_by/reviewed_at muessen im Gleichschritt gesetzt sein.
+-- CASE 8: reviewed_by/reviewed_at-Gleichschritt ist NICHT (mehr) per CHECK
+-- erzwungen — das war chk_employee_absences_review_pair, entfernt, weil es
+-- mit reviewed_by ON DELETE SET NULL kollidierte (siehe Migrationskommentar
+-- bei den Spalten reviewed_by/reviewed_at). Der Gleichschritt wird
+-- ausschliesslich von den beiden schreibenden RPCs garantiert (Faelle
+-- weiter unten). Diese Zeile dokumentiert bewusst, dass ein direkter Insert
+-- mit nur reviewed_by (kein Client-Pfad, nur zur Schema-Doku) jetzt
+-- durchgeht — eine Regression zurueck zum alten Constraint waere die
+-- Deletion-Blockade von vorher.
 do $$
 declare v text;
 begin
   begin
     insert into public.employee_absences (company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, created_by, reviewed_by)
     values ('e1000000-0000-0000-0000-000000000001','e2000000-0000-0000-0000-000000000002','Anna A','vacation','approved', current_date+50, current_date+51, 'e2000000-0000-0000-0000-000000000002','e2000000-0000-0000-0000-000000000001');
-    v := 'AKZEPTIERT';
-  exception when others then v := 'ABGELEHNT';
+    v := 'OK';
+  exception when others then v := 'ABGELEHNT('||sqlstate||')';
   end;
-  insert into _abs values (8,'reviewed_by ohne reviewed_at wird abgelehnt','ABGELEHNT',v);
+  insert into _abs values (8,'reviewed_by ohne reviewed_at ist NICHT per CHECK blockiert (Fix: Deletion-Blockade)','OK',v);
   raise notice 'CASE 8 -> %', v;
 end $$;
 
@@ -718,6 +729,73 @@ begin
     'rows=1/emp=NULL/name=Dirk Loeschbar/status=requested', v);
   raise notice 'CASE 36 -> %', v;
 end $$;
+
+-- CASE 37: REGRESSION fuer den Review-Fix. Ein Admin (H) reviewt eine
+-- Urlaubsanfrage (reviewed_by/reviewed_at gemeinsam gesetzt), wird DANACH
+-- geloescht. Vor dem Fix schlug genau diese Loeschung mit 23514
+-- (chk_employee_absences_review_pair) fehl, weil ON DELETE SET NULL nur
+-- reviewed_by nullt, nicht reviewed_at. Erwartet jetzt: Loeschung gelingt,
+-- die Zeile bleibt vollstaendig erhalten (reviewed_by=NULL, reviewed_at
+-- UNVERAENDERT gesetzt, status weiterhin approved, employee_id/Snapshot
+-- unberuehrt weil NUR der Reviewer geloescht wurde, nicht der Mitarbeiter),
+-- Admin E (dieselbe Firma, weiterhin aktiv) kann die Zeile lesen, Admin F
+-- (fremde Firma) weiterhin nicht.
+do $$
+declare v text; v_id uuid; v_reviewed_at_vorher timestamptz;
+begin
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000002');
+  set local role authenticated;
+  select id into v_id from public.request_own_vacation(current_date+160, current_date+162, 'Regressionsfall Review-Loeschung');
+  reset role;
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000008');
+  set local role authenticated;
+  perform public.admin_review_vacation(v_id, 'approved', 'Regressionstest');
+  reset role;
+
+  select reviewed_at into v_reviewed_at_vorher from public.employee_absences where id = v_id;
+  if v_reviewed_at_vorher is null then
+    raise exception 'Testfehler: reviewed_at wurde von admin_review_vacation nicht gesetzt';
+  end if;
+
+  begin
+    delete from auth.users where id = 'e2000000-0000-0000-0000-000000000008';
+    v := 'DELETED';
+  exception when others then v := 'BLOCKED('||sqlstate||')';
+  end;
+
+  if v = 'DELETED' then
+    select 'loeschung=DELETED'
+           ||'/reviewed_by='||coalesce(reviewed_by::text,'NULL')
+           ||'/reviewed_at_erhalten='||(reviewed_at = v_reviewed_at_vorher)::text
+           ||'/status='||status::text
+           ||'/emp='||employee_id::text
+           ||'/name='||employee_name_snapshot
+      into v
+    from public.employee_absences where id = v_id;
+  end if;
+
+  insert into _abs values (37,'Loeschung eines reviewenden Admins gelingt; Zeile bleibt mit reviewed_at erhalten (Review-Fix)',
+    'loeschung=DELETED/reviewed_by=NULL/reviewed_at_erhalten=true/status=approved/emp=e2000000-0000-0000-0000-000000000002/name=Anna A', v);
+  raise notice 'CASE 37 -> %', v;
+
+  -- Lesezugriffe NACH der Loeschung.
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000001');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences where id = v_id;
+  reset role;
+  insert into _abs values (38,'Gleiche Firma (Admin E) kann die Zeile nach Reviewer-Loeschung weiterhin lesen','1',v);
+  raise notice 'CASE 38 -> %', v;
+
+  perform pg_temp.act_as('e2000000-0000-0000-0000-000000000006');
+  set local role authenticated;
+  select count(*)::text into v from public.employee_absences where id = v_id;
+  reset role;
+  insert into _abs values (39,'Fremde Firma (Admin F) kann die Zeile weiterhin nicht lesen','0',v);
+  raise notice 'CASE 39 -> %', v;
+end $$;
+
+delete from public.employee_absences where employee_id = 'e2000000-0000-0000-0000-000000000002';
 
 
 -- =========================================================


### PR DESCRIPTION
## Summary

Pure database foundation for the "Abwesenheiten" (Urlaub/Krankheit) feature — no UI, no notifications, no Timesheet integration. Those follow in separate PRs once this workflow is proven, per the architecture audit.

- New `employee_absences` table, typed with `absence_type` (`vacation`|`sickness`) and `absence_status`, with a `CHECK` constraint (`chk_employee_absences_status_matches_type`) that makes invalid type/status combinations structurally impossible instead of splitting into two tables.
- `employee_id` is `ON DELETE SET NULL` + `employee_name_snapshot`, mirroring the `job_assignments`/`employee_time_adjustments` pattern — absence history survives account deletion.
- RLS enabled, **read-only** (employee sees own rows, admin sees company rows); no INSERT/UPDATE/DELETE policy at all — every write goes through a `SECURITY DEFINER` RPC, same model as `admin_correct_assignment_time`.
- Seven RPCs: `request_own_vacation`, `report_own_sickness`, `cancel_own_vacation`, `cancel_own_sickness`, `update_own_sickness_end`, `admin_review_vacation`, `admin_create_absence`.
- Minimal overlap guards: a new vacation request is rejected if it overlaps an existing `requested`/`approved` vacation for the same employee; sickness allows at most one active (`reported`) report at a time. Vacation-vs-sickness overlap is intentionally **not** blocked at the DB level (future HR policy call).
- No stored duration/hours column — a future "planned absence minutes" Timesheet calc is designed to derive it dynamically from `jobs.planned_duration_minutes` on the employee's actual occurrences (recurring jobs are already materialized into real `jobs` rows via `generate_job_occurrences`/`update_job_occurrences`, so no schema change is needed for that later).
- `notification_outbox`, `dispatch-notifications`, `timesheet.service.ts`, and every `.ts`/`.tsx` file are untouched.

## Test plan
- [x] `supabase db reset` applies cleanly on top of the existing migration chain (24 prior migrations + this one), no errors.
- [x] New suite `supabase/tests/absences_foundation.test.sql` — 36/36 cases pass (schema constraints, RLS read scoping, no-direct-write grants, all 7 RPCs including cross-employee and cross-company attack attempts, deactivated-user rejection, and anonymization-on-account-deletion).
- [x] Regression: ran all 15 existing `supabase/tests/*.test.sql` suites. 12 pass; 3 (`employee_read_via_assignments`, `shared_job_time_multi_assignment`, `recurring_jobs_display`) fail identically **with this migration removed**, confirming they are pre-existing failures on `main`, unrelated to this change.
- [x] `tsc --noEmit` — clean (no `.ts` files changed).
- [x] `npm run lint` — clean, exit 0.
- [x] Self-audit: no destructive SQL, every `SECURITY DEFINER` function sets `search_path`, every grant follows the revoke-then-grant ordering this repo requires, every RPC is company-scoped, zero notification/outbox references.

## Deliberately out of scope (per instructions)
- No `admin_correct_absence` RPC — no concrete need found; corrections go through `cancel_own_vacation`/`admin_review_vacation`'s reject path or re-creation via `admin_create_absence`.
- No append-only absence-history table — `created_by`/`reviewed_by`/`reviewed_at`/notes are sufficient for Beta auditability.
- `lib/schema.sql` intentionally **not** updated — it already documents known drift (e.g. `job_assignments` and `employee_time_adjustments` from the two most recent migrations aren't reflected there either), so this follows the same real precedent rather than a first attempt at re-sync.
- No changes to employee/admin UI, `notification_outbox`, `dispatch-notifications`, or Timesheet code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)