### PR TITLE
feat(absences): admin workflow — review, sickness visibility, manual entry

### DIFF
--- a/app/admin/absences/create.tsx
+++ b/app/admin/absences/create.tsx
@@ -1,0 +1,7 @@
+import AdminCreateAbsenceScreen from "@/features/absences/admin/AdminCreateAbsenceScreen";
+import { useLocalSearchParams } from "expo-router";
+
+export default function AdminCreateAbsenceRoute() {
+  const { employeeId } = useLocalSearchParams<{ employeeId?: string }>();
+  return <AdminCreateAbsenceScreen preselectedEmployeeId={employeeId} />;
+}

--- a/app/admin/absences/index.tsx
+++ b/app/admin/absences/index.tsx
@@ -1,0 +1,11 @@
+import AdminAbsencesScreen from "@/features/absences/admin/AdminAbsencesScreen";
+import { useLocalSearchParams } from "expo-router";
+
+export default function AdminAbsencesRoute() {
+  const { tab } = useLocalSearchParams<{ tab?: string }>();
+  return (
+    <AdminAbsencesScreen
+      initialSegment={tab === "sickness" ? "sickness" : "vacation"}
+    />
+  );
+}

--- a/app/employees/[id]/absences.tsx
+++ b/app/employees/[id]/absences.tsx
@@ -1,0 +1,7 @@
+import EmployeeAbsenceHistoryScreen from "@/features/absences/admin/EmployeeAbsenceHistoryScreen";
+import { useLocalSearchParams } from "expo-router";
+
+export default function EmployeeAbsenceHistoryRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  return <EmployeeAbsenceHistoryScreen employeeId={id} />;
+}

--- a/features/absences/AbsencesScreen.tsx
+++ b/features/absences/AbsencesScreen.tsx
@@ -9,7 +9,6 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingScreen,
-  ScreenContainer,
   SectionHeader,
 } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
@@ -18,7 +17,16 @@ import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { router } from "expo-router";
 import React, { useCallback, useMemo, useRef } from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  RefreshControl,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { AbsenceCard } from "./components/AbsenceCard";
 import { useAbsences } from "./hooks/useAbsences";
 import { groupAbsences } from "@/utils/absenceGrouping";
@@ -65,14 +73,27 @@ export default function AbsencesScreen() {
   if (loading) return <LoadingScreen />;
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
       <AppHeader title="Abwesenheiten" showBack />
 
-      <ScreenContainer
-        refreshing={refreshing}
-        onRefresh={() => {
-          void refresh();
-        }}
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => {
+              void refresh();
+            }}
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+          />
+        }
       >
         {loadError ? (
           <View style={styles.bannerWrap}>
@@ -154,8 +175,8 @@ export default function AbsencesScreen() {
         )}
 
         <View style={{ height: theme.spacing.xl }} />
-      </ScreenContainer>
-    </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
@@ -205,6 +226,12 @@ function createStyles(theme: AppTheme) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,
+    },
+    scrollContent: {
+      flexGrow: 1,
+      paddingHorizontal: theme.spacing.gutter,
+      paddingTop: theme.spacing.lg,
+      paddingBottom: 32,
     },
     bannerWrap: {
       marginBottom: theme.spacing.md,

--- a/features/absences/admin/AdminAbsencesScreen.tsx
+++ b/features/absences/admin/AdminAbsencesScreen.tsx
@@ -15,13 +15,21 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingScreen,
-  ScreenContainer,
 } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import { router, useFocusEffect } from "expo-router";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  RefreshControl,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { AdminAbsenceRow } from "./components/AdminAbsenceRow";
 import { useAdminAbsences } from "./hooks/useAdminAbsences";
 
