### PR TITLE
feat(absences): employee self-service UI for Urlaub/Krankheit (Phase B)

### DIFF
--- a/app/absences/index.tsx
+++ b/app/absences/index.tsx
@@ -1,0 +1,5 @@
+import AbsencesScreen from "@/features/absences/AbsencesScreen";
+
+export default function AbsencesRoute() {
+  return <AbsencesScreen />;
+}

--- a/app/absences/report-sickness.tsx
+++ b/app/absences/report-sickness.tsx
@@ -1,0 +1,5 @@
+import ReportSicknessScreen from "@/features/absences/ReportSicknessScreen";
+
+export default function ReportSicknessRoute() {
+  return <ReportSicknessScreen />;
+}

--- a/app/absences/request-vacation.tsx
+++ b/app/absences/request-vacation.tsx
@@ -1,0 +1,5 @@
+import RequestVacationScreen from "@/features/absences/RequestVacationScreen";
+
+export default function RequestVacationRoute() {
+  return <RequestVacationScreen />;
+}

--- a/features/absences/AbsencesScreen.tsx
+++ b/features/absences/AbsencesScreen.tsx
@@ -1,0 +1,226 @@
+// features/absences/AbsencesScreen.tsx
+// "Meine Abwesenheiten" — Übersicht über eigene Urlaubs-/Krankheitseinträge,
+// gruppiert Aktuell/Bevorstehend/Vergangen (siehe utils/absenceGrouping.ts).
+// Erreichbar über Profil → Meine Arbeit → Abwesenheiten.
+
+import {
+  AppHeader,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  LoadingScreen,
+  ScreenContainer,
+  SectionHeader,
+} from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { AbsenceCard } from "./components/AbsenceCard";
+import { useAbsences } from "./hooks/useAbsences";
+import { groupAbsences } from "@/utils/absenceGrouping";
+
+export default function AbsencesScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const {
+    absences,
+    loading,
+    loadError,
+    refreshing,
+    refresh,
+    actionBusyId,
+    actionError,
+    clearActionError,
+    cancelVacation,
+    cancelSickness,
+    updateSicknessEnd,
+  } = useAbsences();
+
+  const { current, upcoming, past } = useMemo(
+    () => groupAbsences(absences),
+    [absences],
+  );
+
+  if (loading) return <LoadingScreen />;
+
+  return (
+    <View style={styles.container}>
+      <AppHeader title="Abwesenheiten" showBack />
+
+      <ScreenContainer
+        refreshing={refreshing}
+        onRefresh={() => {
+          void refresh();
+        }}
+      >
+        {loadError ? (
+          <View style={styles.bannerWrap}>
+            <ErrorBanner
+              message={loadError}
+              actionLabel="Erneut versuchen"
+              onAction={() => {
+                void refresh();
+              }}
+            />
+          </View>
+        ) : null}
+
+        {actionError ? (
+          <View style={styles.bannerWrap}>
+            <ErrorBanner message={actionError} onDismiss={clearActionError} />
+          </View>
+        ) : null}
+
+        {/* ── Aktionen ── */}
+        <View style={styles.actionRow}>
+          <TouchableOpacity
+            style={styles.actionCard}
+            activeOpacity={0.85}
+            onPress={() => router.push("/absences/request-vacation")}
+          >
+            <Ionicons name="sunny-outline" size={20} color={theme.colors.primary} />
+            <Text style={styles.actionCardText}>Urlaub beantragen</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionCard}
+            activeOpacity={0.85}
+            onPress={() => router.push("/absences/report-sickness")}
+          >
+            <Ionicons
+              name="medkit-outline"
+              size={20}
+              color={theme.colors.statusOpen}
+            />
+            <Text style={styles.actionCardText}>Krank melden</Text>
+          </TouchableOpacity>
+        </View>
+
+        {absences.length === 0 ? (
+          <Card>
+            <EmptyState
+              title="Noch keine Abwesenheiten erfasst."
+              icon="calendar-outline"
+            />
+          </Card>
+        ) : (
+          <>
+            <AbsenceGroupSection
+              title="Aktuell"
+              absences={current}
+              actionBusyId={actionBusyId}
+              onCancelVacation={cancelVacation}
+              onCancelSickness={cancelSickness}
+              onUpdateSicknessEnd={updateSicknessEnd}
+            />
+            <AbsenceGroupSection
+              title="Bevorstehend"
+              absences={upcoming}
+              actionBusyId={actionBusyId}
+              onCancelVacation={cancelVacation}
+              onCancelSickness={cancelSickness}
+              onUpdateSicknessEnd={updateSicknessEnd}
+            />
+            <AbsenceGroupSection
+              title="Vergangen"
+              absences={past}
+              actionBusyId={actionBusyId}
+              onCancelVacation={cancelVacation}
+              onCancelSickness={cancelSickness}
+              onUpdateSicknessEnd={updateSicknessEnd}
+            />
+          </>
+        )}
+
+        <View style={{ height: theme.spacing.xl }} />
+      </ScreenContainer>
+    </View>
+  );
+}
+
+function AbsenceGroupSection({
+  title,
+  absences,
+  actionBusyId,
+  onCancelVacation,
+  onCancelSickness,
+  onUpdateSicknessEnd,
+}: {
+  title: string;
+  absences: ReturnType<typeof groupAbsences>["current"];
+  actionBusyId: string | null;
+  onCancelVacation: (id: string) => void;
+  onCancelSickness: (id: string) => void;
+  onUpdateSicknessEnd: (id: string, newEndDate: string | null) => void;
+}) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  if (absences.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <SectionHeader title={title} />
+      <View style={styles.cardList}>
+        {absences.map((absence) => (
+          <AbsenceCard
+            key={absence.id}
+            absence={absence}
+            busy={actionBusyId === absence.id}
+            onCancelVacation={() => onCancelVacation(absence.id)}
+            onCancelSickness={() => onCancelSickness(absence.id)}
+            onUpdateSicknessEnd={(newEndDate) =>
+              onUpdateSicknessEnd(absence.id, newEndDate)
+            }
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    bannerWrap: {
+      marginBottom: theme.spacing.md,
+    },
+    actionRow: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+      marginBottom: theme.spacing.xl,
+    },
+    actionCard: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      backgroundColor: theme.colors.surface,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    actionCardText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    section: {
+      marginBottom: theme.spacing.xl,
+    },
+    cardList: {
+      gap: theme.spacing.sm,
+    },
+  });
+}