@@ -70,14 +78,27 @@ export default function AdminAbsencesScreen({
   const list = segment === "vacation" ? pendingVacations : sicknessReports;
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
       <AppHeader title="Abwesenheiten verwalten" showBack />
 
-      <ScreenContainer
-        refreshing={refreshing}
-        onRefresh={() => {
-          void refresh();
-        }}
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => {
+              void refresh();
+            }}
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+          />
+        }
       >
         {loadError ? (
           <View style={styles.bannerWrap}>
@@ -155,8 +176,8 @@ export default function AdminAbsencesScreen({
         )}
 
         <View style={{ height: theme.spacing.xl }} />
-      </ScreenContainer>
-    </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
@@ -165,6 +186,12 @@ function createStyles(theme: AppTheme) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,
+    },
+    scrollContent: {
+      flexGrow: 1,
+      paddingHorizontal: theme.spacing.gutter,
+      paddingTop: theme.spacing.lg,
+      paddingBottom: 32,
     },
     bannerWrap: {
       marginBottom: theme.spacing.md,

--- a/features/absences/admin/AdminAbsencesScreen.tsx
+++ b/features/absences/admin/AdminAbsencesScreen.tsx
@@ -1,0 +1,222 @@
+// features/absences/admin/AdminAbsencesScreen.tsx
+// "Abwesenheiten verwalten" — die eine Admin-Workflow-Fläche für Phase C:
+// zwei Reiter, Urlaubsanträge (Genehmigen/Ablehnen) und Krankmeldungen
+// (read-only, siehe Architektur-Audit Phase C Abschnitt 9 — Krankheit ist ein
+// Report, kein Genehmigungs-Workflow). Erreichbar über Dashboard-Chip,
+// Profil → Administration, und den "Alle anzeigen"-Link in EmployeeDetail.
+//
+// Kein neuer Realtime-Kanal — useFocusEffect lädt bei jedem Refokussieren
+// still neu (gleiches Muster wie AbsencesScreen), Aktionen aktualisieren die
+// Liste optimistisch (siehe useAdminAbsences).
+
+import {
+  AppHeader,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  LoadingScreen,
+  ScreenContainer,
+} from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import { router, useFocusEffect } from "expo-router";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { AdminAbsenceRow } from "./components/AdminAbsenceRow";
+import { useAdminAbsences } from "./hooks/useAdminAbsences";
+
+type Segment = "vacation" | "sickness";
+
+const SEGMENTS: { key: Segment; label: string }[] = [
+  { key: "vacation", label: "Urlaubsanträge" },
+  { key: "sickness", label: "Krankmeldungen" },
+];
+
+export default function AdminAbsencesScreen({
+  initialSegment = "vacation",
+}: {
+  initialSegment?: Segment;
+}) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [segment, setSegment] = useState<Segment>(initialSegment);
+
+  const {
+    pendingVacations,
+    sicknessReports,
+    loading,
+    loadError,
+    load,
+    refreshing,
+    refresh,
+    busyId,
+    error: actionError,
+    clearError,
+    approve,
+    reject,
+  } = useAdminAbsences();
+
+  const hasLoadedOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      load({ silent: hasLoadedOnceRef.current });
+      hasLoadedOnceRef.current = true;
+    }, [load]),
+  );
+
+  if (loading) return <LoadingScreen />;
+
+  const list = segment === "vacation" ? pendingVacations : sicknessReports;
+
+  return (
+    <View style={styles.container}>
+      <AppHeader title="Abwesenheiten verwalten" showBack />
+
+      <ScreenContainer
+        refreshing={refreshing}
+        onRefresh={() => {
+          void refresh();
+        }}
+      >
+        {loadError ? (
+          <View style={styles.bannerWrap}>
+            <ErrorBanner
+              message={loadError}
+              actionLabel="Erneut versuchen"
+              onAction={() => {
+                void refresh();
+              }}
+            />
+          </View>
+        ) : null}
+
+        {actionError ? (
+          <View style={styles.bannerWrap}>
+            <ErrorBanner message={actionError} onDismiss={clearError} />
+          </View>
+        ) : null}
+
+        {/* ── Segmented Control (gleiche Bauform wie JobFormFields' Auftragstyp) ── */}
+        <View style={styles.segment}>
+          {SEGMENTS.map((opt) => {
+            const active = segment === opt.key;
+            const count = opt.key === "vacation" ? pendingVacations.length : null;
+            return (
+              <TouchableOpacity
+                key={opt.key}
+                style={[styles.segmentItem, active && styles.segmentItemActive]}
+                onPress={() => setSegment(opt.key)}
+                activeOpacity={0.8}
+              >
+                <Text
+                  style={[styles.segmentText, active && styles.segmentTextActive]}
+                  numberOfLines={1}
+                >
+                  {opt.label}
+                  {count ? ` (${count})` : ""}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <TouchableOpacity
+          style={styles.createBtn}
+          activeOpacity={0.85}
+          onPress={() => router.push("/admin/absences/create")}
+        >
+          <Text style={styles.createBtnText}>Abwesenheit erfassen</Text>
+        </TouchableOpacity>
+
+        {list.length === 0 ? (
+          <Card>
+            <EmptyState
+              title={
+                segment === "vacation"
+                  ? "Keine offenen Urlaubsanträge."
+                  : "Keine Krankmeldungen."
+              }
+              icon={segment === "vacation" ? "sunny-outline" : "medkit-outline"}
+            />
+          </Card>
+        ) : (
+          <View style={styles.cardList}>
+            {list.map((absence) => (
+              <AdminAbsenceRow
+                key={absence.id}
+                absence={absence}
+                busy={busyId === absence.id}
+                onApprove={approve}
+                onReject={reject}
+              />
+            ))}
+          </View>
+        )}
+
+        <View style={{ height: theme.spacing.xl }} />
+      </ScreenContainer>
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    bannerWrap: {
+      marginBottom: theme.spacing.md,
+    },
+    segment: {
+      flexDirection: "row",
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: 3,
+      gap: 3,
+      marginBottom: theme.spacing.md,
+    },
+    segmentItem: {
+      flex: 1,
+      paddingVertical: 9,
+      borderRadius: theme.radius.sm,
+      alignItems: "center",
+    },
+    segmentItemActive: {
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    segmentText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+    segmentTextActive: {
+      color: theme.colors.onPrimaryContainer,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+    },
+    createBtn: {
+      alignSelf: "flex-start",
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 9,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+      marginBottom: theme.spacing.lg,
+    },
+    createBtnText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.primary,
+    },
+    cardList: {
+      gap: theme.spacing.sm,
+    },
+  });
+}

--- a/features/absences/admin/AdminCreateAbsenceScreen.tsx
+++ b/features/absences/admin/AdminCreateAbsenceScreen.tsx
@@ -1,0 +1,269 @@
+// features/absences/admin/AdminCreateAbsenceScreen.tsx
+// "Abwesenheit erfassen" — manuelle Admin-Erfassung über admin_create_absence.
+// Urlaub landet serverseitig direkt bei status=approved, Krankheit bei
+// status=reported (siehe Migration) — kein clientseitig erfundener Status.
+//
+// Gleiche Struktur wie features/absences/RequestVacationScreen.tsx /
+// ReportSicknessScreen.tsx (Employee-Selbstbedienung), erweitert um die
+// Mitarbeiter-Auswahl und den Urlaub/Krankheit-Umschalter.
+
+import { AppHeader, ErrorBanner, Input } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import { useJobs } from "@/context/JobContext";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { adminCreateAbsence } from "@/services/absences/adminAbsences.service";
+import type { AppTheme } from "@/constants/theme";
+import type { AbsenceType } from "@/types/absence";
+import { formatDateISO } from "@/utils/date";
+import { alertDialog } from "@/utils/dialogs";
+import { router } from "expo-router";
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { EmployeePickerField } from "./components/EmployeePickerField";
+
+const TYPE_OPTIONS: { key: AbsenceType; label: string }[] = [
+  { key: "vacation", label: "Urlaub" },
+  { key: "sickness", label: "Krankheit" },
+];
+
+export default function AdminCreateAbsenceScreen({
+  preselectedEmployeeId,
+}: {
+  preselectedEmployeeId?: string;
+}) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { employees } = useJobs();
+
+  const [employeeId, setEmployeeId] = useState<string | null>(
+    preselectedEmployeeId ?? null,
+  );
+  const [type, setType] = useState<AbsenceType>("vacation");
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [note, setNote] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const validate = (): string | null => {
+    if (!employeeId) return "Bitte einen Mitarbeiter auswählen.";
+    if (!startDate) return "Bitte ein Startdatum angeben.";
+    if (type === "vacation" && !endDate) {
+      return "Bitte ein Enddatum für den Urlaub angeben.";
+    }
+    if (endDate && formatDateISO(endDate)! < formatDateISO(startDate)!) {
+      return "Das Enddatum darf nicht vor dem Startdatum liegen.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError("");
+    setSubmitting(true);
+    try {
+      await adminCreateAbsence({
+        employeeId: employeeId!,
+        type,
+        startDate: formatDateISO(startDate!)!,
+        endDate: endDate ? formatDateISO(endDate) : null,
+        note: note.trim() || undefined,
+      });
+
+      await alertDialog(
+        "Abwesenheit erfasst",
+        type === "vacation"
+          ? "Der Urlaub wurde als genehmigt erfasst."
+          : "Die Krankmeldung wurde erfasst.",
+      );
+      router.back();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Die Abwesenheit konnte nicht erfasst werden.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <AppHeader title="Abwesenheit erfassen" showBack />
+
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {error ? (
+            <ErrorBanner message={error} onDismiss={() => setError("")} />
+          ) : null}
+
+          <View style={styles.form}>
+            <EmployeePickerField
+              employees={employees}
+              value={employeeId}
+              onChange={setEmployeeId}
+            />
+
+            <View>
+              <Text style={styles.sectionLabel}>Art *</Text>
+              <View style={styles.segment}>
+                {TYPE_OPTIONS.map((opt) => {
+                  const active = type === opt.key;
+                  return (
+                    <TouchableOpacity
+                      key={opt.key}
+                      style={[styles.segmentItem, active && styles.segmentItemActive]}
+                      onPress={() => setType(opt.key)}
+                      activeOpacity={0.8}
+                    >
+                      <Text
+                        style={[
+                          styles.segmentText,
+                          active && styles.segmentTextActive,
+                        ]}
+                      >
+                        {opt.label}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+
+            <DateTimeField
+              label="Von *"
+              mode="date"
+              value={startDate}
+              onChange={setStartDate}
+            />
+            <DateTimeField
+              label={type === "vacation" ? "Bis *" : "Bis (optional)"}
+              mode="date"
+              value={endDate}
+              onChange={setEndDate}
+              placeholder={
+                type === "sickness" ? "Kein Enddatum bekannt" : undefined
+              }
+            />
+
+            <Input
+              label="Notiz (optional)"
+              placeholder="z. B. telefonisch gemeldet"
+              value={note}
+              onChangeText={setNote}
+              multiline
+              editable={!submitting}
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+            activeOpacity={0.8}
+            onPress={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={theme.colors.onPrimary} />
+            ) : (
+              <Text style={styles.submitButtonText}>Abwesenheit erfassen</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    flex: { flex: 1 },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      padding: theme.spacing.lg,
+      gap: theme.spacing.lg,
+    },
+    form: {
+      gap: theme.spacing.md,
+    },
+    sectionLabel: {
+      fontSize: theme.typography.size.xs,
+      fontWeight: theme.typography.weight.semibold,
+      fontFamily: theme.typography.family.semibold,
+      color: theme.colors.onSurfaceVariant,
+      letterSpacing: theme.typography.letterSpacing.wide,
+      marginBottom: 6,
+    },
+    segment: {
+      flexDirection: "row",
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: 3,
+      gap: 3,
+    },
+    segmentItem: {
+      flex: 1,
+      paddingVertical: 9,
+      borderRadius: theme.radius.sm,
+      alignItems: "center",
+    },
+    segmentItemActive: {
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    segmentText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+    segmentTextActive: {
+      color: theme.colors.onPrimaryContainer,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+    },
+    submitButton: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: theme.spacing.tapTarget,
+    },
+    submitButtonDisabled: {
+      opacity: 0.6,
+    },
+    submitButtonText: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimary,
+    },
+  });
+}

--- a/features/absences/admin/EmployeeAbsenceHistoryScreen.tsx
+++ b/features/absences/admin/EmployeeAbsenceHistoryScreen.tsx
@@ -12,7 +12,6 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingScreen,
-  ScreenContainer,
   SectionHeader,
 } from "@/components/ui";
 import { useJobs } from "@/context/JobContext";
@@ -20,7 +19,8 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import { groupAbsences } from "@/utils/absenceGrouping";
 import { useFocusEffect } from "@react-navigation/native";
 import React, { useCallback, useMemo, useRef } from "react";
-import { View } from "react-native";
+import { RefreshControl, ScrollView, StatusBar, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { AdminAbsenceRow } from "./components/AdminAbsenceRow";
 import { useEmployeeAbsences } from "./hooks/useEmployeeAbsences";
 
@@ -65,17 +65,38 @@ export default function EmployeeAbsenceHistoryScreen({
   if (loading) return <LoadingScreen />;
 
   return (
-    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      edges={["top"]}
+    >
+      <StatusBar
+        barStyle={theme.isDark ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
       <AppHeader
         title={employee ? `Abwesenheiten — ${employee.fullName}` : "Abwesenheiten"}
         showBack
       />
 
-      <ScreenContainer
-        refreshing={refreshing}
-        onRefresh={() => {
-          void refresh();
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: theme.spacing.gutter,
+          paddingTop: theme.spacing.lg,
+          paddingBottom: 32,
         }}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => {
+              void refresh();
+            }}
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+          />
+        }
       >
         {loadError ? (
           <View style={{ marginBottom: theme.spacing.md }}>
@@ -129,8 +150,8 @@ export default function EmployeeAbsenceHistoryScreen({
         )}
 
         <View style={{ height: theme.spacing.xl }} />
-      </ScreenContainer>
-    </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/features/absences/admin/EmployeeAbsenceHistoryScreen.tsx
+++ b/features/absences/admin/EmployeeAbsenceHistoryScreen.tsx
@@ -1,0 +1,170 @@
+// features/absences/admin/EmployeeAbsenceHistoryScreen.tsx
+// "Alle anzeigen" aus dem Abwesenheiten-Abschnitt in EmployeeDetailScreen —
+// volle Abwesenheitshistorie eines Mitarbeiters, gruppiert wie
+// features/absences/AbsencesScreen.tsx (Aktuell/Bevorstehend/Vergangen, via
+// utils/absenceGrouping.ts — keine zweite Gruppierungslogik). Pending
+// Urlaubsanträge bleiben genehmig-/ablehnbar, egal in welcher Gruppe sie
+// landen (AdminAbsenceRow zeigt Aktionen nur bei status=requested Urlaub).
+
+import {
+  AppHeader,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  LoadingScreen,
+  ScreenContainer,
+  SectionHeader,
+} from "@/components/ui";
+import { useJobs } from "@/context/JobContext";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { groupAbsences } from "@/utils/absenceGrouping";
+import { useFocusEffect } from "@react-navigation/native";
+import React, { useCallback, useMemo, useRef } from "react";
+import { View } from "react-native";
+import { AdminAbsenceRow } from "./components/AdminAbsenceRow";
+import { useEmployeeAbsences } from "./hooks/useEmployeeAbsences";
+
+const HISTORY_LIMIT = 100;
+
+export default function EmployeeAbsenceHistoryScreen({
+  employeeId,
+}: {
+  employeeId: string;
+}) {
+  const theme = useAppTheme();
+  const { employees } = useJobs();
+  const employee = employees.find((e) => e.id === employeeId);
+
+  const {
+    absences,
+    loading,
+    loadError,
+    load,
+    refreshing,
+    refresh,
+    busyId,
+    error: actionError,
+    clearError,
+    approve,
+    reject,
+  } = useEmployeeAbsences(employeeId, HISTORY_LIMIT);
+
+  const hasLoadedOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      load({ silent: hasLoadedOnceRef.current });
+      hasLoadedOnceRef.current = true;
+    }, [load]),
+  );
+
+  const { current, upcoming, past } = useMemo(
+    () => groupAbsences(absences),
+    [absences],
+  );
+
+  if (loading) return <LoadingScreen />;
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      <AppHeader
+        title={employee ? `Abwesenheiten — ${employee.fullName}` : "Abwesenheiten"}
+        showBack
+      />
+
+      <ScreenContainer
+        refreshing={refreshing}
+        onRefresh={() => {
+          void refresh();
+        }}
+      >
+        {loadError ? (
+          <View style={{ marginBottom: theme.spacing.md }}>
+            <ErrorBanner
+              message={loadError}
+              actionLabel="Erneut versuchen"
+              onAction={() => {
+                void refresh();
+              }}
+            />
+          </View>
+        ) : null}
+
+        {actionError ? (
+          <View style={{ marginBottom: theme.spacing.md }}>
+            <ErrorBanner message={actionError} onDismiss={clearError} />
+          </View>
+        ) : null}
+
+        {absences.length === 0 ? (
+          <Card>
+            <EmptyState
+              title="Keine Abwesenheiten erfasst."
+              icon="calendar-outline"
+            />
+          </Card>
+        ) : (
+          <>
+            <HistoryGroup
+              title="Aktuell"
+              absences={current}
+              busyId={busyId}
+              onApprove={approve}
+              onReject={reject}
+            />
+            <HistoryGroup
+              title="Bevorstehend"
+              absences={upcoming}
+              busyId={busyId}
+              onApprove={approve}
+              onReject={reject}
+            />
+            <HistoryGroup
+              title="Vergangen"
+              absences={past}
+              busyId={busyId}
+              onApprove={approve}
+              onReject={reject}
+            />
+          </>
+        )}
+
+        <View style={{ height: theme.spacing.xl }} />
+      </ScreenContainer>
+    </View>
+  );
+}
+
+function HistoryGroup({
+  title,
+  absences,
+  busyId,
+  onApprove,
+  onReject,
+}: {
+  title: string;
+  absences: ReturnType<typeof groupAbsences>["current"];
+  busyId: string | null;
+  onApprove: (id: string) => void;
+  onReject: (id: string, note: string) => void;
+}) {
+  const theme = useAppTheme();
+  if (absences.length === 0) return null;
+
+  return (
+    <View style={{ marginBottom: theme.spacing.xl, gap: theme.spacing.sm }}>
+      <SectionHeader title={title} />
+      <View style={{ gap: theme.spacing.sm }}>
+        {absences.map((absence) => (
+          <AdminAbsenceRow
+            key={absence.id}
+            absence={absence}
+            busy={busyId === absence.id}
+            showEmployeeName={false}
+            onApprove={onApprove}
+            onReject={onReject}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/features/absences/admin/components/AdminAbsenceRow.tsx
+++ b/features/absences/admin/components/AdminAbsenceRow.tsx
@@ -1,0 +1,259 @@
+// features/absences/admin/components/AdminAbsenceRow.tsx
+// Eine Abwesenheits-Zeile in der Admin-Ansicht: Typ, Zeitraum, Status,
+// Mitarbeitername (optional, z. B. in EmployeeDetail ausgeblendet), Notizen,
+// und — nur bei status="requested" Urlaub — Genehmigen/Ablehnen.
+//
+// Geteilt zwischen AdminAbsencesScreen (Urlaubsanträge-Reiter, Krankmeldungen-
+// Reiter) und EmployeeDetailScreen (pending Anträge dieses Mitarbeiters) —
+// eine Komponente, ein Aktions-Vertrag, statt zwei Kopien mit demselben
+// Genehmigen/Ablehnen-Verhalten.
+
+import { Card } from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import type { Absence } from "@/types/absence";
+import { formatAbsenceDateRange } from "@/utils/absenceFormat";
+import { confirmDialog } from "@/utils/dialogs";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { AbsenceStatusBadge } from "../../components/AbsenceStatusBadge";
+import { RejectVacationSheet } from "./RejectVacationSheet";
+
+type Props = {
+  absence: Absence;
+  busy: boolean;
+  /** Standard true — EmployeeDetail blendet den Namen aus (steht bereits im Screen-Kontext). */
+  showEmployeeName?: boolean;
+  onApprove: (absenceId: string) => void;
+  onReject: (absenceId: string, adminNote: string) => void;
+};
+
+export function AdminAbsenceRow({
+  absence,
+  busy,
+  showEmployeeName = true,
+  onApprove,
+  onReject,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [rejectSheetOpen, setRejectSheetOpen] = useState(false);
+
+  const isVacation = absence.type === "vacation";
+  const isPendingVacation = isVacation && absence.status === "requested";
+  const reviewerNote =
+    absence.status === "rejected" || absence.status === "approved"
+      ? absence.adminNote
+      : null;
+
+  const handleApprove = async () => {
+    const confirmed = await confirmDialog({
+      title: "Urlaub genehmigen",
+      message: `Urlaubsantrag von ${absence.employeeName} (${formatAbsenceDateRange(absence)}) genehmigen?`,
+      confirmLabel: "Genehmigen",
+    });
+    if (confirmed) onApprove(absence.id);
+  };
+
+  const handleConfirmReject = (note: string) => {
+    onReject(absence.id, note);
+  };
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.headerRow}>
+        <View style={styles.typeRow}>
+          <View
+            style={[
+              styles.typeIcon,
+              isVacation ? styles.typeIconVacation : styles.typeIconSickness,
+            ]}
+          >
+            <Ionicons
+              name={isVacation ? "sunny-outline" : "medkit-outline"}
+              size={16}
+              color={isVacation ? theme.colors.primary : theme.colors.statusOpen}
+            />
+          </View>
+          <View style={styles.typeTextWrap}>
+            {showEmployeeName ? (
+              <Text style={styles.employeeName} numberOfLines={1}>
+                {absence.employeeName}
+              </Text>
+            ) : (
+              <Text style={styles.typeLabel}>
+                {isVacation ? "Urlaub" : "Krankheit"}
+              </Text>
+            )}
+            <Text style={styles.dateRange}>{formatAbsenceDateRange(absence)}</Text>
+          </View>
+        </View>
+        <AbsenceStatusBadge status={absence.status} />
+      </View>
+
+      {absence.employeeNote ? (
+        <Text style={styles.note} numberOfLines={4}>
+          {absence.employeeNote}
+        </Text>
+      ) : null}
+
+      {reviewerNote ? (
+        <View style={styles.adminNoteWrap}>
+          <Text style={styles.adminNoteLabel}>Deine Notiz</Text>
+          <Text style={styles.note} numberOfLines={4}>
+            {reviewerNote}
+          </Text>
+        </View>
+      ) : null}
+
+      {isPendingVacation ? (
+        <View style={styles.actionsRow}>
+          <TouchableOpacity
+            style={[styles.actionBtn, styles.approveBtn, busy && styles.actionBtnDisabled]}
+            disabled={busy}
+            activeOpacity={0.8}
+            onPress={handleApprove}
+          >
+            <Ionicons name="checkmark" size={16} color={theme.colors.statusCompleted} />
+            <Text style={styles.approveBtnText}>Genehmigen</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.actionBtn, styles.rejectBtn, busy && styles.actionBtnDisabled]}
+            disabled={busy}
+            activeOpacity={0.8}
+            onPress={() => setRejectSheetOpen(true)}
+          >
+            <Ionicons name="close" size={16} color={theme.colors.error} />
+            <Text style={styles.rejectBtnText}>Ablehnen</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      <RejectVacationSheet
+        visible={rejectSheetOpen}
+        employeeName={absence.employeeName}
+        busy={busy}
+        onCancel={() => setRejectSheetOpen(false)}
+        onConfirm={(note) => {
+          setRejectSheetOpen(false);
+          handleConfirmReject(note);
+        }}
+      />
+    </Card>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.spacing.sm,
+    },
+    headerRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    typeRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      flexShrink: 1,
+    },
+    typeIcon: {
+      width: 32,
+      height: 32,
+      borderRadius: theme.radius.md,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    typeIconVacation: {
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    typeIconSickness: {
+      backgroundColor: theme.colors.statusOpenBg,
+    },
+    typeTextWrap: {
+      flexShrink: 1,
+    },
+    employeeName: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    typeLabel: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    dateRange: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      marginTop: 1,
+    },
+    note: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.sm,
+    },
+    adminNoteWrap: {
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.sm,
+      gap: 2,
+    },
+    adminNoteLabel: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurfaceVariant,
+      textTransform: "uppercase",
+      letterSpacing: theme.typography.letterSpacing.wide,
+    },
+    actionsRow: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+      marginTop: 2,
+    },
+    actionBtn: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 6,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 10,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+    },
+    actionBtnDisabled: {
+      opacity: 0.5,
+    },
+    approveBtn: {
+      backgroundColor: theme.colors.statusCompletedBg,
+      borderColor: theme.colors.statusCompletedBorder,
+    },
+    approveBtnText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.statusCompleted,
+    },
+    rejectBtn: {
+      backgroundColor: theme.colors.errorContainer,
+      borderColor: theme.colors.error,
+    },
+    rejectBtnText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.error,
+    },
+  });
+}

--- a/features/absences/admin/components/EmployeePickerField.tsx
+++ b/features/absences/admin/components/EmployeePickerField.tsx
@@ -1,0 +1,315 @@
+// features/absences/admin/components/EmployeePickerField.tsx
+// Mitarbeiter-Einzelauswahl für "Abwesenheit erfassen". Gleiches Sheet-Muster
+// wie features/jobs/components/EmployeeFilterControl.tsx, aber als
+// Formularfeld (Label + Wert statt Icon-Button) und OHNE "Alle"/"Nicht
+// zugewiesen" — hier wird immer genau ein Mitarbeiter gebraucht.
+//
+// Inaktive Mitarbeiter werden NICHT ausgeblendet (admin_create_absence
+// erlaubt sie explizit für historische Nacherfassung, siehe Migrations-
+// Kommentar), aber mit einem "Inaktiv"-Tag markiert.
+
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import type { EmployeeOption } from "@/types/job";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo, useState } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+const SEARCH_THRESHOLD = 8;
+
+type Props = {
+  label?: string;
+  employees: EmployeeOption[];
+  value: string | null;
+  onChange: (employeeId: string) => void;
+  error?: string;
+};
+
+export function EmployeePickerField({
+  label = "Mitarbeiter *",
+  employees,
+  value,
+  onChange,
+  error,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const selected = employees.find((e) => e.id === value) ?? null;
+  const showSearch = employees.length >= SEARCH_THRESHOLD;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return employees;
+    return employees.filter((e) => e.fullName.toLowerCase().includes(q));
+  }, [employees, query]);
+
+  const select = (id: string) => {
+    onChange(id);
+    setOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+
+      <TouchableOpacity
+        style={[styles.field, error && styles.fieldError]}
+        onPress={() => setOpen(true)}
+        activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Mitarbeiter auswählen"
+      >
+        <Text
+          style={[styles.fieldText, !selected && styles.fieldPlaceholder]}
+          numberOfLines={1}
+        >
+          {selected ? selected.fullName : "Mitarbeiter auswählen…"}
+        </Text>
+        {selected?.isActive === false ? (
+          <View style={styles.inactiveTag}>
+            <Text style={styles.inactiveTagText}>Inaktiv</Text>
+          </View>
+        ) : null}
+        <Ionicons
+          name="chevron-down"
+          size={16}
+          color={theme.colors.onSurfaceVariant}
+        />
+      </TouchableOpacity>
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable style={styles.backdrop} onPress={() => setOpen(false)}>
+          <Pressable style={styles.sheet} onPress={() => {}}>
+            <View style={styles.grabber} />
+            <Text style={styles.sheetTitle}>Mitarbeiter</Text>
+
+            {showSearch ? (
+              <View style={styles.sheetSearch}>
+                <Ionicons
+                  name="search"
+                  size={16}
+                  color={theme.colors.onSurfaceVariant}
+                />
+                <TextInput
+                  value={query}
+                  onChangeText={setQuery}
+                  placeholder="Mitarbeiter suchen …"
+                  placeholderTextColor={theme.colors.outline}
+                  style={styles.sheetSearchInput}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+            ) : null}
+
+            <ScrollView
+              style={styles.optionScroll}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              {filtered.map((emp) => {
+                const isSelected = value === emp.id;
+                return (
+                  <TouchableOpacity
+                    key={emp.id}
+                    style={[styles.option, isSelected && styles.optionSelected]}
+                    onPress={() => select(emp.id)}
+                    activeOpacity={0.75}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: isSelected }}
+                  >
+                    <Text
+                      style={[
+                        styles.optionLabel,
+                        isSelected && styles.optionLabelSelected,
+                      ]}
+                      numberOfLines={1}
+                    >
+                      {emp.fullName}
+                    </Text>
+                    {emp.isActive === false ? (
+                      <View style={styles.inactiveTag}>
+                        <Text style={styles.inactiveTagText}>Inaktiv</Text>
+                      </View>
+                    ) : null}
+                    {isSelected ? (
+                      <Ionicons
+                        name="checkmark"
+                        size={18}
+                        color={theme.colors.onPrimaryContainer}
+                      />
+                    ) : null}
+                  </TouchableOpacity>
+                );
+              })}
+
+              {filtered.length === 0 ? (
+                <Text style={styles.noMatch}>Keine Treffer.</Text>
+              ) : null}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    wrapper: {
+      gap: 6,
+    },
+    label: {
+      fontSize: theme.typography.size.xs,
+      fontWeight: theme.typography.weight.semibold,
+      fontFamily: theme.typography.family.semibold,
+      color: theme.colors.onSurfaceVariant,
+      letterSpacing: theme.typography.letterSpacing.wide,
+    },
+    field: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.background,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 13,
+      borderRadius: theme.radius.md,
+      borderWidth: 1.5,
+      borderColor: theme.colors.outlineVariant,
+      minHeight: theme.spacing.tapTarget,
+    },
+    fieldError: {
+      borderColor: theme.colors.error,
+    },
+    fieldText: {
+      flex: 1,
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+    fieldPlaceholder: {
+      color: theme.colors.outline,
+    },
+    errorText: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.error,
+      fontFamily: theme.typography.family.regular,
+      marginTop: 2,
+    },
+    inactiveTag: {
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+    },
+    inactiveTagText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+
+    backdrop: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.4)",
+      justifyContent: "flex-end",
+    },
+    sheet: {
+      backgroundColor: theme.colors.surface,
+      borderTopLeftRadius: theme.radius.lg,
+      borderTopRightRadius: theme.radius.lg,
+      paddingHorizontal: theme.spacing.lg,
+      paddingTop: theme.spacing.sm,
+      paddingBottom: theme.spacing.xl,
+      maxHeight: "70%",
+    },
+    grabber: {
+      alignSelf: "center",
+      width: 36,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: theme.colors.outlineVariant,
+      marginBottom: theme.spacing.sm,
+    },
+    sheetTitle: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+      marginBottom: theme.spacing.sm,
+    },
+    sheetSearch: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      marginBottom: theme.spacing.sm,
+      minHeight: 40,
+    },
+    sheetSearchInput: {
+      flex: 1,
+      paddingVertical: 8,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+    optionScroll: {
+      flexGrow: 0,
+    },
+    option: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 12,
+      borderRadius: theme.radius.md,
+      minHeight: theme.spacing.tapTarget,
+    },
+    optionSelected: {
+      backgroundColor: theme.colors.primaryContainer,
+    },
+    optionLabel: {
+      flex: 1,
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    optionLabelSelected: {
+      color: theme.colors.onPrimaryContainer,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+    },
+    noMatch: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.md,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/absences/admin/components/RejectVacationSheet.tsx
+++ b/features/absences/admin/components/RejectVacationSheet.tsx
@@ -1,0 +1,152 @@
+// features/absences/admin/components/RejectVacationSheet.tsx
+// Kleines Bottom-Sheet für "Ablehnen": optionale Notiz + Bestätigen/Abbrechen.
+// admin_note_input ist auf der RPC optional (default null) — für die Beta
+// bewusst kein Pflichtfeld, siehe Architektur-Audit Phase C Abschnitt 4.
+// Eigenes Sheet statt Alert.alert, weil Alert keinen Freitext-Input kennt und
+// auf Web ohnehin eine leere Attrappe ist (siehe utils/dialogs.ts).
+
+import { Button } from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import React, { useMemo, useState } from "react";
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+type Props = {
+  visible: boolean;
+  employeeName: string;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (note: string) => void;
+};
+
+export function RejectVacationSheet({
+  visible,
+  employeeName,
+  busy,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [note, setNote] = useState("");
+
+  const handleClose = () => {
+    if (busy) return;
+    setNote("");
+    onCancel();
+  };
+
+  const handleConfirm = () => {
+    onConfirm(note.trim());
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <Pressable style={styles.backdrop} onPress={handleClose}>
+        <Pressable style={styles.sheet} onPress={() => {}}>
+          <View style={styles.grabber} />
+          <Text style={styles.title}>Urlaub ablehnen</Text>
+          <Text style={styles.subtitle}>
+            Antrag von {employeeName} ablehnen. Eine Notiz ist optional.
+          </Text>
+
+          <TextInput
+            style={styles.input}
+            value={note}
+            onChangeText={setNote}
+            placeholder="Notiz für den Mitarbeiter (optional)"
+            placeholderTextColor={theme.colors.outline}
+            multiline
+            editable={!busy}
+          />
+
+          <View style={styles.actions}>
+            <Button
+              label="Abbrechen"
+              variant="secondary"
+              onPress={handleClose}
+              disabled={busy}
+              style={styles.actionBtn}
+            />
+            <Button
+              label="Ablehnen"
+              variant="danger"
+              onPress={handleConfirm}
+              loading={busy}
+              style={styles.actionBtn}
+            />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.4)",
+      justifyContent: "flex-end",
+    },
+    sheet: {
+      backgroundColor: theme.colors.surface,
+      borderTopLeftRadius: theme.radius.lg,
+      borderTopRightRadius: theme.radius.lg,
+      paddingHorizontal: theme.spacing.lg,
+      paddingTop: theme.spacing.sm,
+      paddingBottom: theme.spacing.xl,
+      gap: theme.spacing.md,
+    },
+    grabber: {
+      alignSelf: "center",
+      width: 36,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: theme.colors.outlineVariant,
+    },
+    title: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.bold,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+    },
+    subtitle: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+    input: {
+      backgroundColor: theme.colors.background,
+      color: theme.colors.onSurface,
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.regular,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 12,
+      borderRadius: theme.radius.md,
+      borderWidth: 1.5,
+      borderColor: theme.colors.outlineVariant,
+      minHeight: 88,
+      textAlignVertical: "top",
+    },
+    actions: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+    },
+    actionBtn: {
+      flex: 1,
+    },
+  });
+}

--- a/features/absences/admin/components/RejectVacationSheet.tsx
+++ b/features/absences/admin/components/RejectVacationSheet.tsx
@@ -4,14 +4,25 @@
 // bewusst kein Pflichtfeld, siehe Architektur-Audit Phase C Abschnitt 4.
 // Eigenes Sheet statt Alert.alert, weil Alert keinen Freitext-Input kennt und
 // auf Web ohnehin eine leere Attrappe ist (siehe utils/dialogs.ts).
-
+//
+// Tastatur-Handling: gleiche Bauform wie
+// features/timesheets/components/TimeCorrectionSheet.tsx (das einzige andere
+// Modal-Sheet mit Texteingabe in der App) — Modal > Overlay-View
+// (justifyContent: flex-end) > KeyboardAvoidingView (behavior "padding" nur
+// auf iOS) > Sheet-View. Ohne KeyboardAvoidingView schiebt sich das am
+// unteren Rand angepinnte Sheet auf iOS NICHT über die Tastatur, die dann das
+// Notizfeld verdeckt — Modals hängen an einem eigenen nativen Fenster und
+// erben keinen KeyboardAvoidingView/SafeAreaView vom umgebenden Screen.
 import { Button } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import React, { useMemo, useState } from "react";
 import {
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -55,40 +66,51 @@ export function RejectVacationSheet({
       onRequestClose={handleClose}
     >
       <Pressable style={styles.backdrop} onPress={handleClose}>
-        <Pressable style={styles.sheet} onPress={() => {}}>
-          <View style={styles.grabber} />
-          <Text style={styles.title}>Urlaub ablehnen</Text>
-          <Text style={styles.subtitle}>
-            Antrag von {employeeName} ablehnen. Eine Notiz ist optional.
-          </Text>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.kav}
+        >
+          <Pressable style={styles.sheet} onPress={() => {}}>
+            <ScrollView
+              contentContainerStyle={styles.scroll}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.grabber} />
+              <Text style={styles.title}>Urlaub ablehnen</Text>
+              <Text style={styles.subtitle}>
+                Antrag von {employeeName} ablehnen. Eine Notiz ist optional.
+              </Text>
 
-          <TextInput
-            style={styles.input}
-            value={note}
-            onChangeText={setNote}
-            placeholder="Notiz für den Mitarbeiter (optional)"
-            placeholderTextColor={theme.colors.outline}
-            multiline
-            editable={!busy}
-          />
+              <TextInput
+                style={styles.input}
+                value={note}
+                onChangeText={setNote}
+                placeholder="Notiz für den Mitarbeiter (optional)"
+                placeholderTextColor={theme.colors.outline}
+                multiline
+                editable={!busy}
+              />
 
-          <View style={styles.actions}>
-            <Button
-              label="Abbrechen"
-              variant="secondary"
-              onPress={handleClose}
-              disabled={busy}
-              style={styles.actionBtn}
-            />
-            <Button
-              label="Ablehnen"
-              variant="danger"
-              onPress={handleConfirm}
-              loading={busy}
-              style={styles.actionBtn}
-            />
-          </View>
-        </Pressable>
+              <View style={styles.actions}>
+                <Button
+                  label="Abbrechen"
+                  variant="secondary"
+                  onPress={handleClose}
+                  disabled={busy}
+                  style={styles.actionBtn}
+                />
+                <Button
+                  label="Ablehnen"
+                  variant="danger"
+                  onPress={handleConfirm}
+                  loading={busy}
+                  style={styles.actionBtn}
+                />
+              </View>
+            </ScrollView>
+          </Pressable>
+        </KeyboardAvoidingView>
       </Pressable>
     </Modal>
   );