--- a/features/absences/AbsencesScreen.tsx
+++ b/features/absences/AbsencesScreen.tsx
@@ -15,8 +15,9 @@ import {
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "@react-navigation/native";
 import { router } from "expo-router";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { AbsenceCard } from "./components/AbsenceCard";
 import { useAbsences } from "./hooks/useAbsences";
@@ -30,6 +31,7 @@ export default function AbsencesScreen() {
     absences,
     loading,
     loadError,
+    load,
     refreshing,
     refresh,
     actionBusyId,
@@ -39,6 +41,21 @@ export default function AbsencesScreen() {
     cancelSickness,
     updateSicknessEnd,
   } = useAbsences();
+
+  // Lädt bei JEDEM Fokussieren neu, nicht nur beim Mounten — Urlaub
+  // beantragen/Krank melden sind eigene Root-Stack-Screens (app/absences/
+  // request-vacation, report-sickness), die diesen Screen beim
+  // Zurücknavigieren NICHT neu mounten. Gleiches Muster wie
+  // AdminRecurringRulesScreen/JobDetailScreen: erstes Fokussieren lädt mit
+  // vollem Spinner, jedes weitere still im Hintergrund (RefreshControl bleibt
+  // unberührt, kein zusätzlicher Request beim allerersten Mount).
+  const hasLoadedOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      load({ silent: hasLoadedOnceRef.current });
+      hasLoadedOnceRef.current = true;
+    }, [load]),
+  );
 
   const { current, upcoming, past } = useMemo(
     () => groupAbsences(absences),
@@ -155,7 +172,7 @@ function AbsenceGroupSection({
   actionBusyId: string | null;
   onCancelVacation: (id: string) => void;
   onCancelSickness: (id: string) => void;
-  onUpdateSicknessEnd: (id: string, newEndDate: string | null) => void;
+  onUpdateSicknessEnd: (id: string, newEndDate: string | null) => Promise<unknown>;
 }) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);

--- a/features/absences/ReportSicknessScreen.tsx
+++ b/features/absences/ReportSicknessScreen.tsx
@@ -1,0 +1,164 @@
+// features/absences/ReportSicknessScreen.tsx
+// "Krank melden": Krank ab (Default heute) / Voraussichtlich bis (optional) /
+// Notiz → report_own_sickness. Wird sofort aktiv (status=reported), keine
+// Admin-Genehmigung nötig — kein Enddatum zu kennen ist der Normalfall, nicht
+// die Ausnahme, deshalb ist "Bis" hier nie Pflicht.
+
+import { AppHeader, ErrorBanner, Input } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { reportOwnSickness } from "@/services/absences/absences.service";
+import type { AppTheme } from "@/constants/theme";
+import { formatDateISO } from "@/utils/date";
+import { alertDialog } from "@/utils/dialogs";
+import { router } from "expo-router";
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function ReportSicknessScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [startDate, setStartDate] = useState<Date | null>(new Date());
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [note, setNote] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const validate = (): string | null => {
+    if (!startDate) {
+      return "Bitte ein Startdatum angeben.";
+    }
+    if (endDate && formatDateISO(endDate)! < formatDateISO(startDate)!) {
+      return "Das Enddatum darf nicht vor dem Startdatum liegen.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError("");
+    setSubmitting(true);
+    try {
+      await reportOwnSickness({
+        startDate: formatDateISO(startDate!)!,
+        endDate: endDate ? formatDateISO(endDate) : null,
+        note: note.trim() || undefined,
+      });
+
+      await alertDialog("Krankmeldung gespeichert", "Deine Krankmeldung wurde erfasst.");
+      router.back();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Die Krankmeldung konnte nicht gespeichert werden.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <AppHeader title="Krank melden" showBack />
+
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {error ? (
+            <ErrorBanner message={error} onDismiss={() => setError("")} />
+          ) : null}
+
+          <View style={styles.form}>
+            <DateTimeField
+              label="Krank ab"
+              mode="date"
+              value={startDate}
+              onChange={setStartDate}
+            />
+            <DateTimeField
+              label="Voraussichtlich bis (optional)"
+              mode="date"
+              value={endDate}
+              onChange={setEndDate}
+              placeholder="Noch nicht bekannt"
+            />
+            <Input
+              label="Notiz (optional)"
+              placeholder="z. B. Art der Erkrankung, Vertretung"
+              value={note}
+              onChangeText={setNote}
+              multiline
+              editable={!submitting}
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+            activeOpacity={0.8}
+            onPress={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={theme.colors.onPrimary} />
+            ) : (
+              <Text style={styles.submitButtonText}>Krank melden</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      padding: theme.spacing.lg,
+      gap: theme.spacing.lg,
+    },
+    form: {
+      gap: theme.spacing.md,
+    },
+    submitButton: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: theme.spacing.tapTarget,
+    },
+    submitButtonDisabled: {
+      opacity: 0.6,
+    },
+    submitButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimary,
+    },
+  });
+}