@@ -101,10 +123,16 @@ function createStyles(theme: AppTheme) {
       backgroundColor: "rgba(0,0,0,0.4)",
       justifyContent: "flex-end",
     },
+    kav: {
+      width: "100%",
+    },
     sheet: {
       backgroundColor: theme.colors.surface,
       borderTopLeftRadius: theme.radius.lg,
       borderTopRightRadius: theme.radius.lg,
+      maxHeight: "92%",
+    },
+    scroll: {
       paddingHorizontal: theme.spacing.lg,
       paddingTop: theme.spacing.sm,
       paddingBottom: theme.spacing.xl,

--- a/features/absences/admin/hooks/useAdminAbsences.ts
+++ b/features/absences/admin/hooks/useAdminAbsences.ts
@@ -1,0 +1,87 @@
+// features/absences/admin/hooks/useAdminAbsences.ts
+// Lädt die zwei Listen von AdminAbsencesScreen ("Urlaubsanträge" +
+// "Krankmeldungen") und kapselt die Genehmigen/Ablehnen-Aktion darüber.
+// Gleiches Muster wie features/absences/hooks/useAbsences.ts: eigener
+// Ladezustand, kein globaler Context, `load` wird per useFocusEffect vom
+// Screen aufgerufen (nicht per Mount-Effect) — siehe dortige Begründung.
+
+import {
+  getPendingVacationRequests,
+  getSicknessReports,
+} from "@/services/absences/adminAbsences.service";
+import type { Absence } from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useVacationReview } from "./useVacationReview";
+
+// Krankmeldungen-Reiter: aktive (reported) zuerst relevant, aber auch kürzlich
+// stornierte sichtbar lassen (Nachvollziehbarkeit) — rejected/approved/
+// requested gibt es für Krankheit ohnehin nicht (siehe CHECK-Constraint).
+const SICKNESS_STATUSES: Absence["status"][] = ["reported", "cancelled"];
+
+export function useAdminAbsences() {
+  const [pendingVacations, setPendingVacations] = useState<Absence[]>([]);
+  const [sicknessReports, setSicknessReports] = useState<Absence[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoading(true);
+    setLoadError("");
+    try {
+      const [vacations, sickness] = await Promise.all([
+        getPendingVacationRequests(),
+        getSicknessReports({ status: SICKNESS_STATUSES }),
+      ]);
+      if (mountedRef.current) {
+        setPendingVacations(vacations);
+        setSicknessReports(sickness);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setLoadError(
+          toUserMessage(err, "Die Abwesenheiten konnten nicht geladen werden."),
+        );
+      }
+    } finally {
+      if (mountedRef.current && !opts?.silent) setLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ silent: true });
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, [load]);
+
+  // Ein genehmigter/abgelehnter Antrag verlässt die Pending-Liste (er ist per
+  // Definition nicht mehr requested) — kein Reload nötig, reines Herausfiltern.
+  const handleReviewed = useCallback((updated: Absence) => {
+    setPendingVacations((prev) => prev.filter((a) => a.id !== updated.id));
+  }, []);
+
+  const review = useVacationReview(handleReviewed);
+
+  return {
+    pendingVacations,
+    sicknessReports,
+    loading,
+    loadError,
+    load,
+    refreshing,
+    refresh,
+    ...review,
+  };
+}

--- a/features/absences/admin/hooks/useEmployeeAbsences.ts
+++ b/features/absences/admin/hooks/useEmployeeAbsences.ts
@@ -1,0 +1,75 @@
+// features/absences/admin/hooks/useEmployeeAbsences.ts
+// Lädt die Abwesenheitshistorie eines einzelnen Mitarbeiters für den Admin —
+// genutzt vom "Abwesenheiten"-Abschnitt in EmployeeDetailScreen (kompakter
+// Ausschnitt) UND von EmployeeAbsenceHistoryScreen ("Alle anzeigen", höheres
+// Limit). Gleiches Lade-/Review-Muster wie useAdminAbsences.
+
+import { getEmployeeAbsences } from "@/services/absences/adminAbsences.service";
+import type { Absence } from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useVacationReview } from "./useVacationReview";
+
+export function useEmployeeAbsences(employeeId: string | undefined, limit: number) {
+  const [absences, setAbsences] = useState<Absence[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!employeeId) {
+        setLoading(false);
+        return;
+      }
+      if (!opts?.silent) setLoading(true);
+      setLoadError("");
+      try {
+        const data = await getEmployeeAbsences(employeeId, limit);
+        if (mountedRef.current) setAbsences(data);
+      } catch (err) {
+        if (mountedRef.current) {
+          setLoadError(
+            toUserMessage(err, "Die Abwesenheiten konnten nicht geladen werden."),
+          );
+        }
+      } finally {
+        if (mountedRef.current && !opts?.silent) setLoading(false);
+      }
+    },
+    [employeeId, limit],
+  );
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ silent: true });
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, [load]);
+
+  const handleReviewed = useCallback((updated: Absence) => {
+    setAbsences((prev) => prev.map((a) => (a.id === updated.id ? updated : a)));
+  }, []);
+
+  const review = useVacationReview(handleReviewed);
+
+  return {
+    absences,
+    loading,
+    loadError,
+    load,
+    refreshing,
+    refresh,
+    ...review,
+  };
+}

--- a/features/absences/admin/hooks/useVacationReview.ts
+++ b/features/absences/admin/hooks/useVacationReview.ts
@@ -1,0 +1,74 @@
+// features/absences/admin/hooks/useVacationReview.ts
+// Kapselt Genehmigen/Ablehnen eines Urlaubsantrags (admin_review_vacation).
+// Geteilt zwischen AdminAbsencesScreen und EmployeeDetailScreen — beide
+// zeigen dieselbe Aktion auf denselben Zeilen, nur in unterschiedlichem
+// Listenkontext. Ruft bei Erfolg `onReviewed(updated)` auf, damit der
+// Aufrufer die lokale Liste optimistisch aktualisiert (kein Reload nötig).
+
+import {
+  reviewVacation,
+  type AdminCreateAbsenceInput,
+} from "@/services/absences/adminAbsences.service";
+import type { Absence } from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Re-export nur für Konsumenten, die den Input-Typ ebenfalls brauchen
+// (AdminCreateAbsenceScreen) — vermeidet einen doppelten Import-Pfad.
+export type { AdminCreateAbsenceInput };
+
+export function useVacationReview(onReviewed: (updated: Absence) => void) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const approve = useCallback(
+    async (absenceId: string) => {
+      setBusyId(absenceId);
+      setError("");
+      try {
+        const updated = await reviewVacation(absenceId, "approved");
+        onReviewed(updated);
+        return updated;
+      } catch (err) {
+        setError(toUserMessage(err, "Der Urlaub konnte nicht genehmigt werden."));
+        return null;
+      } finally {
+        if (mountedRef.current) setBusyId(null);
+      }
+    },
+    [onReviewed],
+  );
+
+  const reject = useCallback(
+    async (absenceId: string, adminNote?: string) => {
+      setBusyId(absenceId);
+      setError("");
+      try {
+        const updated = await reviewVacation(absenceId, "rejected", adminNote);
+        onReviewed(updated);
+        return updated;
+      } catch (err) {
+        setError(toUserMessage(err, "Der Urlaub konnte nicht abgelehnt werden."));
+        return null;
+      } finally {
+        if (mountedRef.current) setBusyId(null);
+      }
+    },
+    [onReviewed],
+  );
+
+  return {
+    busyId,
+    error,
+    clearError: () => setError(""),
+    approve,
+    reject,
+  };
+}

--- a/features/absences/components/AbsenceCard.tsx
+++ b/features/absences/components/AbsenceCard.tsx
@@ -9,29 +9,13 @@ import { DateTimeField } from "@/components/ui/DateTimeField";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import type { Absence } from "@/types/absence";
+import { formatAbsenceDateRange } from "@/utils/absenceFormat";
 import { formatDateISO } from "@/utils/date";
 import { confirmDialog } from "@/utils/dialogs";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { AbsenceStatusBadge } from "./AbsenceStatusBadge";
-
-/** "YYYY-MM-DD" → "DD.MM." (ohne Jahr, wie in den Kartenbeispielen). */
-function formatDayMonth(dateIso: string): string {
-  const [, m, d] = dateIso.split("-");
-  return `${d}.${m}.`;
-}
-
-function formatDateRangeLabel(absence: Absence): string {
-  if (absence.type === "vacation") {
-    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate!)}`;
-  }
-  // Krankheit: mit Ende ein Bereich, ohne Ende "Seit ...".
-  if (absence.endDate) {
-    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate)}`;
-  }
-  return `Seit ${formatDayMonth(absence.startDate)}`;
-}
 
 const today = () => formatDateISO(new Date())!;
 
@@ -124,7 +108,7 @@ export function AbsenceCard({
             <Text style={styles.typeLabel}>
               {isVacation ? "Urlaub" : "Krankheit"}
             </Text>
-            <Text style={styles.dateRange}>{formatDateRangeLabel(absence)}</Text>
+            <Text style={styles.dateRange}>{formatAbsenceDateRange(absence)}</Text>
           </View>
         </View>
         <AbsenceStatusBadge status={absence.status} />

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -24,16 +24,21 @@ import { useJobs } from "@/context/JobContext";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { AppTheme } from "@/constants/theme";
 import type { Job } from "@/types/job";
+import type { Absence } from "@/types/absence";
 import {
   getScheduleKpis,
   type ScheduleKpis,
 } from "@/services/jobs/jobs.service";
+import {
+  getCurrentCompanyAbsences,
+  getPendingVacationCount,
+} from "@/services/absences/adminAbsences.service";
 import { formatDateISO } from "@/utils/date";
 import { isAssignedTo } from "@/utils/jobAssignees";
 import { getJobStatusLabel } from "@/utils/jobStatus";
 import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useFocusEffect } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
@@ -143,6 +148,51 @@ export default function AdminDashboardScreen() {
     void loadKpis();
   }, [loadKpis]);
 
+  // ── Abwesenheiten (Phase C — Admin Absence Workflow) ──────────────────────
+  // Zwei leichte Signale, keine Zeilenlisten: die Anzahl offener Urlaubs-
+  // anträge (Dashboard-Chip) und die firmenweit heute aktiven Abwesenheiten
+  // (genehmigter Urlaub / gemeldete Krankheit — NICHT requested, siehe
+  // getCurrentCompanyAbsences). Eine Abfrage für die ganze Firma, kein Loop
+  // pro Mitarbeiter. useFocusEffect statt Mount-Effect: nach einem Review auf
+  // AdminAbsencesScreen soll der Chip beim Zurücknavigieren sofort stimmen.
+  const [pendingVacationCount, setPendingVacationCount] = useState<number | null>(null);
+  const [currentAbsences, setCurrentAbsences] = useState<Absence[]>([]);
+  const absenceLoadingRef = useRef(false);
+
+  const loadAbsenceSignals = useCallback(async () => {
+    if (!todayKey || absenceLoadingRef.current) return;
+    absenceLoadingRef.current = true;
+    try {
+      const [count, active] = await Promise.all([
+        getPendingVacationCount(),
+        getCurrentCompanyAbsences(todayKey),
+      ]);
+      setPendingVacationCount(count);
+      setCurrentAbsences(active);
+    } catch {
+      // Stiller Fehlschlag: Chip/Aktivitäts-Status bleiben einfach auf dem
+      // vorherigen Stand stehen. Ein eigenes Banner für zwei Nebeninfos wäre
+      // unverhältnismäßig — Dashboard-KPIs haben bereits eines für den
+      // wichtigeren Fall.
+    } finally {
+      absenceLoadingRef.current = false;
+    }
+  }, [todayKey]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadAbsenceSignals();
+    }, [loadAbsenceSignals]),
+  );
+
+  const absenceByEmployeeId = useMemo(() => {
+    const map = new Map<string, Absence>();
+    for (const absence of currentAbsences) {
+      if (absence.employeeId) map.set(absence.employeeId, absence);
+    }
+    return map;
+  }, [currentAbsences]);
+
   // ── Pull-to-Refresh ──────────────────────────────────────────────────────
   // Aktualisiert Jobs, Mitarbeiter und KPIs gemeinsam. Bewusst KEIN
   // loading-Gate: der LoadingScreen darf den Screen dabei nicht ersetzen,