--- a/features/absences/RequestVacationScreen.tsx
+++ b/features/absences/RequestVacationScreen.tsx
@@ -1,0 +1,165 @@
+// features/absences/RequestVacationScreen.tsx
+// "Urlaub beantragen": Von/Bis + optionale Notiz → request_own_vacation.
+// Kein clientseitig erfundener Genehmigungsstatus — die Anfrage geht als
+// status=requested raus, die RPC ist die einzige Instanz.
+
+import { AppHeader, ErrorBanner, Input } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { requestOwnVacation } from "@/services/absences/absences.service";
+import type { AppTheme } from "@/constants/theme";
+import { formatDateISO } from "@/utils/date";
+import { alertDialog } from "@/utils/dialogs";
+import { router } from "expo-router";
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function RequestVacationScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [note, setNote] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const validate = (): string | null => {
+    if (!startDate || !endDate) {
+      return "Bitte Von- und Bis-Datum angeben.";
+    }
+    if (formatDateISO(endDate)! < formatDateISO(startDate)!) {
+      return "Das Enddatum darf nicht vor dem Startdatum liegen.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError("");
+    setSubmitting(true);
+    try {
+      await requestOwnVacation({
+        startDate: formatDateISO(startDate!)!,
+        endDate: formatDateISO(endDate!)!,
+        note: note.trim() || undefined,
+      });
+
+      await alertDialog(
+        "Urlaub beantragt",
+        "Dein Urlaubsantrag wurde eingereicht und wartet auf Prüfung.",
+      );
+      router.back();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Der Urlaubsantrag konnte nicht gestellt werden.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <AppHeader title="Urlaub beantragen" showBack />
+
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {error ? (
+            <ErrorBanner message={error} onDismiss={() => setError("")} />
+          ) : null}
+
+          <View style={styles.form}>
+            <DateTimeField
+              label="Von"
+              mode="date"
+              value={startDate}
+              onChange={setStartDate}
+            />
+            <DateTimeField
+              label="Bis"
+              mode="date"
+              value={endDate}
+              onChange={setEndDate}
+            />
+            <Input
+              label="Notiz (optional)"
+              placeholder="z. B. Grund oder Hinweis für den Admin"
+              value={note}
+              onChangeText={setNote}
+              multiline
+              editable={!submitting}
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+            activeOpacity={0.8}
+            onPress={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={theme.colors.onPrimary} />
+            ) : (
+              <Text style={styles.submitButtonText}>Urlaub beantragen</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      padding: theme.spacing.lg,
+      gap: theme.spacing.lg,
+    },
+    form: {
+      gap: theme.spacing.md,
+    },
+    submitButton: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: theme.spacing.tapTarget,
+    },
+    submitButtonDisabled: {
+      opacity: 0.6,
+    },
+    submitButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimary,
+    },
+  });
+}