@@ -155,12 +205,17 @@ export default function AdminDashboardScreen() {
     refreshingRef.current = true;
     setRefreshing(true);
     try {
-      await Promise.all([refreshJobs(), refreshEmployees(), loadKpis()]);
+      await Promise.all([
+        refreshJobs(),
+        refreshEmployees(),
+        loadKpis(),
+        loadAbsenceSignals(),
+      ]);
     } finally {
       refreshingRef.current = false;
       setRefreshing(false);
     }
-  }, [refreshJobs, refreshEmployees, loadKpis]);
+  }, [refreshJobs, refreshEmployees, loadKpis, loadAbsenceSignals]);
 
   const openCount = kpis?.offen ?? null;
   const inProgressCount = kpis?.inArbeit ?? null;
@@ -168,7 +223,11 @@ export default function AdminDashboardScreen() {
   const todayCount = kpis?.heute ?? null;
   const overdueCount = kpis?.ueberfaellig ?? 0;
 
-  // ── Mitarbeiter-Aktivität: aktiver (in_progress) Job pro Mitarbeiter
+  // ── Mitarbeiter-Aktivität: aktiver (in_progress) Job ODER aktive
+  // Abwesenheit pro Mitarbeiter, in dieser Priorität. Ein laufender Job zählt
+  // immer als das dringlichere Signal — kommt in der Praxis kaum vor
+  // (schlechte Datenlage, keine strukturelle Garantie), gewinnt aber bewusst
+  // visuell, siehe Architektur-Audit Phase C Abschnitt 16 (Risiken).
   const employeeActivity = useMemo(
     () =>
       employees
@@ -177,9 +236,10 @@ export default function AdminDashboardScreen() {
           const activeJob = jobs.find(
             (j) => isAssignedTo(j, emp.id) && j.status === "in_progress",
           );
-          return { id: emp.id, name: emp.fullName, activeJob };
+          const activeAbsence = absenceByEmployeeId.get(emp.id) ?? null;
+          return { id: emp.id, name: emp.fullName, activeJob, activeAbsence };
         }),
-    [employees, jobs],
+    [employees, jobs, absenceByEmployeeId],
   );
 
   // ── Letzte Aktivitäten: nach Zeitstempel absteigend, dann pro
@@ -332,6 +392,26 @@ export default function AdminDashboardScreen() {
         </TouchableOpacity>
       ) : null}
 
+      {/* ── Urlaubsanträge (nur wenn welche offen sind) ── */}
+      {pendingVacationCount && pendingVacationCount > 0 ? (
+        <TouchableOpacity
+          style={styles.pendingVacationCard}
+          activeOpacity={0.8}
+          onPress={() => router.push("/admin/absences?tab=vacation")}
+        >
+          <View style={styles.pendingVacationIcon}>
+            <Ionicons name="sunny-outline" size={20} color={theme.colors.primary} />
+          </View>
+          <View style={styles.timesheetInfo}>
+            <Text style={styles.timesheetTitle}>Urlaubsanträge</Text>
+            <Text style={styles.timesheetSub}>
+              {pendingVacationCount} offen
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={theme.colors.outline} />
+        </TouchableOpacity>
+      ) : null}
+
       {/* ── Mitarbeiter-Aktivität ── */}
       <View style={styles.section}>
         <SectionHeader
@@ -350,6 +430,23 @@ export default function AdminDashboardScreen() {
           <Card padding={0}>
             {employeeActivity.map((emp, idx) => {
               const isActive = !!emp.activeJob;
+              // Priorität: laufender Job > aktive Abwesenheit > "Kein aktiver Job".
+              // Nur genehmigter Urlaub/gemeldete Krankheit zählen als aktive
+              // Abwesenheit (siehe getCurrentCompanyAbsences) — eine
+              // angefragte Abwesenheit macht niemanden "abwesend".
+              const isAbsent = !isActive && !!emp.activeAbsence;
+              const activityLabel = isActive
+                ? emp.activeJob?.customerName ?? emp.activeJob?.service ?? "Aktiver Job"
+                : isAbsent
+                  ? emp.activeAbsence!.type === "sickness"
+                    ? "Krank gemeldet"
+                    : "Im Urlaub"
+                  : "Kein aktiver Job";
+              const dotColor = isActive
+                ? theme.colors.statusInProgress
+                : isAbsent
+                  ? theme.colors.statusOpen
+                  : theme.colors.outline;
               return (
                 <TouchableOpacity
                   key={emp.id}
@@ -366,22 +463,11 @@ export default function AdminDashboardScreen() {
                       {emp.name}
                     </Text>
                     <Text style={styles.empJob} numberOfLines={1}>
-                      {isActive
-                        ? emp.activeJob?.customerName ??
-                          emp.activeJob?.service ??
-                          "Aktiver Job"
-                        : "Kein aktiver Job"}
+                      {activityLabel}
                     </Text>
                   </View>
                   <View
-                    style={[
-                      styles.statusDot,
-                      {
-                        backgroundColor: isActive
-                          ? theme.colors.statusInProgress
-                          : theme.colors.outline,
-                      },
-                    ]}
+                    style={[styles.statusDot, { backgroundColor: dotColor }]}
                   />
                 </TouchableOpacity>
               );
@@ -649,6 +735,28 @@ function createStyles(theme: AppTheme) {
     },
     timesheetInfo: {
       flex: 1,
+    },
+
+    // ── Urlaubsanträge-Karte (gleiche Bauform wie Stundenzettel-Karte)
+    pendingVacationCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.md,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.lg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusOpenBorder,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.xl,
+      ...theme.shadows.sm,
+    },
+    pendingVacationIcon: {
+      width: 40,
+      height: 40,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.primaryContainer,
+      alignItems: "center",
+      justifyContent: "center",
     },
     timesheetTitle: {
       fontSize: theme.typography.size.md,

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Card,
   EmptyState,
+  ErrorBanner,
   InfoRow,
   InitialsAvatar,
   KPICard,
@@ -29,10 +30,22 @@ import { isAssignedTo } from "@/utils/jobAssignees";
 import { getJobStatusLabel } from "@/utils/jobStatus";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useMemo, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Alert, ScrollView, StatusBar, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { toUserMessage } from "@/utils/userMessages";
+import { AdminAbsenceRow } from "@/features/absences/admin/components/AdminAbsenceRow";
+import { useEmployeeAbsences } from "@/features/absences/admin/hooks/useEmployeeAbsences";
+import { groupAbsences } from "@/utils/absenceGrouping";
+
+// Abwesenheiten-Abschnitt: kompakter Ausschnitt hier, volle Historie unter
+// "Alle anzeigen" (app/employees/[id]/absences.tsx). Aktuell wird immer
+// gezeigt (kein Cap), Bevorstehend/Vergangen je bis zu 3 Zeilen — spiegelt
+// EmployeeDetailScreen's bestehendes "Cap bei 5, Meta-Zähler"-Muster für
+// Jobs, nur enger, da Abwesenheiten seltener sind als Jobs.
+const ABSENCE_SECTION_LIMIT = 6;
+const ABSENCE_ROWS_PER_GROUP = 3;
 
 // Reihenfolge für die Job-Liste: laufend → offen → erledigt
 const STATUS_ORDER: Record<JobStatus, number> = {
@@ -80,6 +93,30 @@ export default function EmployeeDetailScreen() {
     () => employees.find((e) => e.id === id),
     [employees, id],
   );
+
+  // ── Abwesenheiten (Phase C — Admin Absence Workflow) ──
+  const {
+    absences,
+    loadError: absenceLoadError,
+    load: loadAbsences,
+    busyId: absenceBusyId,
+    error: absenceActionError,
+    clearError: clearAbsenceError,
+    approve: approveVacation,
+    reject: rejectVacation,
+  } = useEmployeeAbsences(employee?.id, ABSENCE_SECTION_LIMIT);
+
+  const hasLoadedAbsencesOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!employee?.id) return;
+      loadAbsences({ silent: hasLoadedAbsencesOnceRef.current });
+      hasLoadedAbsencesOnceRef.current = true;
+    }, [employee?.id, loadAbsences]),
+  );
+
+  const { current: currentAbsences, upcoming: upcomingAbsences, past: pastAbsences } =
+    useMemo(() => groupAbsences(absences), [absences]);
 
   // Alle Jobs dieses Mitarbeiters — über die Zuweisungsmenge, damit auch
   // Aufträge zählen, bei denen er nicht der Legacy-Primär ist.
@@ -407,6 +444,86 @@ export default function EmployeeDetailScreen() {
               ))}
             </View>
           )}