--- a/features/absences/components/AbsenceCard.tsx
+++ b/features/absences/components/AbsenceCard.tsx
@@ -1,0 +1,330 @@
+// features/absences/components/AbsenceCard.tsx
+// Eine Karte in "Meine Abwesenheiten": Typ, Zeitraum, Status, Notizen,
+// kontextabhängige Aktionen. "Ende aktualisieren" klappt INLINE auf (kein
+// eigenes Modal — siehe CLAUDE.md-Vorgabe "keine verschachtelte
+// Modal-Komplexität").
+
+import { Button, Card } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import type { Absence } from "@/types/absence";
+import { formatDateISO } from "@/utils/date";
+import { confirmDialog } from "@/utils/dialogs";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { AbsenceStatusBadge } from "./AbsenceStatusBadge";
+
+/** "YYYY-MM-DD" → "DD.MM." (ohne Jahr, wie in den Kartenbeispielen). */
+function formatDayMonth(dateIso: string): string {
+  const [, m, d] = dateIso.split("-");
+  return `${d}.${m}.`;
+}
+
+function formatDateRangeLabel(absence: Absence): string {
+  if (absence.type === "vacation") {
+    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate!)}`;
+  }
+  // Krankheit: mit Ende ein Bereich, ohne Ende "Seit ...".
+  if (absence.endDate) {
+    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate)}`;
+  }
+  return `Seit ${formatDayMonth(absence.startDate)}`;
+}
+
+const today = () => formatDateISO(new Date())!;
+
+interface AbsenceCardProps {
+  absence: Absence;
+  busy: boolean;
+  onCancelVacation: () => void;
+  onCancelSickness: () => void;
+  onUpdateSicknessEnd: (newEndDate: string | null) => void;
+}
+
+export function AbsenceCard({
+  absence,
+  busy,
+  onCancelVacation,
+  onCancelSickness,
+  onUpdateSicknessEnd,
+}: AbsenceCardProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [editingEnd, setEditingEnd] = useState(false);
+  const [draftEndDate, setDraftEndDate] = useState<Date | null>(
+    absence.endDate ? new Date(absence.endDate) : null,
+  );
+
+  const isVacation = absence.type === "vacation";
+
+  // Server-Prädikate gespiegelt (cancel_own_vacation/-sickness) — nur die
+  // Sichtbarkeit von Aktionen, keine eigene Berechtigungslogik.
+  const canCancelVacation =
+    isVacation &&
+    (absence.status === "requested" || absence.status === "approved") &&
+    absence.startDate > today();
+  const canManageSickness = !isVacation && absence.status === "reported";
+
+  const handleCancelVacation = async () => {
+    const confirmed = await confirmDialog({
+      title: "Anfrage stornieren",
+      message: "Möchtest du diesen Urlaubsantrag wirklich stornieren?",
+      confirmLabel: "Stornieren",
+      destructive: true,
+    });
+    if (confirmed) onCancelVacation();
+  };
+
+  const handleCancelSickness = async () => {
+    const confirmed = await confirmDialog({
+      title: "Krankmeldung stornieren",
+      message: "Möchtest du diese Krankmeldung wirklich stornieren?",
+      confirmLabel: "Stornieren",
+      destructive: true,
+    });
+    if (confirmed) onCancelSickness();
+  };
+
+  const handleSaveEnd = () => {
+    onUpdateSicknessEnd(draftEndDate ? formatDateISO(draftEndDate) : null);
+    setEditingEnd(false);
+  };
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.headerRow}>
+        <View style={styles.typeRow}>
+          <View
+            style={[
+              styles.typeIcon,
+              isVacation ? styles.typeIconVacation : styles.typeIconSickness,
+            ]}
+          >
+            <Ionicons
+              name={isVacation ? "sunny-outline" : "medkit-outline"}
+              size={16}
+              color={
+                isVacation ? theme.colors.primary : theme.colors.statusOpen
+              }
+            />
+          </View>
+          <View>
+            <Text style={styles.typeLabel}>
+              {isVacation ? "Urlaub" : "Krankheit"}
+            </Text>
+            <Text style={styles.dateRange}>{formatDateRangeLabel(absence)}</Text>
+          </View>
+        </View>
+        <AbsenceStatusBadge status={absence.status} />
+      </View>
+
+      {absence.employeeNote ? (
+        <Text style={styles.note} numberOfLines={3}>
+          {absence.employeeNote}
+        </Text>
+      ) : null}
+
+      {absence.adminNote ? (
+        <View style={styles.adminNoteWrap}>
+          <Text style={styles.adminNoteLabel}>Notiz vom Admin</Text>
+          <Text style={styles.note} numberOfLines={3}>
+            {absence.adminNote}
+          </Text>
+        </View>
+      ) : null}
+
+      {(canCancelVacation || canManageSickness) && (
+        <View style={styles.actionsRow}>
+          {canCancelVacation && (
+            <TouchableOpacity
+              style={[styles.actionBtn, busy && styles.actionBtnDisabled]}
+              disabled={busy}
+              activeOpacity={0.8}
+              onPress={handleCancelVacation}
+            >
+              <Text style={styles.actionBtnDangerText}>Anfrage stornieren</Text>
+            </TouchableOpacity>
+          )}
+
+          {canManageSickness && (
+            <>
+              <TouchableOpacity
+                style={[styles.actionBtn, busy && styles.actionBtnDisabled]}
+                disabled={busy}
+                activeOpacity={0.8}
+                onPress={() => setEditingEnd((v) => !v)}
+              >
+                <Text style={styles.actionBtnText}>
+                  {editingEnd ? "Abbrechen" : "Ende aktualisieren"}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.actionBtn, busy && styles.actionBtnDisabled]}
+                disabled={busy}
+                activeOpacity={0.8}
+                onPress={handleCancelSickness}
+              >
+                <Text style={styles.actionBtnDangerText}>
+                  Krankmeldung stornieren
+                </Text>
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      )}
+
+      {editingEnd && (
+        <View style={styles.editEndWrap}>
+          <DateTimeField
+            label="Voraussichtlich bis"
+            mode="date"
+            value={draftEndDate}
+            onChange={setDraftEndDate}
+            placeholder="Kein Enddatum bekannt"
+          />
+          <View style={styles.editEndActions}>
+            {draftEndDate && (
+              <TouchableOpacity
+                style={styles.clearEndBtn}
+                onPress={() => setDraftEndDate(null)}
+              >
+                <Text style={styles.clearEndText}>Enddatum entfernen</Text>
+              </TouchableOpacity>
+            )}
+            <Button
+              label="Speichern"
+              onPress={handleSaveEnd}
+              loading={busy}
+              fullWidth={false}
+              style={styles.saveEndBtn}
+            />
+          </View>
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.sm,
+    },
+    headerRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    typeRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      flexShrink: 1,
+    },
+    typeIcon: {
+      width: 32,
+      height: 32,
+      borderRadius: theme.radius.md,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    typeIconVacation: {
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    typeIconSickness: {
+      backgroundColor: theme.colors.statusOpenBg,
+    },
+    typeLabel: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    dateRange: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      marginTop: 1,
+    },
+    note: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+    adminNoteWrap: {
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.sm,
+      gap: 2,
+    },
+    adminNoteLabel: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurfaceVariant,
+      textTransform: "uppercase",
+      letterSpacing: theme.typography.letterSpacing.wide,
+    },
+    actionsRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.sm,
+      marginTop: 2,
+    },
+    actionBtn: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 9,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+    },
+    actionBtnDisabled: {
+      opacity: 0.5,
+    },
+    actionBtnText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    actionBtnDangerText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.error,
+    },
+    editEndWrap: {
+      marginTop: theme.spacing.xs,
+      gap: theme.spacing.sm,
+      paddingTop: theme.spacing.sm,
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.outlineVariant,
+    },
+    editEndActions: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    clearEndBtn: {
+      paddingVertical: 8,
+    },
+    clearEndText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+      textDecorationLine: "underline",
+    },
+    saveEndBtn: {
+      paddingHorizontal: theme.spacing.xl,
+    },
+  });
+}

--- a/features/absences/components/AbsenceCard.tsx
+++ b/features/absences/components/AbsenceCard.tsx
@@ -40,7 +40,8 @@ interface AbsenceCardProps {
   busy: boolean;
   onCancelVacation: () => void;
   onCancelSickness: () => void;
-  onUpdateSicknessEnd: (newEndDate: string | null) => void;
+  /** Resolves to the updated absence on success, or null on failure. */
+  onUpdateSicknessEnd: (newEndDate: string | null) => Promise<unknown>;
 }
 
 export function AbsenceCard({
@@ -88,9 +89,17 @@ export function AbsenceCard({
     if (confirmed) onCancelSickness();
   };
 
-  const handleSaveEnd = () => {
-    onUpdateSicknessEnd(draftEndDate ? formatDateISO(draftEndDate) : null);
-    setEditingEnd(false);
+  // Erst NACH erfolgreichem Update einklappen — schlägt die RPC fehl (z. B.
+  // Enddatum vor Beginn), bleibt der Editor offen und der Fehler erscheint im
+  // ErrorBanner des Screens, statt den Eingabeversuch kommentarlos zu
+  // verwerfen.
+  const handleSaveEnd = async () => {
+    const result = await onUpdateSicknessEnd(
+      draftEndDate ? formatDateISO(draftEndDate) : null,
+    );
+    if (result) {
+      setEditingEnd(false);
+    }
   };
 
   return (

--- a/features/absences/components/AbsenceStatusBadge.tsx
+++ b/features/absences/components/AbsenceStatusBadge.tsx
@@ -1,0 +1,32 @@
+// features/absences/components/AbsenceStatusBadge.tsx
+// Status-Badge für Abwesenheiten. Nutzt den generischen `Badge` aus
+// components/ui — der bestehende `StatusBadge` ist fest an JobStatus/
+// utils/jobStatus.ts gebunden (siehe dessen Kopfkommentar) und für einen
+// eigenen Status-Enum nicht gedacht.
+
+import { Badge } from "@/components/ui";
+import type { AbsenceStatus } from "@/types/absence";
+import React from "react";
+
+const LABELS: Record<AbsenceStatus, string> = {
+  requested: "Angefragt",
+  approved: "Genehmigt",
+  rejected: "Abgelehnt",
+  cancelled: "Storniert",
+  reported: "Gemeldet",
+};
+
+const VARIANTS: Record<
+  AbsenceStatus,
+  "default" | "success" | "warning" | "danger" | "info"
+> = {
+  requested: "warning",
+  approved: "success",
+  rejected: "danger",
+  cancelled: "default",
+  reported: "info",
+};
+
+export function AbsenceStatusBadge({ status }: { status: AbsenceStatus }) {
+  return <Badge label={LABELS[status]} variant={VARIANTS[status]} />;
+}

--- a/features/absences/hooks/useAbsences.ts
+++ b/features/absences/hooks/useAbsences.ts
@@ -3,6 +3,14 @@
 // Gleiches Muster wie andere Feature-Hooks (z. B. useJobComments): eigener
 // Ladezustand, eigener Fehlerzustand, kein globaler Context — Abwesenheiten
 // sind bewusst online-only, keine Offline-Queue (siehe Backend-Migration).
+//
+// `load` wird bewusst NICHT mehr per Mount-Effect selbst aufgerufen — das ist
+// jetzt Sache des Aufrufers via `useFocusEffect` (siehe AbsencesScreen), exakt
+// das Muster aus AdminRecurringRulesScreen/JobDetailScreen: `app/absences/
+// request-vacation` bzw. `report-sickness` sind eigene Stack-Screens, die
+// beim Zurücknavigieren AbsencesScreen NICHT neu mounten. Ein reiner
+// Mount-Effect würde die Liste nach einem erfolgreichen Antrag/Meldung
+// dauerhaft veraltet stehen lassen.
 
 import {
   cancelOwnSickness,
@@ -52,10 +60,6 @@ export function useAbsences() {
       if (mountedRef.current && !opts?.silent) setLoading(false);
     }
   }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   const refresh = useCallback(async () => {
     setRefreshing(true);
@@ -144,6 +148,7 @@ export function useAbsences() {
     absences,
     loading,
     loadError,
+    load,
     refreshing,
     refresh,
     actionBusyId,

--- a/features/absences/hooks/useAbsences.ts
+++ b/features/absences/hooks/useAbsences.ts
@@ -1,0 +1,158 @@
+// features/absences/hooks/useAbsences.ts
+// Lädt "Meine Abwesenheiten" und kapselt die Stornier-/Update-Aktionen.
+// Gleiches Muster wie andere Feature-Hooks (z. B. useJobComments): eigener
+// Ladezustand, eigener Fehlerzustand, kein globaler Context — Abwesenheiten
+// sind bewusst online-only, keine Offline-Queue (siehe Backend-Migration).
+
+import {
+  cancelOwnSickness,
+  cancelOwnVacation,
+  getMyAbsences,
+  reportOwnSickness,
+  requestOwnVacation,
+  updateOwnSicknessEnd,
+} from "@/services/absences/absences.service";
+import type {
+  Absence,
+  ReportSicknessInput,
+  RequestVacationInput,
+} from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useAbsences() {
+  const [absences, setAbsences] = useState<Absence[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [actionBusyId, setActionBusyId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState("");
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoading(true);
+    setLoadError("");
+    try {
+      const data = await getMyAbsences();
+      if (mountedRef.current) setAbsences(data);
+    } catch (err) {
+      if (mountedRef.current) {
+        setLoadError(
+          toUserMessage(err, "Die Abwesenheiten konnten nicht geladen werden."),
+        );
+      }
+    } finally {
+      if (mountedRef.current && !opts?.silent) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ silent: true });
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, [load]);
+
+  const upsertLocal = useCallback((updated: Absence) => {
+    setAbsences((prev) => {
+      const exists = prev.some((a) => a.id === updated.id);
+      if (exists) return prev.map((a) => (a.id === updated.id ? updated : a));
+      return [updated, ...prev];
+    });
+  }, []);
+
+  const runAction = useCallback(
+    async <T,>(id: string, action: () => Promise<T>): Promise<T | null> => {
+      setActionBusyId(id);
+      setActionError("");
+      try {
+        return await action();
+      } catch (err) {
+        if (mountedRef.current) {
+          setActionError(toUserMessage(err, "Die Aktion konnte nicht ausgeführt werden."));
+        }
+        return null;
+      } finally {
+        if (mountedRef.current) setActionBusyId(null);
+      }
+    },
+    [],
+  );
+
+  const requestVacation = useCallback(
+    async (input: RequestVacationInput) => {
+      const result = await requestOwnVacation(input);
+      upsertLocal(result);
+      return result;
+    },
+    [upsertLocal],
+  );
+
+  const reportSickness = useCallback(
+    async (input: ReportSicknessInput) => {
+      const result = await reportOwnSickness(input);
+      upsertLocal(result);
+      return result;
+    },
+    [upsertLocal],
+  );
+
+  const cancelVacation = useCallback(
+    (id: string) =>
+      runAction(id, async () => {
+        const result = await cancelOwnVacation(id);
+        upsertLocal(result);
+        return result;
+      }),
+    [runAction, upsertLocal],
+  );
+
+  const cancelSickness = useCallback(
+    (id: string) =>
+      runAction(id, async () => {
+        const result = await cancelOwnSickness(id);
+        upsertLocal(result);
+        return result;
+      }),
+    [runAction, upsertLocal],
+  );
+
+  const updateSicknessEnd = useCallback(
+    (id: string, newEndDate: string | null) =>
+      runAction(id, async () => {
+        const result = await updateOwnSicknessEnd(id, newEndDate);
+        upsertLocal(result);
+        return result;
+      }),
+    [runAction, upsertLocal],
+  );
+
+  return {
+    absences,
+    loading,
+    loadError,
+    refreshing,
+    refresh,
+    actionBusyId,
+    actionError,
+    clearActionError: () => setActionError(""),
+    requestVacation,
+    reportSickness,
+    cancelVacation,
+    cancelSickness,
+    updateSicknessEnd,
+  };
+}

--- a/features/home/EmployeeOverviewScreen.tsx
+++ b/features/home/EmployeeOverviewScreen.tsx
@@ -340,10 +340,30 @@ export default function EmployeeOverviewScreen() {
           (anderer Zeilenumbruch/Abschnitt) — sichtbares Zappeln im Kopfbereich.
           Der Badge ist entfallen; aussagekräftige Zustände zeigt das Banner. */}
       <View style={styles.header}>
-        <Text style={styles.greeting} numberOfLines={1}>
-          {getGreeting(now)}, {firstName}
-        </Text>
-        <Text style={styles.dateText}>{dateLabel}</Text>
+        <View style={styles.headerTopRow}>
+          <View style={styles.headerTextCol}>
+            <Text style={styles.greeting} numberOfLines={1}>
+              {getGreeting(now)}, {firstName}
+            </Text>
+            <Text style={styles.dateText}>{dateLabel}</Text>
+          </View>
+
+          {/* Kleine Quick-Action, kein neues Dashboard-Card — Urlaub bewusst
+              NICHT hier (nur Krankmeldung ist ein spontaner "jetzt gerade"-
+              Vorgang, Urlaub bleibt im Abwesenheiten-Screen). */}
+          <TouchableOpacity
+            style={styles.sickShortcut}
+            activeOpacity={0.8}
+            onPress={() => router.push("/absences/report-sickness")}
+          >
+            <Ionicons
+              name="medkit-outline"
+              size={14}
+              color={theme.colors.statusOpen}
+            />
+            <Text style={styles.sickShortcutText}>Krank melden</Text>
+          </TouchableOpacity>
+        </View>
       </View>
 
       {/* ── Heute-Übersicht (2×2) ── */}
@@ -652,6 +672,32 @@ function createStyles(theme: AppTheme) {
     header: {
       paddingTop: theme.spacing.md,
       marginBottom: theme.spacing.xl,
+    },
+    headerTopRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    headerTextCol: {
+      flex: 1,
+    },
+    sickShortcut: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingHorizontal: theme.spacing.sm,
+      paddingVertical: 7,
+      borderRadius: theme.radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    sickShortcutText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
     },
     greeting: {
       fontSize: theme.typography.size.xxl,

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -162,6 +162,13 @@ export default function ProfileScreen({
               icon="time-outline"
               label="Meine Arbeitszeit"
               onPress={() => router.push("/timesheets")}
+              styles={styles}
+              theme={theme}
+            />
+            <SettingsRow
+              icon="calendar-outline"
+              label="Abwesenheiten"
+              onPress={() => router.push("/absences")}
               isLast
               styles={styles}
               theme={theme}

--- a/services/absences/absences.service.ts
+++ b/services/absences/absences.service.ts
@@ -1,0 +1,244 @@
+// services/absences/absences.service.ts
+// Supabase-Operationen für Urlaub/Krankheit (Phase B).
+//
+// EINZIGER SCHREIBPFAD sind die fünf Mitarbeiter-RPCs aus
+// supabase/migrations/20260816000000_absences_foundation.sql
+// (request_own_vacation, report_own_sickness, cancel_own_vacation,
+// cancel_own_sickness, update_own_sickness_end) — es gibt bewusst keine
+// INSERT/UPDATE/DELETE-Policy auf employee_absences, siehe dortigen
+// Kopfkommentar. Lesen läuft über ein normales SELECT, RLS beschränkt das
+// bereits auf die eigenen Zeilen ("employee read own absences").
+//
+// Admin-RPCs (admin_review_vacation, admin_create_absence) sind bewusst NICHT
+// hier verdrahtet — Admin-Workflow ist eine spätere Phase.
+
+import { supabase } from "@/lib/supabase";
+import {
+  Absence,
+  AbsenceStatus,
+  AbsenceType,
+  ReportSicknessInput,
+  RequestVacationInput,
+} from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+
+type AbsenceRow = {
+  id: string;
+  company_id: string;
+  employee_id: string | null;
+  employee_name_snapshot: string;
+  type: AbsenceType;
+  status: AbsenceStatus;
+  start_date: string;
+  end_date: string | null;
+  employee_note: string | null;
+  admin_note: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function mapAbsence(row: AbsenceRow): Absence {
+  return {
+    id: row.id,
+    companyId: row.company_id,
+    employeeId: row.employee_id,
+    employeeName: row.employee_name_snapshot,
+    type: row.type,
+    status: row.status,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    employeeNote: row.employee_note,
+    adminNote: row.admin_note,
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// Bekannte englische RPC-Ablehnungen → deutsche Nutzer-Meldung. Reihenfolge
+// spezifisch → grob, gleiche Bauform wie
+// services/timesheets/timeCorrection.service.ts (translateRpcError).
+const RPC_MESSAGE_MAP: { match: string; message: string }[] = [
+  {
+    match: "Only employees can request their own vacation",
+    message: "Nur Mitarbeiter können Urlaub beantragen.",
+  },
+  {
+    match: "Only employees can report their own sickness",
+    message: "Nur Mitarbeiter können eine Krankheit melden.",
+  },
+  {
+    match: "Only employees can cancel their own vacation",
+    message: "Nur Mitarbeiter können ihren eigenen Urlaub stornieren.",
+  },
+  {
+    match: "Only employees can cancel their own sickness report",
+    message: "Nur Mitarbeiter können ihre eigene Krankmeldung stornieren.",
+  },
+  {
+    match: "Only employees can update their own sickness report",
+    message: "Nur Mitarbeiter können ihre eigene Krankmeldung aktualisieren.",
+  },
+  {
+    match: "start_date and end_date are required",
+    message: "Bitte Von- und Bis-Datum angeben.",
+  },
+  {
+    match: "start_date is required",
+    message: "Bitte ein Startdatum angeben.",
+  },
+  {
+    match: "end_date must not be before start_date",
+    message: "Das Enddatum darf nicht vor dem Startdatum liegen.",
+  },
+  {
+    match: "Overlaps an existing vacation request",
+    message:
+      "Dieser Zeitraum überschneidet sich mit einem bereits bestehenden Urlaubsantrag.",
+  },
+  {
+    match: "Overlaps an existing active sickness report",
+    message:
+      "Dieser Zeitraum überschneidet sich mit einer bereits aktiven Krankmeldung.",
+  },
+  {
+    match: "Vacation not found, not yours, or no longer cancellable",
+    message:
+      "Dieser Urlaub kann nicht mehr storniert werden — er ist entweder bereits vergangen oder wurde schon entschieden.",
+  },
+  {
+    match: "Sickness report not found, not yours, or already closed",
+    message:
+      "Diese Krankmeldung wurde nicht gefunden oder ist bereits abgeschlossen.",
+  },
+];
+
+function translateRpcError(err: unknown, fallback: string): string {
+  const raw =
+    typeof err === "object" && err !== null && "message" in err
+      ? String((err as { message?: unknown }).message ?? "")
+      : "";
+
+  const hit = RPC_MESSAGE_MAP.find((entry) => raw.includes(entry.match));
+  if (hit) return hit.message;
+
+  return toUserMessage(err, fallback);
+}
+
+const ABSENCE_SELECT =
+  "id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, employee_note, admin_note, reviewed_at, created_at, updated_at";
+
+/** Lädt die eigenen Abwesenheiten des aktuellen Mitarbeiters (RLS-skopiert). */
+export async function getMyAbsences(): Promise<Absence[]> {
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .order("start_date", { ascending: false });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+function firstRow(data: AbsenceRow[] | null): Absence {
+  const row = data?.[0];
+  if (!row) {
+    throw new Error("Die Abwesenheit konnte nicht geladen werden.");
+  }
+  return mapAbsence(row);
+}
+
+/** Mitarbeiter beantragt eigenen Urlaub (status=requested). */
+export async function requestOwnVacation(
+  input: RequestVacationInput,
+): Promise<Absence> {
+  const { data, error } = await supabase.rpc("request_own_vacation", {
+    start_date_input: input.startDate,
+    end_date_input: input.endDate,
+    employee_note_input: input.note?.trim() || null,
+  });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Der Urlaubsantrag konnte nicht gestellt werden."),
+    );
+  }
+
+  return firstRow(data as AbsenceRow[] | null);
+}
+
+/** Mitarbeiter meldet eigene Krankheit (status=reported, sofort aktiv). */
+export async function reportOwnSickness(
+  input: ReportSicknessInput,
+): Promise<Absence> {
+  const { data, error } = await supabase.rpc("report_own_sickness", {
+    start_date_input: input.startDate,
+    end_date_input: input.endDate ?? null,
+    employee_note_input: input.note?.trim() || null,
+  });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Die Krankmeldung konnte nicht gespeichert werden."),
+    );
+  }
+
+  return firstRow(data as AbsenceRow[] | null);
+}
+
+/** Mitarbeiter storniert eigenen, noch nicht begonnenen Urlaub. */
+export async function cancelOwnVacation(absenceId: string): Promise<Absence> {
+  const { data, error } = await supabase.rpc("cancel_own_vacation", {
+    absence_id_input: absenceId,
+  });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Der Urlaub konnte nicht storniert werden."),
+    );
+  }
+
+  return firstRow(data as AbsenceRow[] | null);
+}
+
+/** Mitarbeiter storniert eigene Krankmeldung (z. B. fälschlich erfasst). */
+export async function cancelOwnSickness(absenceId: string): Promise<Absence> {
+  const { data, error } = await supabase.rpc("cancel_own_sickness", {
+    absence_id_input: absenceId,
+  });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Die Krankmeldung konnte nicht storniert werden."),
+    );
+  }
+
+  return firstRow(data as AbsenceRow[] | null);
+}
+
+/**
+ * Mitarbeiter setzt/ändert das Enddatum der eigenen aktiven Krankmeldung.
+ * `newEndDate: null` macht sie wieder offen-endig ("bis auf Weiteres").
+ */
+export async function updateOwnSicknessEnd(
+  absenceId: string,
+  newEndDate: string | null,
+): Promise<Absence> {
+  const { data, error } = await supabase.rpc("update_own_sickness_end", {
+    absence_id_input: absenceId,
+    new_end_date_input: newEndDate,
+  });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Das Enddatum konnte nicht aktualisiert werden."),
+    );
+  }
+
+  return firstRow(data as AbsenceRow[] | null);
+}

--- a/types/absence.ts
+++ b/types/absence.ts
@@ -1,0 +1,50 @@
+// types/absence.ts
+// Typen für Urlaub/Krankheit (Phase B — Employee Absence UI).
+// Backend siehe supabase/migrations/20260816000000_absences_foundation.sql:
+// ein typ-diskriminiertes Modell (type + status), Schreibzugriff ausschließlich
+// über RPCs (services/absences/absences.service.ts).
+
+export type AbsenceType = "vacation" | "sickness";
+
+// vacation: requested | approved | rejected | cancelled
+// sickness: reported | cancelled
+export type AbsenceStatus =
+  | "requested"
+  | "approved"
+  | "rejected"
+  | "cancelled"
+  | "reported";
+
+export type Absence = {
+  id: string;
+  companyId: string;
+  employeeId: string | null;
+  employeeName: string;
+  type: AbsenceType;
+  status: AbsenceStatus;
+  /** "YYYY-MM-DD" */
+  startDate: string;
+  /** "YYYY-MM-DD", nur bei Krankheit ohne bekanntes Ende null */
+  endDate: string | null;
+  employeeNote: string | null;
+  adminNote: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RequestVacationInput = {
+  /** "YYYY-MM-DD" */
+  startDate: string;
+  /** "YYYY-MM-DD" */
+  endDate: string;
+  note?: string;
+};
+
+export type ReportSicknessInput = {
+  /** "YYYY-MM-DD" */
+  startDate: string;
+  /** "YYYY-MM-DD", optional — Ende noch unbekannt */
+  endDate?: string | null;
+  note?: string;
+};

--- a/utils/absenceGrouping.ts
+++ b/utils/absenceGrouping.ts
@@ -1,0 +1,59 @@
+// utils/absenceGrouping.ts
+// Gruppiert "Meine Abwesenheiten" in Aktuell/Bevorstehend/Vergangen.
+//
+// Rein clientseitige Anzeige-Heuristik (keine Occurrences wie bei Jobs) —
+// beschrieben hier, damit sie nicht in mehreren Screens neu erfunden wird:
+//   * rejected/cancelled  → immer "Vergangen" (entschiedener/abgeschlossener
+//     Zustand, unabhängig vom Datum).
+//   * end_date < heute    → "Vergangen".
+//   * start_date <= heute (und offen/laufend) → "Aktuell".
+//   * start_date > heute  → "Bevorstehend".
+
+import type { Absence } from "@/types/absence";
+import { formatDateISO } from "@/utils/date";
+
+export type AbsenceGroup = "current" | "upcoming" | "past";
+
+export function categorizeAbsence(
+  absence: Absence,
+  today: Date = new Date(),
+): AbsenceGroup {
+  if (absence.status === "cancelled" || absence.status === "rejected") {
+    return "past";
+  }
+
+  const todayIso = formatDateISO(today)!;
+
+  if (absence.endDate && absence.endDate < todayIso) {
+    return "past";
+  }
+
+  if (absence.startDate <= todayIso) {
+    return "current";
+  }
+
+  return "upcoming";
+}
+
+export function groupAbsences(
+  absences: Absence[],
+  today: Date = new Date(),
+): { current: Absence[]; upcoming: Absence[]; past: Absence[] } {
+  const current: Absence[] = [];
+  const upcoming: Absence[] = [];
+  const past: Absence[] = [];
+
+  for (const absence of absences) {
+    const group = categorizeAbsence(absence, today);
+    if (group === "current") current.push(absence);
+    else if (group === "upcoming") upcoming.push(absence);
+    else past.push(absence);
+  }
+
+  // Aktuell/Bevorstehend: nächstliegendes zuerst. Vergangen: jüngstes zuerst.
+  current.sort((a, b) => a.startDate.localeCompare(b.startDate));
+  upcoming.sort((a, b) => a.startDate.localeCompare(b.startDate));
+  past.sort((a, b) => b.startDate.localeCompare(a.startDate));
+
+  return { current, upcoming, past };
+}


### PR DESCRIPTION
## Summary
- Employee-facing UI for the Phase A absence backend (`employee_absences` + `request_own_vacation`/`report_own_sickness`/`cancel_own_vacation`/`cancel_own_sickness`/`update_own_sickness_end`, already live in staging/prod).
- New "Meine Abwesenheiten" screen (`/absences`) grouped Aktuell/Bevorstehend/Vergangen, with "Urlaub beantragen" and "Krank melden" forms.
- Entry points: Profil → Meine Arbeit → Abwesenheiten, and a small "Krank melden" shortcut on the employee overview (no new bottom tab, no large new dashboard card).
- All writes go through the existing RPCs (no direct INSERT/UPDATE/DELETE); reads are RLS-scoped to the current employee.

## Explicitly out of scope (per spec)
- No DB migration
- No admin approve/reject or manual-creation UI
- No calendar integration
- No timesheet integration
- No notifications
- No planned-duration/paid-hour calculation

## Files
- `types/absence.ts` — `Absence`/`AbsenceType`/`AbsenceStatus` domain types
- `services/absences/absences.service.ts` — thin RPC wrapper + German error translation (same pattern as `services/timesheets/timeCorrection.service.ts`)
- `utils/absenceGrouping.ts` — Aktuell/Bevorstehend/Vergangen grouping heuristic
- `features/absences/` — `AbsencesScreen`, `RequestVacationScreen`, `ReportSicknessScreen`, `useAbsences` hook, `AbsenceCard`, `AbsenceStatusBadge`
- `app/absences/{index,request-vacation,report-sickness}.tsx` — thin routes
- `features/profile/ProfileScreen.tsx` — new "Abwesenheiten" row (employee-only "Meine Arbeit" section)
- `features/home/EmployeeOverviewScreen.tsx` — small "Krank melden" shortcut next to the greeting

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Manual QA on a physical device / simulator (no JS test runner in this repo):
  - **Urlaub**: request vacation → list shows "Angefragt"; end-before-start blocked client-side; overlapping vacation shows the translated RPC error; cancel an eligible future request → list refreshes and status becomes "Storniert"
  - **Krankheit**: report sickness with no end date → card shows "Seit DD.MM."; report with an end date → shows the range; "Ende aktualisieren" (inline, no modal) updates/clears the end date; "Krankmeldung stornieren" with confirmation; overlap error surfaces clearly
  - **Navigation**: Profil → Abwesenheiten; Übersicht "Krank melden" shortcut; back navigation from both forms
  - **State**: closing/reopening the forms doesn't leak stale input; app restart preserves records (server-backed); pull-to-refresh on the list works

🤖 Generated with [Claude Code](https://claude.com/claude-code)