+        </View>
+
+        {/* ── Abwesenheiten ── */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={styles.sectionLabel}>ABWESENHEITEN</Text>
+            {absences.length >= ABSENCE_SECTION_LIMIT ? (
+              <Text
+                style={styles.sectionMeta}
+                onPress={() => router.push(`/employees/${employee.id}/absences`)}
+              >
+                Alle anzeigen
+              </Text>
+            ) : null}
+          </View>
+
+          {absenceLoadError ? (
+            <ErrorBanner
+              message={absenceLoadError}
+              actionLabel="Erneut versuchen"
+              onAction={() => loadAbsences()}
+            />
+          ) : null}
+
+          {absenceActionError ? (
+            <ErrorBanner message={absenceActionError} onDismiss={clearAbsenceError} />
+          ) : null}
+
+          {absences.length === 0 && !absenceLoadError ? (
+            <Card padding={theme.spacing.lg}>
+              <EmptyState
+                title="Keine Abwesenheiten erfasst"
+                message="Urlaub oder Krankheit dieses Mitarbeiters erscheinen hier."
+                icon="calendar-outline"
+              />
+            </Card>
+          ) : (
+            <View style={styles.jobList}>
+              {currentAbsences.map((absence) => (
+                <AdminAbsenceRow
+                  key={absence.id}
+                  absence={absence}
+                  busy={absenceBusyId === absence.id}
+                  showEmployeeName={false}
+                  onApprove={approveVacation}
+                  onReject={rejectVacation}
+                />
+              ))}
+              {upcomingAbsences.slice(0, ABSENCE_ROWS_PER_GROUP).map((absence) => (
+                <AdminAbsenceRow
+                  key={absence.id}
+                  absence={absence}
+                  busy={absenceBusyId === absence.id}
+                  showEmployeeName={false}
+                  onApprove={approveVacation}
+                  onReject={rejectVacation}
+                />
+              ))}
+              {pastAbsences.slice(0, ABSENCE_ROWS_PER_GROUP).map((absence) => (
+                <AdminAbsenceRow
+                  key={absence.id}
+                  absence={absence}
+                  busy={absenceBusyId === absence.id}
+                  showEmployeeName={false}
+                  onApprove={approveVacation}
+                  onReject={rejectVacation}
+                />
+              ))}
+            </View>
+          )}
+
+          <Button
+            label="Abwesenheit erfassen"
+            variant="secondary"
+            icon="calendar-outline"
+            onPress={() =>
+              router.push(`/admin/absences/create?employeeId=${employee.id}`)
+            }
+            style={{ marginTop: theme.spacing.sm }}
+          />
         </View>
 
         {/* ── Aktionen ── */}

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -237,6 +237,13 @@ export default function ProfileScreen({
               theme={theme}
             />
             <SettingsRow
+              icon="calendar-outline"
+              label="Abwesenheiten verwalten"
+              onPress={() => router.push("/admin/absences")}
+              styles={styles}
+              theme={theme}
+            />
+            <SettingsRow
               icon="document-text-outline"
               label="Stundenzettel"
               onPress={() => router.push("/timesheets")}

--- a/services/absences/absences.service.ts
+++ b/services/absences/absences.service.ts
@@ -10,7 +10,9 @@
 // bereits auf die eigenen Zeilen ("employee read own absences").
 //
 // Admin-RPCs (admin_review_vacation, admin_create_absence) sind bewusst NICHT
-// hier verdrahtet — Admin-Workflow ist eine spätere Phase.
+// hier verdrahtet — Admin-Workflow lebt in services/absences/adminAbsences.service.ts
+// (Phase C), das AbsenceRow/mapAbsence/ABSENCE_SELECT von hier importiert statt
+// sie zu duplizieren.
 
 import { supabase } from "@/lib/supabase";
 import {
@@ -22,7 +24,11 @@ import {
 } from "@/types/absence";
 import { toUserMessage } from "@/utils/userMessages";
 
-type AbsenceRow = {
+// Exportiert für services/absences/adminAbsences.service.ts — Zeilenform und
+// Mapping sind für Mitarbeiter- und Admin-Lesezugriff identisch (dieselbe
+// Tabelle, dieselbe SELECT-Projektion), nur die WHERE-Bedingungen und RPCs
+// unterscheiden sich. Keine zweite Kopie dieser Typen/Funktion pflegen.
+export type AbsenceRow = {
   id: string;
   company_id: string;
   employee_id: string | null;
@@ -38,7 +44,7 @@ type AbsenceRow = {
   updated_at: string;
 };
 
-function mapAbsence(row: AbsenceRow): Absence {
+export function mapAbsence(row: AbsenceRow): Absence {
   return {
     id: row.id,
     companyId: row.company_id,
@@ -126,7 +132,7 @@ function translateRpcError(err: unknown, fallback: string): string {
   return toUserMessage(err, fallback);
 }
 
-const ABSENCE_SELECT =
+export const ABSENCE_SELECT =
   "id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, employee_note, admin_note, reviewed_at, created_at, updated_at";
 
 /** Lädt die eigenen Abwesenheiten des aktuellen Mitarbeiters (RLS-skopiert). */

--- a/services/absences/adminAbsences.service.ts
+++ b/services/absences/adminAbsences.service.ts
@@ -1,0 +1,309 @@
+// services/absences/adminAbsences.service.ts
+// Admin-Operationen für Urlaub/Krankheit (Phase C — Admin Absence Workflow).
+//
+// LESEN: normale SELECTs auf employee_absences. RLS ("admin read company
+// absences", siehe supabase/migrations/20260816000000_absences_foundation.sql)
+// beschränkt das bereits auf die eigene Firma — kein RPC nötig, gleiches
+// Muster wie getJobs()/getEmployees() in services/jobs/jobs.service.ts.
+//
+// SCHREIBEN: ausschließlich über die zwei Admin-RPCs aus derselben Migration
+// (admin_review_vacation, admin_create_absence). Es gibt bewusst KEINE
+// INSERT/UPDATE/DELETE-Policy auf der Tabelle — jeder direkte Schreibversuch
+// von hier aus würde ohnehin an RLS scheitern.
+//
+// Employee-Selbstbedienung bleibt in absences.service.ts (siehe dessen
+// Kopfkommentar) — diese Datei importiert von dort nur die geteilte
+// Zeilenform/das Mapping, dupliziert sie nicht.
+
+import { supabase } from "@/lib/supabase";
+import {
+  ABSENCE_SELECT,
+  mapAbsence,
+  type AbsenceRow,
+} from "@/services/absences/absences.service";
+import {
+  Absence,
+  AbsenceStatus,
+  AbsenceType,
+} from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+
+export type AdminCreateAbsenceInput = {
+  employeeId: string;
+  type: AbsenceType;
+  /** "YYYY-MM-DD" */
+  startDate: string;
+  /** "YYYY-MM-DD", nur bei Urlaub Pflicht */
+  endDate?: string | null;
+  note?: string;
+};
+
+// Sicherheitsdeckel für ungefilterte/weit gefasste Listen — gleiche Rolle wie
+// OCCURRENCE_LIMIT in AdminJobsCalendarScreen: kein erwarteter Regelfall,
+// verhindert nur eine stillschweigend unvollständige, unbegrenzte Abfrage.
+const COMPANY_ABSENCES_LIMIT = 200;
+const PENDING_REQUESTS_LIMIT = 100;
+
+// Bekannte englische RPC-Ablehnungen der Admin-RPCs → deutsche Nutzer-
+// Meldung. Reihenfolge spezifisch → grob, gleiche Bauform wie
+// services/absences/absences.service.ts (translateRpcError).
+const ADMIN_RPC_MESSAGE_MAP: { match: string; message: string }[] = [
+  {
+    match: "Only admins can review vacation requests",
+    message: "Nur Admins können Urlaubsanträge bearbeiten.",
+  },
+  {
+    match: "Only admins can manually record an absence",
+    message: "Nur Admins können Abwesenheiten manuell erfassen.",
+  },
+  {
+    match: "Vacation request not found, not in your company, or already reviewed",
+    message:
+      "Dieser Antrag wurde bereits bearbeitet oder ist nicht mehr verfügbar.",
+  },
+  {
+    match: "Employee not found in your company",
+    message: "Dieser Mitarbeiter wurde nicht gefunden.",
+  },
+  {
+    match: "start_date is required",
+    message: "Bitte ein Startdatum angeben.",
+  },
+  {
+    match: "end_date is required for vacation",
+    message: "Bitte ein Enddatum für den Urlaub angeben.",
+  },
+  {
+    match: "end_date must not be before start_date",
+    message: "Das Enddatum darf nicht vor dem Startdatum liegen.",
+  },
+  {
+    match: "Overlaps an existing vacation request",
+    message:
+      "Dieser Zeitraum überschneidet sich mit einem bereits bestehenden Urlaubsantrag.",
+  },
+  {
+    match: "Overlaps an existing active sickness report",
+    message:
+      "Dieser Zeitraum überschneidet sich mit einer bereits aktiven Krankmeldung.",
+  },
+  {
+    match: "decision must be",
+    message: "Ungültige Entscheidung.",
+  },
+];
+
+function translateAdminRpcError(err: unknown, fallback: string): string {
+  const raw =
+    typeof err === "object" && err !== null && "message" in err
+      ? String((err as { message?: unknown }).message ?? "")
+      : "";
+
+  const hit = ADMIN_RPC_MESSAGE_MAP.find((entry) => raw.includes(entry.match));
+  if (hit) return hit.message;
+
+  return toUserMessage(err, fallback);
+}
+
+function firstRow(data: AbsenceRow[] | null): Absence {
+  const row = data?.[0];
+  if (!row) {
+    throw new Error("Die Abwesenheit konnte nicht geladen werden.");
+  }
+  return mapAbsence(row);
+}
+
+/**
+ * Firmenweite Abwesenheiten, optional nach Zeitraum/Typ/Status gefiltert.
+ * RLS beschränkt bereits auf die eigene Firma. Für unbegrenzte Aufrufe gilt
+ * ein Sicherheitsdeckel (COMPANY_ABSENCES_LIMIT) — kein Regelfall in der
+ * Firmengröße dieser App, aber verhindert eine stillschweigend unvollständige
+ * Liste bei sehr vielen historischen Einträgen.
+ */
+export async function getCompanyAbsences(params?: {
+  /** "YYYY-MM-DD", inklusive — Zeilen mit start_date >= from */
+  from?: string;
+  /** "YYYY-MM-DD", inklusive — Zeilen mit start_date <= to */
+  to?: string;
+  type?: AbsenceType;
+  status?: AbsenceStatus[];
+  limit?: number;
+}): Promise<Absence[]> {
+  let query = supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .order("start_date", { ascending: false })
+    .limit(params?.limit ?? COMPANY_ABSENCES_LIMIT);
+
+  if (params?.from) query = query.gte("start_date", params.from);
+  if (params?.to) query = query.lte("start_date", params.to);
+  if (params?.type) query = query.eq("type", params.type);
+  if (params?.status?.length) query = query.in("status", params.status);
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/** Abwesenheitshistorie eines einzelnen Mitarbeiters, neueste zuerst. */
+export async function getEmployeeAbsences(
+  employeeId: string,
+  limit = 10,
+): Promise<Absence[]> {
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .eq("employee_id", employeeId)
+    .order("start_date", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/** Reine Zählung offener Urlaubsanträge — für den Dashboard-Chip, ohne Zeilen zu laden. */
+export async function getPendingVacationCount(): Promise<number> {
+  const { count, error } = await supabase
+    .from("employee_absences")
+    .select("id", { count: "exact", head: true })
+    .eq("type", "vacation")
+    .eq("status", "requested");
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Anzahl offener Anträge konnte nicht geladen werden."),
+    );
+  }
+  return count ?? 0;
+}
+
+/** Offene Urlaubsanträge, älteste zuerst (FIFO-Warteschlange für die Review-Liste). */
+export async function getPendingVacationRequests(): Promise<Absence[]> {
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .eq("type", "vacation")
+    .eq("status", "requested")
+    .order("created_at", { ascending: true })
+    .limit(PENDING_REQUESTS_LIMIT);
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Urlaubsanträge konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/**
+ * Firmenweite Krankmeldungen, neueste zuerst — für den "Krankmeldungen"-
+ * Reiter. Zeigt reported (aktiv) UND cancelled (kürzlich storniert) nicht
+ * automatisch aus; der Aufrufer filtert nach Bedarf serverseitig über
+ * `status`. Ohne status-Filter: alle Krankheits-Zeilen (begrenzt).
+ */
+export async function getSicknessReports(params?: {
+  status?: AbsenceStatus[];
+  limit?: number;
+}): Promise<Absence[]> {
+  let query = supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .eq("type", "sickness")
+    .order("start_date", { ascending: false })
+    .limit(params?.limit ?? COMPANY_ABSENCES_LIMIT);
+
+  if (params?.status?.length) query = query.in("status", params.status);
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Krankmeldungen konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/**
+ * Aktive Abwesenheiten der Firma an einem bestimmten Tag (Standard: heute).
+ * NUR genehmigter Urlaub und gemeldete Krankheit zählen als "aktive
+ * Abwesenheit" — eine angefragte (requested) Abwesenheit macht niemanden
+ * "abwesend" (siehe Architektur-Audit Phase C, Abschnitt 3B). Eine Abfrage
+ * für die gesamte Firma, kein Loop pro Mitarbeiter — der Aufrufer joint
+ * client-seitig gegen die bereits geladene Mitarbeiterliste, exakt wie
+ * AdminDashboardScreen es heute für `activeJob` tut.
+ */
+export async function getCurrentCompanyAbsences(
+  dateIso: string,
+): Promise<Absence[]> {
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .or("and(type.eq.vacation,status.eq.approved),and(type.eq.sickness,status.eq.reported)")
+    .lte("start_date", dateIso)
+    .or(`end_date.is.null,end_date.gte.${dateIso}`);
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/** Admin genehmigt/lehnt eine Urlaubsanfrage der eigenen Firma ab. */
+export async function reviewVacation(
+  absenceId: string,
+  decision: "approved" | "rejected",
+  adminNote?: string,
+): Promise<Absence> {
+  const { data, error } = await supabase.rpc("admin_review_vacation", {
+    absence_id_input: absenceId,
+    decision_input: decision,
+    admin_note_input: adminNote?.trim() || null,
+  });
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(
+        error,
+        decision === "approved"
+          ? "Der Urlaub konnte nicht genehmigt werden."
+          : "Der Urlaub konnte nicht abgelehnt werden.",
+      ),
+    );
+  }
+  return firstRow(data as AbsenceRow[] | null);
+}
+
+/**
+ * Admin erfasst eine Abwesenheit manuell für einen Mitarbeiter der eigenen
+ * Firma. Urlaub landet direkt bei status=approved, Krankheit bei
+ * status=reported — beides serverseitig, kein clientseitig erfundener
+ * Zwischenzustand.
+ */
+export async function adminCreateAbsence(
+  input: AdminCreateAbsenceInput,
+): Promise<Absence> {
+  const { data, error } = await supabase.rpc("admin_create_absence", {
+    employee_id_input: input.employeeId,
+    type_input: input.type,
+    start_date_input: input.startDate,
+    end_date_input: input.endDate ?? null,
+    note_input: input.note?.trim() || null,
+  });
+
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Abwesenheit konnte nicht erfasst werden."),
+    );
+  }
+  return firstRow(data as AbsenceRow[] | null);
+}

--- a/utils/absenceFormat.ts
+++ b/utils/absenceFormat.ts
@@ -1,0 +1,24 @@
+// utils/absenceFormat.ts
+// Geteilte Anzeige-Formatierung für Abwesenheits-Zeiträume — extrahiert aus
+// features/absences/components/AbsenceCard.tsx, damit die Admin-Seite
+// (features/absences/admin/) dieselbe Formatierung nutzt statt sie zu
+// duplizieren ("Krank seit DD.MM." / "DD.MM.–DD.MM.").
+
+import type { Absence } from "@/types/absence";
+
+/** "YYYY-MM-DD" → "DD.MM." (ohne Jahr). */
+export function formatDayMonth(dateIso: string): string {
+  const [, m, d] = dateIso.split("-");
+  return `${d}.${m}.`;
+}
+
+/** Lesbarer Zeitraum: Urlaub immer als Bereich, Krankheit ggf. offen-endig. */
+export function formatAbsenceDateRange(absence: Absence): string {
+  if (absence.type === "vacation") {
+    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate!)}`;
+  }
+  if (absence.endDate) {
+    return `${formatDayMonth(absence.startDate)}–${formatDayMonth(absence.endDate)}`;
+  }
+  return `Seit ${formatDayMonth(absence.startDate)}`;
+}


### PR DESCRIPTION
## Summary

Phase C of the absence workflow (Urlaub/Krankheit) — the admin side, on top of the already-merged employee self-service UI (Phase B) and backend foundation (Phase A). Client-side only; no migration, no calendar/timesheet/notification changes, no new realtime subscription.

Admins can now:
- See pending vacation requests and **Genehmigen**/**Ablehnen** them (optional rejection note)
- See sickness reports (open-ended: "Krank seit DD.MM.", with end: "DD.MM.–DD.MM.") — read-only, no approve/reject (Krankheit is a report, not a request)
- View an employee's absence history from **Employee Detail** (current / up to 3 upcoming / up to 3 recent, "Alle anzeigen" for full history), with inline Genehmigen/Ablehnen on pending rows
- Manually record **Urlaub** (goes straight to `approved`) or **Krankheit** (goes straight to `reported`) for an employee via "Abwesenheit erfassen", inactive employees included and labeled "Inaktiv"
- See a compact **"Urlaubsanträge — N offen"** chip on the Dashboard (only rendered when N > 0), tapping into the vacation tab of the new management screen
- See **"Krank gemeldet"** / **"Im Urlaub"** in Mitarbeiter-Aktivität for today, with priority: active job > active absence > "Kein aktiver Job". Only `vacation+approved` and `sickness+reported` count as active — a *requested* vacation never makes someone look absent.

## Backend

**Reused as-is, no changes**: `admin_review_vacation`, `admin_create_absence` RPCs, and the existing `"admin read company absences"` RLS policy on `employee_absences` (all deployed in the Phase A migration). All reads are plain company-scoped `SELECT`s; all writes go exclusively through the two RPCs — no direct INSERT/UPDATE/DELETE anywhere in the new code.

## New files

- `services/absences/adminAbsences.service.ts` — admin reads (`getCompanyAbsences`, `getEmployeeAbsences`, `getPendingVacationCount`, `getPendingVacationRequests`, `getSicknessReports`, `getCurrentCompanyAbsences`) + writes (`reviewVacation`, `adminCreateAbsence`), reusing `AbsenceRow`/`mapAbsence`/`ABSENCE_SELECT` exported from the employee-facing `absences.service.ts` instead of duplicating them
- `features/absences/admin/` — `AdminAbsencesScreen` (Urlaubsanträge/Krankmeldungen segments), `AdminCreateAbsenceScreen`, `EmployeeAbsenceHistoryScreen`, shared `AdminAbsenceRow`/`RejectVacationSheet`/`EmployeePickerField` components, and `useAdminAbsences`/`useEmployeeAbsences`/`useVacationReview` hooks
- `app/admin/absences/index.tsx`, `app/admin/absences/create.tsx`, `app/employees/[id]/absences.tsx` — pushed routes, no new tab
- `utils/absenceFormat.ts` — extracted the date-range formatting ("Seit DD.MM." / "DD.MM.–DD.MM.") out of `AbsenceCard.tsx` so the admin UI reuses it instead of re-implementing it

## Modified

- `features/admin/AdminDashboardScreen.tsx` — pending-vacation chip + absence state in Mitarbeiter-Aktivität, one company-wide query (`getCurrentCompanyAbsences`), no per-employee loop
- `features/employees/EmployeeDetailScreen.tsx` — new "Abwesenheiten" section
- `features/profile/ProfileScreen.tsx` — "Abwesenheiten verwalten" row under Administration
- `services/absences/absences.service.ts` — exported `AbsenceRow`/`mapAbsence`/`ABSENCE_SELECT` for reuse, updated header comment
- `features/absences/components/AbsenceCard.tsx` — now imports the extracted formatter instead of a private copy

## Refresh strategy

No new Supabase realtime channel. `useFocusEffect` reloads (silent after first load) on the two new list screens and on the Dashboard's absence signals, matching the existing `AbsencesScreen`/`AdminJobsCalendarScreen` pattern. Review/create actions update the relevant list optimistically from the RPC's returned row — no forced reload, no flicker.

## Security

- Admin reads are RLS-scoped to the caller's company (`"admin read company absences"`); no RPC needed for reads.
- Writes go exclusively through `admin_review_vacation` / `admin_create_absence` — both re-check `role='admin'` server-side and are company-scoped in their `WHERE`/lookup clauses.
- New admin routes have no client-side role gate — consistent with the rest of this app's existing admin screens (e.g. `app/employees/[id]/index.tsx`, `app/jobs/create.tsx`), which also rely entirely on backend RLS/RPC checks rather than client route guards.
- `employee_name_snapshot` is used for display, so historical rows render fine after an employee account deletion (`employee_id = NULL`); `reviewed_by = NULL` is handled (rejection/approval note UI never assumes a reviewer profile exists).

## Verification

- `npx tsc --noEmit` — clean, 0 errors
- `npm run lint` (`expo lint`) — clean, 0 errors, 0 new warnings (2 pre-existing `AdminDashboardScreen` warnings unrelated to this change, 1 pre-existing unused-import warning in `EmployeeDetailScreen` predating this branch)
- No browser/simulator run in this PR — the project's Staging web target is documented as broken (missing edge functions/photo bucket) and this workflow needs a real admin+employee account pair with live RPCs, so verification is the manual QA checklist below on a real device against a real Supabase project.

## Manual QA checklist (physical device)

**A. Vacation review**
- [ ] Employee requests vacation → appears in admin's Urlaubsanträge tab
- [ ] Admin approves → employee's "Meine Abwesenheiten" shows "Genehmigt" after refresh
- [ ] Admin rejects a second request (with and without a note) → employee sees "Abgelehnt" + note
- [ ] Reviewing an already-reviewed/stale request surfaces "Dieser Antrag wurde bereits bearbeitet oder ist nicht mehr verfügbar."

**B. Sickness visibility**
- [ ] Employee reports open-ended sickness → admin sees "Krank seit DD.MM.", no Genehmigen/Ablehnen shown
- [ ] Sickness with an end date shows "DD.MM.–DD.MM."

**C. Manual creation**
- [ ] Admin creates vacation for an employee → appears immediately as Genehmigt
- [ ] Admin creates open-ended sickness → appears as Gemeldet
- [ ] Overlap attempt shows the translated German overlap error, not a raw Supabase message

**D. Employee Detail**
- [ ] Abwesenheiten section shows current/upcoming/past correctly, "Alle anzeigen" appears once ≥6 rows exist
- [ ] A historical row for a deleted employee account renders via the name snapshot, no crash
- [ ] "Abwesenheit erfassen" from Employee Detail preselects that employee

**E. Dashboard**
- [ ] Pending vacation count matches the actual open-request count and updates after review
- [ ] "Krank gemeldet"/"Im Urlaub" appears for the right employees today; requested-but-not-approved vacation does NOT trigger it
- [ ] An employee with both an in-progress job and an active absence shows the job state, not the absence state

**F. Navigation/state**
- [ ] Back navigation from review/create screens returns to a correctly refreshed list
- [ ] No stale data after focus changes, no visible flicker on approve/reject/create

## Explicitly out of scope (unchanged)

Calendar markers/filters, job-assignment warnings, Timesheet absence integration, planned-absence-minutes, PDF changes, notifications/notification_outbox, an admin sickness-correction RPC, any new migration.