### PR TITLE
Phase D: Calendar absences + assignment warnings

### DIFF
--- a/app/admin/absences/index.tsx
+++ b/app/admin/absences/index.tsx
@@ -3,9 +3,7 @@ import { useLocalSearchParams } from "expo-router";
 
 export default function AdminAbsencesRoute() {
   const { tab } = useLocalSearchParams<{ tab?: string }>();
-  return (
-    <AdminAbsencesScreen
-      initialSegment={tab === "sickness" ? "sickness" : "vacation"}
-    />
-  );
+  const initialSegment =
+    tab === "absent" ? "absent" : tab === "sickness" ? "sickness" : "vacation";
+  return <AdminAbsencesScreen initialSegment={initialSegment} />;
 }

--- a/features/absences/admin/AdminAbsencesScreen.tsx
+++ b/features/absences/admin/AdminAbsencesScreen.tsx
@@ -30,12 +30,14 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { AbsentTodayRow } from "./components/AbsentTodayRow";
 import { AdminAbsenceRow } from "./components/AdminAbsenceRow";
 import { useAdminAbsences } from "./hooks/useAdminAbsences";
 
-type Segment = "vacation" | "sickness";
+type Segment = "absent" | "vacation" | "sickness";
 
 const SEGMENTS: { key: Segment; label: string }[] = [
+  { key: "absent", label: "Abwesend" },
   { key: "vacation", label: "Urlaubsanträge" },
   { key: "sickness", label: "Krankmeldungen" },
 ];
@@ -53,6 +55,7 @@ export default function AdminAbsencesScreen({
   const {
     pendingVacations,
     sicknessReports,
+    activeToday,
     loading,
     loadError,
     load,
@@ -75,7 +78,12 @@ export default function AdminAbsencesScreen({
 
   if (loading) return <LoadingScreen />;
 
-  const list = segment === "vacation" ? pendingVacations : sicknessReports;
+  const list =
+    segment === "vacation"
+      ? pendingVacations
+      : segment === "sickness"
+        ? sicknessReports
+        : activeToday;
 
   return (
     <SafeAreaView style={styles.container} edges={["top"]}>
@@ -122,6 +130,10 @@ export default function AdminAbsencesScreen({
         <View style={styles.segment}>
           {SEGMENTS.map((opt) => {
             const active = segment === opt.key;
+            // Nur der Urlaubsanträge-Reiter trägt eine Zähl-Badge (Warte-
+            // schlange, die abgearbeitet werden muss) — "Abwesend" ist eine
+            // Momentaufnahme, keine Warteschlange, daher bewusst ohne Zahl im
+            // Segment (die Dashboard-Karte trägt die Zahl bereits).
             const count = opt.key === "vacation" ? pendingVacations.length : null;
             return (
               <TouchableOpacity
@@ -156,11 +168,35 @@ export default function AdminAbsencesScreen({
               title={
                 segment === "vacation"
                   ? "Keine offenen Urlaubsanträge."
-                  : "Keine Krankmeldungen."
+                  : segment === "sickness"
+                    ? "Keine Krankmeldungen."
+                    : "Heute sind keine Mitarbeiter abwesend."
               }
-              icon={segment === "vacation" ? "sunny-outline" : "medkit-outline"}
+              icon={
+                segment === "vacation"
+                  ? "sunny-outline"
+                  : segment === "sickness"
+                    ? "medkit-outline"
+                    : "walk-outline"
+              }
             />
           </Card>
+        ) : segment === "absent" ? (
+          <View style={styles.cardList}>
+            {activeToday.map((absence) => (
+              <AbsentTodayRow
+                key={absence.id}
+                absence={absence}
+                // Gelöschtes Konto (employeeId null) → nicht antippbar, bleibt
+                // aber lesbar über employee_name_snapshot (siehe mapAbsence).
+                onPress={
+                  absence.employeeId
+                    ? () => router.push(`/employees/${absence.employeeId}`)
+                    : undefined
+                }
+              />
+            ))}
+          </View>
         ) : (
           <View style={styles.cardList}>
             {list.map((absence) => (

--- a/features/absences/admin/components/AbsentTodayRow.tsx
+++ b/features/absences/admin/components/AbsentTodayRow.tsx
@@ -1,0 +1,119 @@
+// features/absences/admin/components/AbsentTodayRow.tsx
+// Eine Zeile im "Abwesend"-Reiter von AdminAbsencesScreen: wer ist HEUTE
+// aktiv abwesend (genehmigter Urlaub / gemeldete Krankheit)?
+//
+// Bewusst KEINE Wiederverwendung von AdminAbsenceRow: dieser Reiter ist rein
+// lesend (kein Genehmigen/Ablehnen — "Abwesend" ist keine Review-Warteschlange,
+// sondern eine Momentaufnahme) UND tippbar (→ Employee Detail), wofür
+// AdminAbsenceRow keinen Vertrag hat (reine Card, kein onPress). Gleiches
+// Formatierungs-/Farb-Vokabular wie überall sonst: `formatAbsenceDateRange`
+// (utils/absenceFormat.ts, liefert "Krank seit DD.MM." für offen-endige
+// Krankheit) und Urlaub=primary/Krankheit=statusOpen (wie AbsenceCard,
+// AdminAbsenceRow, DayAgendaSheet).
+
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import type { Absence } from "@/types/absence";
+import { formatAbsenceDateRange } from "@/utils/absenceFormat";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+type Props = {
+  absence: Absence;
+  /**
+   * Fehlt (kein employeeId → gelöschtes Konto): Zeile bleibt lesbar, aber
+   * nicht antippbar — kein kaputtes Navigationsziel.
+   */
+  onPress?: () => void;
+};
+
+export function AbsentTodayRow({ absence, onPress }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const isVacation = absence.type === "vacation";
+
+  return (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={onPress}
+      disabled={!onPress}
+      activeOpacity={0.7}
+      accessibilityRole={onPress ? "button" : undefined}
+      accessibilityLabel={
+        onPress
+          ? `${absence.employeeName}, ${isVacation ? "Urlaub" : "Krank"}, Mitarbeiterdetails öffnen`
+          : undefined
+      }
+    >
+      <View
+        style={[
+          styles.icon,
+          {
+            backgroundColor: isVacation
+              ? theme.colors.primaryContainer
+              : theme.colors.statusOpenBg,
+          },
+        ]}
+      >
+        <Ionicons
+          name={isVacation ? "sunny-outline" : "medkit-outline"}
+          size={16}
+          color={isVacation ? theme.colors.primary : theme.colors.statusOpen}
+        />
+      </View>
+
+      <View style={styles.textWrap}>
+        <Text style={styles.name} numberOfLines={1}>
+          {absence.employeeName}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {isVacation ? "Urlaub" : "Krank"} · {formatAbsenceDateRange(absence)}
+        </Text>
+      </View>
+
+      {onPress ? (
+        <Ionicons name="chevron-forward" size={16} color={theme.colors.outline} />
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.lg,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      ...theme.shadows.sm,
+    },
+    icon: {
+      width: 32,
+      height: 32,
+      borderRadius: theme.radius.md,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    textWrap: {
+      flex: 1,
+    },
+    name: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    meta: {
+      marginTop: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/absences/admin/hooks/useAdminAbsences.ts
+++ b/features/absences/admin/hooks/useAdminAbsences.ts
@@ -6,10 +6,12 @@
 // Screen aufgerufen (nicht per Mount-Effect) — siehe dortige Begründung.
 
 import {
+  getCurrentCompanyAbsences,
   getPendingVacationRequests,
   getSicknessReports,
 } from "@/services/absences/adminAbsences.service";
 import type { Absence } from "@/types/absence";
+import { formatDateISO } from "@/utils/date";
 import { toUserMessage } from "@/utils/userMessages";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVacationReview } from "./useVacationReview";
@@ -22,6 +24,12 @@ const SICKNESS_STATUSES: Absence["status"][] = ["reported", "cancelled"];
 export function useAdminAbsences() {
   const [pendingVacations, setPendingVacations] = useState<Absence[]>([]);
   const [sicknessReports, setSicknessReports] = useState<Absence[]>([]);
+  // "Abwesend"-Reiter: firmenweit heute aktive Abwesenheiten (genehmigter
+  // Urlaub / gemeldete Krankheit — NICHT requested/rejected/cancelled, siehe
+  // getCurrentCompanyAbsences). Dieselbe Abfrage/Semantik wie der Dashboard-
+  // Chip "Heute abwesend" — dort wird bewusst dieselbe bereits geladene
+  // Liste wiederverwendet statt hier UND dort je eine eigene zu halten.
+  const [activeToday, setActiveToday] = useState<Absence[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
   const [refreshing, setRefreshing] = useState(false);
@@ -38,13 +46,16 @@ export function useAdminAbsences() {
     if (!opts?.silent) setLoading(true);
     setLoadError("");
     try {
-      const [vacations, sickness] = await Promise.all([
+      const todayKey = formatDateISO(new Date()) ?? "";
+      const [vacations, sickness, active] = await Promise.all([
         getPendingVacationRequests(),
         getSicknessReports({ status: SICKNESS_STATUSES }),
+        getCurrentCompanyAbsences(todayKey),
       ]);
       if (mountedRef.current) {
         setPendingVacations(vacations);
         setSicknessReports(sickness);
+        setActiveToday(active);
       }
     } catch (err) {
       if (mountedRef.current) {
@@ -77,6 +88,7 @@ export function useAdminAbsences() {
   return {
     pendingVacations,
     sicknessReports,
+    activeToday,
     loading,
     loadError,
     load,

--- a/features/admin/AdminDashboardScreen.tsx
+++ b/features/admin/AdminDashboardScreen.tsx
@@ -412,6 +412,28 @@ export default function AdminDashboardScreen() {
         </TouchableOpacity>
       ) : null}
 
+      {/* ── Heute abwesend (nur wenn welche aktiv sind) ──
+          Wiederverwendet `currentAbsences` (bereits für Mitarbeiter-Aktivität
+          geladen, siehe loadAbsenceSignals) — keine zweite/eigene Abfrage. */}
+      {currentAbsences.length > 0 ? (
+        <TouchableOpacity
+          style={styles.absentTodayCard}
+          activeOpacity={0.8}
+          onPress={() => router.push("/admin/absences?tab=absent")}
+        >
+          <View style={styles.absentTodayIcon}>
+            <Ionicons name="walk-outline" size={20} color={theme.colors.statusOpen} />
+          </View>
+          <View style={styles.timesheetInfo}>
+            <Text style={styles.timesheetTitle}>Heute abwesend</Text>
+            <Text style={styles.timesheetSub}>
+              {currentAbsences.length} Mitarbeiter
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={theme.colors.outline} />
+        </TouchableOpacity>
+      ) : null}
+
       {/* ── Mitarbeiter-Aktivität ── */}
       <View style={styles.section}>
         <SectionHeader
@@ -755,6 +777,28 @@ function createStyles(theme: AppTheme) {
       height: 40,
       borderRadius: theme.radius.md,
       backgroundColor: theme.colors.primaryContainer,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+
+    // ── Heute-abwesend-Karte (gleiche Bauform wie Urlaubsanträge-Karte)
+    absentTodayCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.md,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.lg,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.xl,
+      ...theme.shadows.sm,
+    },
+    absentTodayIcon: {
+      width: 40,
+      height: 40,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.statusOpenBg,
       alignItems: "center",
       justifyContent: "center",
     },

--- a/features/admin/AdminScreen.tsx
+++ b/features/admin/AdminScreen.tsx
@@ -8,6 +8,7 @@ import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
 import { JobFormFields } from "@/features/jobs/components/JobFormFields";
+import { useAssignmentAbsenceGuard } from "@/features/jobs/hooks/useAssignmentAbsenceGuard";
 import { useJobForm } from "@/features/jobs/hooks/useJobForm";
 import { formatDateISO, formatTimeHHmm, formatToISO } from "@/utils/date";
 import type { CreateJobInput } from "@/types/job";
@@ -114,6 +115,7 @@ export default function AdminScreen() {
   );
 
   const { values, errors, isDirty, setField, validate, reset } = useJobForm();
+  const { guardSave } = useAssignmentAbsenceGuard();
 
   // Warnung vor dem Verlassen mit ungespeicherten Eingaben. Deckt eigenen
   // Zurück-Button, Android-Hardware-Zurück und iOS-Swipe ab (siehe Hook).
@@ -150,67 +152,84 @@ export default function AdminScreen() {
     try {
       setSubmitting(true);
 
-      // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
-      // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
-      const parsedDuration = parseInt(values.durationMinutes, 10);
-      const plannedDurationMinutes =
-        Number.isFinite(parsedDuration) && parsedDuration > 0
-          ? parsedDuration
-          : null;
+      // Zuweisung × Abwesenheit VOR dem eigentlichen Speichern prüfen
+      // (Phase D). Bei Konflikten zeigt guardSave EINE Warnung und ruft
+      // performSave nur bei Bestätigung (oder ganz ohne Konflikt) auf — die
+      // Prüfung selbst speichert nie.
+      await guardSave(
+        {
+          employeeIds: values.employeeIds,
+          employees: activeEmployees,
+          jobType: values.jobType,
+          singleDate: formatDateISO(values.singleDateTime),
+          recurringDays: values.recurringDays,
+          recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
+          recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
+        },
+        async () => {
+          // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
+          // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
+          const parsedDuration = parseInt(values.durationMinutes, 10);
+          const plannedDurationMinutes =
+            Number.isFinite(parsedDuration) && parsedDuration > 0
+              ? parsedDuration
+              : null;
 
-      // Gemeinsame Basis
-      const base = {
-        customerName: values.customerName.trim(),
-        location: values.location.trim(),
-        service: values.service.trim(),
-        employeeIds: values.employeeIds,
-        notes: values.notes.trim() || null,
-        plannedDurationMinutes,
-      };
+          // Gemeinsame Basis
+          const base = {
+            customerName: values.customerName.trim(),
+            location: values.location.trim(),
+            service: values.service.trim(),
+            employeeIds: values.employeeIds,
+            notes: values.notes.trim() || null,
+            plannedDurationMinutes,
+          };
 
-      // Terminierung je nach Auftragstyp aufbauen
-      const input: CreateJobInput =
-        values.jobType === "single"
-          ? {
-              ...base,
-              jobType: "single",
-              date: formatDateISO(values.singleDateTime),
-              startTime: formatTimeHHmm(values.singleDateTime),
-              // scheduled_start für Detail-/Monats-Anzeigen zusätzlich befüllen
-              scheduledStart: formatToISO(values.singleDateTime),
-            }
-          : {
-              ...base,
-              jobType: "recurring",
-              startTime: formatTimeHHmm(values.startTime),
-              recurringDays: values.recurringDays,
-              isActive: values.isActive,
-              recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
-              recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
-              // recurring hat keinen einzelnen Termin
-              scheduledStart: null,
-            };
+          // Terminierung je nach Auftragstyp aufbauen
+          const input: CreateJobInput =
+            values.jobType === "single"
+              ? {
+                  ...base,
+                  jobType: "single",
+                  date: formatDateISO(values.singleDateTime),
+                  startTime: formatTimeHHmm(values.singleDateTime),
+                  // scheduled_start für Detail-/Monats-Anzeigen zusätzlich befüllen
+                  scheduledStart: formatToISO(values.singleDateTime),
+                }
+              : {
+                  ...base,
+                  jobType: "recurring",
+                  startTime: formatTimeHHmm(values.startTime),
+                  recurringDays: values.recurringDays,
+                  isActive: values.isActive,
+                  recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
+                  recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
+                  // recurring hat keinen einzelnen Termin
+                  scheduledStart: null,
+                };
 
-      const { recurringOccurrencesFailed } = await createJob(input);
+          const { recurringOccurrencesFailed } = await createJob(input);
 
-      // Formular vor dem Erfolgshinweis zurücksetzen (setzt auch isDirty zurück).
-      reset();
+          // Formular vor dem Erfolgshinweis zurücksetzen (setzt auch isDirty zurück).
+          reset();
 
-      // Erst den Hinweis abwarten, DANN navigieren — über alertDialog, weil
-      // Alert.alert im Web nichts anzeigt und der onPress-Callback dort nie
-      // liefe (die Navigation wäre unerreichbar). Der Job ist bereits angelegt,
-      // deshalb navigieren wir auch bei fehlgeschlagener Occurrence-Generierung
-      // — dann aber mit Teil-Erfolg-Hinweis statt vollem Erfolg.
-      if (recurringOccurrencesFailed) {
-        await alertDialog(
-          "Job angelegt",
-          "Der Job wurde angelegt, aber die Termine konnten nicht vollständig erzeugt werden. Bitte prüfe die Terminierung.",
-        );
-      } else {
-        await alertDialog("Erstellt", "Der Job wurde erfolgreich angelegt.");
-      }
+          // Erst den Hinweis abwarten, DANN navigieren — über alertDialog, weil
+          // Alert.alert im Web nichts anzeigt und der onPress-Callback dort nie
+          // liefe (die Navigation wäre unerreichbar). Der Job ist bereits angelegt,
+          // deshalb navigieren wir auch bei fehlgeschlagener Occurrence-Generierung
+          // — dann aber mit Teil-Erfolg-Hinweis statt vollem Erfolg.
+          if (recurringOccurrencesFailed) {
+            await alertDialog(
+              "Job angelegt",
+              "Der Job wurde angelegt, aber die Termine konnten nicht vollständig erzeugt werden. Bitte prüfe die Terminierung.",
+            );
+          } else {
+            await alertDialog("Erstellt", "Der Job wurde erfolgreich angelegt.");
+          }
 
-      leaveWithoutWarning(() => router.replace("/(admin-tabs)/jobs"));
+          leaveWithoutWarning(() => router.replace("/(admin-tabs)/jobs"));
+        },
+      );
     } catch (err: unknown) {
       // Bei einem Fehler wird NICHT navigiert — der Admin bleibt im Formular.
       const msg = toUserMessage(err, "Job konnte nicht erstellt werden.");

--- a/features/jobs/AdminJobsCalendarScreen.tsx
+++ b/features/jobs/AdminJobsCalendarScreen.tsx
@@ -32,6 +32,11 @@
 import { ErrorBanner, LoadingScreen } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useJobs } from "@/context/JobContext";
+import {
+  AbsenceFilterRow,
+  absenceSelectionLabel,
+  type AbsenceSelection,
+} from "@/features/jobs/components/AbsenceFilterRow";
 import { DayAgendaSheet } from "@/features/jobs/components/DayAgendaSheet";
 import {
   EmployeeFilterControl,
@@ -46,8 +51,14 @@ import {
   type StatusSelection,
 } from "@/features/jobs/components/StatusFilterRow";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { getCompanyAbsencesInRange } from "@/services/absences/adminAbsences.service";
 import { getScheduleOccurrences } from "@/services/jobs/jobs.service";
+import type { Absence } from "@/types/absence";
 import type { Job } from "@/types/job";
+import {
+  absenceTypesForDay,
+  buildAbsenceDayIndex,
+} from "@/utils/absenceCalendarMarkers";
 import {
   addMonths,
   buildDaySummaries,
@@ -80,6 +91,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const EMPTY_JOBS: never[] = [];
+const EMPTY_ABSENCES: never[] = [];
 // Deckt die größte bekannte Firma (≈90 Aufträge/60-Tage-Fenster, Stand
 // Prod-Stichprobe) großzügig ab — dient nur als Sicherheitsdeckel, kein
 // erwarteter Regelfall. Wird erreicht → Hinweis statt stiller Untertreibung.
@@ -101,8 +113,10 @@ export default function AdminJobsCalendarScreen() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [employeeSel, setEmployeeSel] = useState<EmployeeSelection>("all");
   const [statusSel, setStatusSel] = useState<StatusSelection>("all");
+  const [absenceSel, setAbsenceSel] = useState<AbsenceSelection>("all");
 
   const [rawJobs, setRawJobs] = useState<Job[]>([]);
+  const [rawAbsences, setRawAbsences] = useState<Absence[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -142,13 +156,23 @@ export default function AdminJobsCalendarScreen() {
       if (!isRefresh) setLoading(true);
       setError(null);
       try {
-        const items = await getScheduleOccurrences({
-          from: gridRange.from,
-          to: gridRange.to,
-          limit: OCCURRENCE_LIMIT,
-        });
+        // Genau ein Job- und EIN Abwesenheits-Query für den sichtbaren
+        // Rasterbereich (Phase D) — keine Abfrage je Tag/Mitarbeiter.
+        const [items, absenceItems] = await Promise.all([
+          getScheduleOccurrences({
+            from: gridRange.from,
+            to: gridRange.to,
+            limit: OCCURRENCE_LIMIT,
+          }),
+          getCompanyAbsencesInRange({
+            from: gridRange.from,
+            to: gridRange.to,
+            activeOnly: true,
+          }),
+        ]);
         setRawJobs(items);
         setPossiblyIncomplete(items.length >= OCCURRENCE_LIMIT);
+        setRawAbsences(absenceItems);
       } catch (err: unknown) {
         setError(toUserMessage(err, "Kalender konnte nicht geladen werden."));
       } finally {
@@ -234,6 +258,37 @@ export default function AdminJobsCalendarScreen() {
     [jobsByDay, selectedKey],
   );
 
+  // ── Phase D: Abwesenheits-Filter — rein clientseitig, wie Mitarbeiter-/
+  // Status-Filter. Der Mitarbeiter-Filter gilt AUCH für Abwesenheits-Zeilen
+  // (Anforderung: "Employee = Lena + Absence = Urlaub" zeigt nur Lenas
+  // Urlaub). "unassigned" hat für Abwesenheiten keine Entsprechung — zeigt
+  // dann bewusst keine Abwesenheiten.
+  const visibleAbsences = useMemo(() => {
+    return rawAbsences.filter((absence) => {
+      if (absenceSel === "vacation" && absence.type !== "vacation") return false;
+      if (absenceSel === "sickness" && absence.type !== "sickness") return false;
+      if (employeeSel === "all") return true;
+      if (employeeSel === "unassigned") return false;
+      return absence.employeeId === employeeSel;
+    });
+  }, [rawAbsences, absenceSel, employeeSel]);
+
+  const absencesByDay = useMemo(
+    () => buildAbsenceDayIndex(visibleAbsences, gridRange),
+    [visibleAbsences, gridRange],
+  );
+  const absenceMarkers = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof absenceTypesForDay>>();
+    for (const [key, list] of absencesByDay) {
+      map.set(key, absenceTypesForDay(list));
+    }
+    return map;
+  }, [absencesByDay]);
+  const selectedAbsences = useMemo(
+    () => absencesByDay.get(selectedKey) ?? EMPTY_ABSENCES,
+    [absencesByDay, selectedKey],
+  );
+
   const monthHasJobs = useMemo(() => {
     for (const key of summaries.keys()) {
       if (key.startsWith(monthKey)) return true;
@@ -241,7 +296,13 @@ export default function AdminJobsCalendarScreen() {
     return false;
   }, [summaries, monthKey]);
 
-  const hasActiveFilter = employeeSel !== "all" || statusSel !== "all";
+  // Getrennt von hasActiveFilter (steuert nur die entfernbaren Filter-Chips):
+  // der Abwesenheits-Filter beeinflusst NIE die Auftragsliste (siehe
+  // AbsenceFilterRow-Kommentar) — "Keine Aufträge für diesen Tag/Monat mit
+  // der aktuellen Filterauswahl" darf also nicht allein wegen absenceSel
+  // erscheinen, das wäre irreführend.
+  const hasJobFilter = employeeSel !== "all" || statusSel !== "all";
+  const hasActiveFilter = hasJobFilter || absenceSel !== "all";
 
   // Nur aktive Mitarbeiter zur Auswahl — deckungsgleich mit der Vorauswahl in
   // app/(admin-tabs)/employees.tsx.
@@ -255,6 +316,7 @@ export default function AdminJobsCalendarScreen() {
     [employeeSel, employees],
   );
   const statusLabel = useMemo(() => statusSelectionLabel(statusSel), [statusSel]);
+  const absenceLabel = useMemo(() => absenceSelectionLabel(absenceSel), [absenceSel]);
 
   // ── Navigation (identisch zum Mitarbeiter-Kalender: kein Swipe) ──
   const goPrevMonth = useCallback(() => setMonthKey((m) => addMonths(m, -1)), []);
@@ -270,15 +332,32 @@ export default function AdminJobsCalendarScreen() {
       setSelectedKey(key);
       const keyMonth = key.slice(0, 7);
       if (keyMonth !== monthKey) setMonthKey(keyMonth);
-      if ((jobsByDay.get(key)?.length ?? 0) > 0) setSheetOpen(true);
+      // Phase D: die Tages-Agenda öffnet auch für einen Tag OHNE Aufträge,
+      // wenn er Abwesenheiten hat — sonst wäre ein reiner Abwesenheits-Tag
+      // nie einsehbar.
+      const hasJobs = (jobsByDay.get(key)?.length ?? 0) > 0;
+      const hasAbsences = (absencesByDay.get(key)?.length ?? 0) > 0;
+      if (hasJobs || hasAbsences) setSheetOpen(true);
     },
-    [jobsByDay, monthKey],
+    [jobsByDay, absencesByDay, monthKey],
   );
 
   const handleOpenJob = useCallback((jobId: string) => {
     cameFromDetailRef.current = true;
     setSheetOpen(false);
     router.push(`/jobs/${jobId}`);
+  }, []);
+
+  // Phase D: Tippen auf eine Abwesenheits-Zeile → Mitarbeiter-Detail (dort
+  // liegt auch die "Job zuweisen"-Aktion — kein neuer, eigener Ziel-Screen
+  // für Phase D). Kein employeeId → Konto gelöscht, dann nicht antippbar
+  // (siehe DayAgendaSheet: onOpenAbsence bleibt für diese Zeile undefiniert
+  // wäre sauberer, aber Absence.employeeId ist hier bereits geprüft nötig).
+  const handleOpenAbsence = useCallback((absence: Absence) => {
+    if (!absence.employeeId) return;
+    cameFromDetailRef.current = true;
+    setSheetOpen(false);
+    router.push(`/employees/${absence.employeeId}`);
   }, []);
 
   const handleRefresh = useCallback(() => {
@@ -291,7 +370,7 @@ export default function AdminJobsCalendarScreen() {
   const canRunActions = useCallback(() => false, []);
   const noopAction = useCallback(() => {}, []);
 
-  const dayAgendaEmptyMessage = hasActiveFilter
+  const dayAgendaEmptyMessage = hasJobFilter
     ? "Keine Aufträge für diesen Tag mit der aktuellen Filterauswahl."
     : "Keine Aufträge an diesem Tag.";
 
@@ -386,6 +465,14 @@ export default function AdminJobsCalendarScreen() {
           </View>
         </View>
 
+        {/* ── Phase D: Abwesenheits-Filter — eigene Zeile, GETRENNT vom
+            Mitarbeiter-/Status-Filter oben. Steuert ausschließlich
+            Abwesenheits-Marker/-Agenda-Zeilen, blendet nie Aufträge aus
+            (siehe AbsenceFilterRow-Kommentar). ── */}
+        <View style={styles.absenceFilterRow}>
+          <AbsenceFilterRow value={absenceSel} onChange={setAbsenceSel} />
+        </View>
+
         {/* ── Aktive Filter: entfernbare Chips ── */}
         {hasActiveFilter ? (
           <View style={styles.activeFilterRow}>
@@ -426,6 +513,27 @@ export default function AdminJobsCalendarScreen() {
                 </TouchableOpacity>
               </View>
             ) : null}
+
+            {absenceSel !== "all" ? (
+              <View style={styles.activeFilterChip}>
+                <Ionicons
+                  name={absenceSel === "vacation" ? "sunny-outline" : "medkit-outline"}
+                  size={13}
+                  color={theme.colors.onPrimaryContainer}
+                />
+                <Text style={styles.activeFilterText} numberOfLines={1}>
+                  Abwesenheit: {absenceLabel}
+                </Text>
+                <TouchableOpacity
+                  onPress={() => setAbsenceSel("all")}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Abwesenheits-Filter ${absenceLabel} entfernen`}
+                >
+                  <Ionicons name="close" size={14} color={theme.colors.onPrimaryContainer} />
+                </TouchableOpacity>
+              </View>
+            ) : null}
           </View>
         ) : null}
 
@@ -435,12 +543,13 @@ export default function AdminJobsCalendarScreen() {
           selectedKey={selectedKey}
           todayKey={todayKey}
           summaries={summaries}
+          absenceMarkers={absenceMarkers}
           onSelectDay={handleSelectDay}
         />
 
         {!monthHasJobs ? (
           <Text style={styles.emptyMonthHint} numberOfLines={2}>
-            {hasActiveFilter
+            {hasJobFilter
               ? "Keine Aufträge für die aktuelle Filterauswahl in diesem Monat."
               : "In diesem Monat sind keine Aufträge geplant."}
           </Text>
@@ -472,6 +581,8 @@ export default function AdminJobsCalendarScreen() {
         onComplete={noopAction}
         showEmployeeName
         emptyMessage={dayAgendaEmptyMessage}
+        absences={selectedAbsences}
+        onOpenAbsence={handleOpenAbsence}
       />
     </SafeAreaView>
   );
@@ -551,6 +662,11 @@ function createStyles(theme: AppTheme) {
     },
     statusFilterWrap: {
       flex: 1,
+    },
+
+    // ── Phase D: Abwesenheits-Filter — eigene Zeile unter Mitarbeiter/Status
+    absenceFilterRow: {
+      paddingHorizontal: theme.spacing.xs,
     },
 
     // ── Aktive Filter: entfernbare Chips (Muster aus AdminScheduleScreen)

--- a/features/jobs/EditJobScreen.tsx
+++ b/features/jobs/EditJobScreen.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/context/AuthContext";
 import { useJobs } from "@/context/JobContext";
 import { EmployeeMultiSelector } from "@/features/jobs/components/EmployeeMultiSelector";
 import { JobFormFields } from "@/features/jobs/components/JobFormFields";
+import { useAssignmentAbsenceGuard } from "@/features/jobs/hooks/useAssignmentAbsenceGuard";
 import { useJobForm } from "@/features/jobs/hooks/useJobForm";
 import {
   formatDateISO,
@@ -137,6 +138,7 @@ export default function EditJobScreen() {
 
   const { values, errors, setField, validate, setValues, setErrors } =
     useJobForm();
+  const { guardSave } = useAssignmentAbsenceGuard();
 
   const isAdmin = role === "admin";
 
@@ -289,69 +291,87 @@ export default function EditJobScreen() {
       return;
     }
 
+    // Zusätzliche Absicherung (defense-in-depth): inaktive Mitarbeiter
+    // dürfen NIE an set_job_assignments gesendet werden (siehe Sperre
+    // oben). Da das Speichern bereits vollständig blockiert ist, solange
+    // hasInactiveAssignedEmployees zutrifft, sollte values.employeeIds an
+    // dieser Stelle nie mehr eine inaktive ID enthalten — dieser Filter
+    // fängt trotzdem den Fall ab, dass sich der Aktiv-Status eines
+    // Mitarbeiters zwischen Prüfung und Absenden ändert (z. B. durch
+    // gleichzeitige Deaktivierung in einer anderen Sitzung).
+    const activeEmployeeIds = new Set(
+      employees.filter((e) => e.isActive !== false).map((e) => e.id),
+    );
+    const submittableEmployeeIds = values.employeeIds.filter((id) =>
+      activeEmployeeIds.has(id),
+    );
+
     try {
       setSubmitting(true);
 
-      // Zusätzliche Absicherung (defense-in-depth): inaktive Mitarbeiter
-      // dürfen NIE an set_job_assignments gesendet werden (siehe Sperre
-      // oben). Da das Speichern bereits vollständig blockiert ist, solange
-      // hasInactiveAssignedEmployees zutrifft, sollte values.employeeIds an
-      // dieser Stelle nie mehr eine inaktive ID enthalten — dieser Filter
-      // fängt trotzdem den Fall ab, dass sich der Aktiv-Status eines
-      // Mitarbeiters zwischen Prüfung und Absenden ändert (z. B. durch
-      // gleichzeitige Deaktivierung in einer anderen Sitzung).
-      const activeEmployeeIds = new Set(
-        employees.filter((e) => e.isActive !== false).map((e) => e.id),
+      // Zuweisung × Abwesenheit VOR dem eigentlichen Speichern prüfen
+      // (Phase D) — mit dem CURRENT Formularstand (Datum/Wochentage/
+      // Zuweisung können sich hier gegenüber dem geladenen Job geändert
+      // haben). Bei Konflikten zeigt guardSave EINE Warnung; performSave
+      // läuft nur bei Bestätigung (oder ganz ohne Konflikt).
+      await guardSave(
+        {
+          employeeIds: submittableEmployeeIds,
+          employees,
+          jobType: values.jobType,
+          singleDate: formatDateISO(values.singleDateTime),
+          recurringDays: values.recurringDays,
+          recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
+          recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
+        },
+        async () => {
+          // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
+          // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
+          const parsedDuration = parseInt(values.durationMinutes, 10);
+          const plannedDurationMinutes =
+            Number.isFinite(parsedDuration) && parsedDuration > 0
+              ? parsedDuration
+              : null;
+
+          const base = {
+            jobId: job.id,
+            customerName: values.customerName.trim(),
+            location: values.location.trim(),
+            service: values.service.trim(),
+            employeeIds: submittableEmployeeIds,
+            notes: values.notes.trim() || null,
+            plannedDurationMinutes,
+          };
+
+          await updateJob(
+            values.jobType === "single"
+              ? {
+                  ...base,
+                  jobType: "single",
+                  date: formatDateISO(values.singleDateTime),
+                  startTime: formatTimeHHmm(values.singleDateTime),
+                  scheduledStart: formatToISO(values.singleDateTime),
+                }
+              : {
+                  ...base,
+                  jobType: "recurring",
+                  startTime: formatTimeHHmm(values.startTime),
+                  recurringDays: values.recurringDays,
+                  isActive: values.isActive,
+                  recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
+                  recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
+                  scheduledStart: null,
+                },
+          );
+
+          // Erst den Hinweis abwarten, DANN zurück. Vorher lief Alert.alert
+          // fire-and-forget und router.back() feuerte sofort — der Hinweis stand
+          // dann über dem VORHERIGEN Screen bzw. verschwand mit dem Wechsel. Im
+          // Web zeigte Alert.alert ohnehin nichts an.
+          await alertDialog("Gespeichert", "Der Job wurde aktualisiert.");
+          leaveWithoutWarning(() => router.back());
+        },
       );
-      const submittableEmployeeIds = values.employeeIds.filter((id) =>
-        activeEmployeeIds.has(id),
-      );
-
-      // Rohtext -> positive Ganzzahl oder null (leer/ungültig = keine Dauer
-      // geplant). JobFormFields lässt ohnehin nur Ziffern zu.
-      const parsedDuration = parseInt(values.durationMinutes, 10);
-      const plannedDurationMinutes =
-        Number.isFinite(parsedDuration) && parsedDuration > 0
-          ? parsedDuration
-          : null;
-
-      const base = {
-        jobId: job.id,
-        customerName: values.customerName.trim(),
-        location: values.location.trim(),
-        service: values.service.trim(),
-        employeeIds: submittableEmployeeIds,
-        notes: values.notes.trim() || null,
-        plannedDurationMinutes,
-      };
-
-      await updateJob(
-        values.jobType === "single"
-          ? {
-              ...base,
-              jobType: "single",
-              date: formatDateISO(values.singleDateTime),
-              startTime: formatTimeHHmm(values.singleDateTime),
-              scheduledStart: formatToISO(values.singleDateTime),
-            }
-          : {
-              ...base,
-              jobType: "recurring",
-              startTime: formatTimeHHmm(values.startTime),
-              recurringDays: values.recurringDays,
-              isActive: values.isActive,
-              recurrenceStartDate: formatDateISO(values.recurrenceStartDate),
-              recurrenceEndDate: formatDateISO(values.recurrenceEndDate),
-              scheduledStart: null,
-            },
-      );
-
-      // Erst den Hinweis abwarten, DANN zurück. Vorher lief Alert.alert
-      // fire-and-forget und router.back() feuerte sofort — der Hinweis stand
-      // dann über dem VORHERIGEN Screen bzw. verschwand mit dem Wechsel. Im
-      // Web zeigte Alert.alert ohnehin nichts an.
-      await alertDialog("Gespeichert", "Der Job wurde aktualisiert.");
-      leaveWithoutWarning(() => router.back());
     } catch (err: unknown) {
       const msg = toUserMessage(err, "Job konnte nicht gespeichert werden.");
 

--- a/features/jobs/EmployeeJobsCalendarScreen.tsx
+++ b/features/jobs/EmployeeJobsCalendarScreen.tsx
@@ -43,9 +43,16 @@ import { DayAgendaSheet } from "@/features/jobs/components/DayAgendaSheet";
 import { MonthGrid } from "@/features/jobs/components/MonthGrid";
 import { MonthYearPickerSheet } from "@/features/jobs/components/MonthYearPickerSheet";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { getOwnAbsencesInRange } from "@/services/absences/absences.service";
+import type { Absence } from "@/types/absence";
+import {
+  absenceTypesForDay,
+  buildAbsenceDayIndex,
+} from "@/utils/absenceCalendarMarkers";
 import {
   addMonths,
   buildDaySummaries,
+  buildMonthMatrix,
   formatMonthLabel,
   groupJobsByDateKey,
   monthKeyOf,
@@ -55,7 +62,7 @@ import { canRunJobActions } from "@/utils/jobAssignees";
 import { toUserMessage } from "@/utils/userMessages";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useFocusEffect } from "expo-router";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   RefreshControl,
   ScrollView,
@@ -68,6 +75,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const EMPTY_JOBS: never[] = [];
+const EMPTY_ABSENCES: never[] = [];
 
 export default function EmployeeJobsCalendarScreen() {
   const theme = useAppTheme();
@@ -89,6 +97,13 @@ export default function EmployeeJobsCalendarScreen() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [actionError, setActionError] = useState("");
+
+  // ── Phase D: eigene aktive Abwesenheiten (genehmigter Urlaub / gemeldete
+  // Krankheit) für den sichtbaren Rasterbereich. Eigener, kleiner Datenpfad
+  // — bewusst NICHT in JobContext, wie beim Admin-Kalender (siehe dortigen
+  // Dateikopf): reiner Screen-lokaler Zustand, RLS beschränkt die Abfrage
+  // bereits auf die eigenen Zeilen ("employee read own absences").
+  const [rawAbsences, setRawAbsences] = useState<Absence[]>([]);
 
   // Merkt sich, dass wir selbst in ein Job-Detail navigiert haben. Beim
   // Zurückkommen bleibt der betrachtete Monat dann stehen (sonst wäre der
@@ -141,6 +156,45 @@ export default function EmployeeJobsCalendarScreen() {
     return false;
   }, [summaries, monthKey]);
 
+  // ── Phase D: eigene aktive Abwesenheiten für den sichtbaren Rasterbereich
+  // (inkl. Vor-/Nachlauftage aus Nachbarmonaten, wie beim Admin-Kalender). ──
+  const gridRange = useMemo(() => {
+    const weeks = buildMonthMatrix(monthKey);
+    return { from: weeks[0][0].key, to: weeks[weeks.length - 1][6].key };
+  }, [monthKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+    getOwnAbsencesInRange({ from: gridRange.from, to: gridRange.to, activeOnly: true })
+      .then((items) => {
+        if (!cancelled) setRawAbsences(items);
+      })
+      .catch(() => {
+        // Bewusst still: die Abwesenheits-Marker sind eine Zusatzinfo, kein
+        // Fehler dieses Screens rechtfertigt einen eigenen ErrorBanner hier
+        // (die Job-Ansicht bleibt in jedem Fall funktionsfähig).
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [gridRange]);
+
+  const absencesByDay = useMemo(
+    () => buildAbsenceDayIndex(rawAbsences, gridRange),
+    [rawAbsences, gridRange],
+  );
+  const absenceMarkers = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof absenceTypesForDay>>();
+    for (const [key, list] of absencesByDay) {
+      map.set(key, absenceTypesForDay(list));
+    }
+    return map;
+  }, [absencesByDay]);
+  const selectedAbsences = useMemo(
+    () => absencesByDay.get(selectedKey) ?? EMPTY_ABSENCES,
+    [absencesByDay, selectedKey],
+  );
+
   // ── Navigation ───────────────────────────────────────────────
   // Drei Wege, alle mit derselben Semantik: sie ändern NUR den angezeigten
   // Monat. Die Auswahl bleibt, wo sie ist — es wird nie ein Tag „erfunden".
@@ -174,9 +228,13 @@ export default function EmployeeJobsCalendarScreen() {
       // Tag aus einem Nachbarmonat angetippt → in diesen Monat wechseln.
       const keyMonth = key.slice(0, 7);
       if (keyMonth !== monthKey) setMonthKey(keyMonth);
-      if ((jobsByDay.get(key)?.length ?? 0) > 0) setSheetOpen(true);
+      // Phase D: auch ein Tag OHNE Aufträge öffnet die Agenda, wenn er
+      // eigene Abwesenheiten hat.
+      const hasJobs = (jobsByDay.get(key)?.length ?? 0) > 0;
+      const hasAbsences = (absencesByDay.get(key)?.length ?? 0) > 0;
+      if (hasJobs || hasAbsences) setSheetOpen(true);
     },
-    [jobsByDay, monthKey],
+    [jobsByDay, absencesByDay, monthKey],
   );
 
   // Job-Detail wird jetzt AUSSCHLIESSLICH aus der Tages-Agenda geöffnet —
@@ -190,11 +248,23 @@ export default function EmployeeJobsCalendarScreen() {
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await refreshJobs();
+      // Phase D: Pull-to-Refresh aktualisiert auch die eigenen Abwesenheiten
+      // für den sichtbaren Bereich — best-effort wie der Hintergrund-Load
+      // oben, kein eigener Fehlerzustand für diesen Nebendatenpfad.
+      await Promise.all([
+        refreshJobs(),
+        getOwnAbsencesInRange({
+          from: gridRange.from,
+          to: gridRange.to,
+          activeOnly: true,
+        })
+          .then(setRawAbsences)
+          .catch(() => {}),
+      ]);
     } finally {
       setRefreshing(false);
     }
-  }, [refreshJobs]);
+  }, [refreshJobs, gridRange]);
 
   const handleStart = useCallback(
     async (jobId: string) => {
@@ -328,6 +398,7 @@ export default function EmployeeJobsCalendarScreen() {
           selectedKey={selectedKey}
           todayKey={todayKey}
           summaries={summaries}
+          absenceMarkers={absenceMarkers}
           onSelectDay={handleSelectDay}
         />
 
@@ -358,6 +429,10 @@ export default function EmployeeJobsCalendarScreen() {
         onComplete={handleComplete}
         errorMessage={actionError}
         onDismissError={() => setActionError("")}
+        absences={selectedAbsences}
+        // Kein onOpenAbsence: im Mitarbeiter-Kalender ist die Zeile rein
+        // lesend (eigene Abwesenheit, "Meine Abwesenheiten" bleibt der
+        // eigentliche Ort dafür) — kein zusätzliches Tipp-Ziel nötig.
       />
     </SafeAreaView>
   );

--- a/features/jobs/components/AbsenceFilterRow.tsx
+++ b/features/jobs/components/AbsenceFilterRow.tsx
@@ -1,0 +1,149 @@
+// features/jobs/components/AbsenceFilterRow.tsx
+// ─────────────────────────────────────────────────────────────────
+// Phase D — Abwesenheits-Filter für den Admin-Kalender: „Alle" / „Urlaub" /
+// „Krank". Gleiches Bauprinzip wie StatusFilterRow (reine Präsentation,
+// Chips, horizontal scrollbar) — bewusst eine eigene, kleine Zeile statt
+// StatusFilterRow zu verallgemeinern, weil die Semantik eine andere ist:
+// dieser Filter blendet NIE Aufträge aus, er steuert ausschließlich, welche
+// Abwesenheits-MARKER/-Agenda-Zeilen sichtbar sind (siehe AdminJobsCalendarScreen).
+//
+// Farben: dieselben Tokens wie in features/absences/components/AbsenceCard.tsx
+// (Urlaub → theme.colors.primary, Krankheit → theme.colors.statusOpen) — keine
+// zweite Abwesenheits-Farbtabelle.
+// ─────────────────────────────────────────────────────────────────
+
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import React, { useMemo } from "react";
+import { ScrollView, StyleSheet, Text, TouchableOpacity } from "react-native";
+
+export type AbsenceSelection = "all" | "vacation" | "sickness";
+
+export const ALL_ABSENCE_LABEL = "Alle";
+
+const ABSENCE_LABELS: Record<Exclude<AbsenceSelection, "all">, string> = {
+  vacation: "Urlaub",
+  sickness: "Krank",
+};
+
+/** Lesbares Label der aktuellen Auswahl (für Chip/Accessibility). */
+export function absenceSelectionLabel(selection: AbsenceSelection): string {
+  return selection === "all" ? ALL_ABSENCE_LABEL : ABSENCE_LABELS[selection];
+}
+
+type Props = {
+  value: AbsenceSelection;
+  onChange: (next: AbsenceSelection) => void;
+};
+
+export function AbsenceFilterRow({ value, onChange }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.row}
+    >
+      <Chip
+        label={ALL_ABSENCE_LABEL}
+        active={value === "all"}
+        onPress={() => onChange("all")}
+        activeBg={theme.colors.primaryContainer}
+        activeBorder={theme.colors.primaryContainer}
+        activeText={theme.colors.onPrimaryContainer}
+        styles={styles}
+      />
+      <Chip
+        label={ABSENCE_LABELS.vacation}
+        active={value === "vacation"}
+        onPress={() => onChange("vacation")}
+        activeBg={theme.colors.primaryContainer}
+        activeBorder={theme.colors.primary}
+        activeText={theme.colors.primary}
+        styles={styles}
+      />
+      <Chip
+        label={ABSENCE_LABELS.sickness}
+        active={value === "sickness"}
+        onPress={() => onChange("sickness")}
+        activeBg={theme.colors.statusOpenBg}
+        activeBorder={theme.colors.statusOpen}
+        activeText={theme.colors.statusOpen}
+        styles={styles}
+      />
+    </ScrollView>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+  activeBg,
+  activeBorder,
+  activeText,
+  styles,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  activeBg: string;
+  activeBorder: string;
+  activeText: string;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.chip,
+        active && { backgroundColor: activeBg, borderColor: activeBorder },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={`Abwesenheits-Filter: ${label}`}
+    >
+      <Text
+        style={[
+          styles.chipText,
+          active && styles.chipTextActive,
+          active && { color: activeText },
+        ]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.xs,
+    },
+    chip: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 7,
+      borderRadius: theme.radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    chipText: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurfaceVariant,
+    },
+    chipTextActive: {
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+    },
+  });
+}

--- a/features/jobs/components/CalendarDayCell.tsx
+++ b/features/jobs/components/CalendarDayCell.tsx
@@ -35,6 +35,7 @@
 
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AbsenceType } from "@/types/absence";
 import type { DaySummary } from "@/utils/calendarMonth";
 import { getJobStatusMeta } from "@/utils/jobStatus";
 import React, { useMemo } from "react";
@@ -51,6 +52,13 @@ type Props = {
   isSelected: boolean;
   /** Verdichtete Tagesinfo — `undefined` = keine Aufträge. */
   summary: DaySummary | undefined;
+  /**
+   * Phase D — vorkommende Abwesenheits-TYPEN dieses Tages (höchstens
+   * ["vacation","sickness"], nie ein Eintrag je Mitarbeiter). `undefined`/
+   * leer = keine aktive Abwesenheit an diesem Tag. Additiv: Aufrufer, die
+   * das nicht übergeben (z. B. bestehende Tests), verhalten sich unverändert.
+   */
+  absenceTypes?: AbsenceType[];
   onSelectDay: (key: string) => void;
 };
 
@@ -69,9 +77,14 @@ function buildA11yLabel(
   dayNumber: number,
   isToday: boolean,
   summary: DaySummary | undefined,
+  absenceTypes: AbsenceType[] | undefined,
 ): string {
   const head = `${dayNumber}.${isToday ? " Heute." : ""}`;
-  if (!summary) return `${head} Keine Aufträge`;
+  const absenceSuffix = absenceTypes?.length
+    ? ` ${absenceTypes.map((t) => (t === "vacation" ? "Urlaub" : "Krank")).join(", ")}.`
+    : "";
+
+  if (!summary) return `${head} Keine Aufträge.${absenceSuffix}`;
 
   const parts: string[] = [];
   if (summary.open > 0) parts.push(`${summary.open} offen`);
@@ -79,7 +92,7 @@ function buildA11yLabel(
   if (summary.completed > 0) parts.push(`${summary.completed} erledigt`);
 
   const total = summary.total === 1 ? "1 Auftrag" : `${summary.total} Aufträge`;
-  return `${head} ${total}: ${parts.join(", ")}`;
+  return `${head} ${total}: ${parts.join(", ")}.${absenceSuffix}`;
 }
 
 function CalendarDayCellBase({
@@ -89,10 +102,12 @@ function CalendarDayCellBase({
   isToday,
   isSelected,
   summary,
+  absenceTypes,
   onSelectDay,
 }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const hasAbsence = !!absenceTypes?.length;
 
   return (
     <TouchableOpacity
@@ -100,7 +115,7 @@ function CalendarDayCellBase({
       activeOpacity={0.7}
       onPress={() => onSelectDay(dayKey)}
       accessibilityRole="button"
-      accessibilityLabel={buildA11yLabel(dayNumber, isToday, summary)}
+      accessibilityLabel={buildA11yLabel(dayNumber, isToday, summary, absenceTypes)}
       accessibilityState={{ selected: isSelected }}
     >
       {/* ── Tageszahl (heute im gefüllten Kreis) ── */}
@@ -144,6 +159,26 @@ function CalendarDayCellBase({
               />
             ))}
           </View>
+        </View>
+      ) : null}
+
+      {/* ── Phase D: Abwesenheits-Marker ── unabhängig von `summary`, ein
+          Tag kann Abwesenheiten OHNE Aufträge haben. Höchstens zwei Punkte
+          (Urlaub, Krank) — nie einer je Mitarbeiter. */}
+      {hasAbsence ? (
+        <View style={[styles.absenceRow, !inMonth && styles.summaryMuted]}>
+          {absenceTypes!.map((type) => (
+            <View
+              key={type}
+              style={[
+                styles.absenceDot,
+                {
+                  backgroundColor:
+                    type === "vacation" ? theme.colors.primary : theme.colors.statusOpen,
+                },
+              ]}
+            />
+          ))}
         </View>
       ) : null}
     </TouchableOpacity>
@@ -260,6 +295,22 @@ function createStyles(theme: AppTheme) {
     dot: {
       width: 4.5,
       height: 4.5,
+      borderRadius: theme.radius.full,
+    },
+
+    // ── Phase D: Abwesenheits-Marker (eigene Zeile, unabhängig von `summary`)
+    absenceRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 3,
+    },
+    // Etwas größer als die Status-Punkte: sie stehen ohne Pille daneben und
+    // sollen trotzdem als eigenes Signal erkennbar bleiben, nicht als
+    // vierter Status-Punkt missverstanden werden.
+    absenceDot: {
+      width: 5.5,
+      height: 5.5,
       borderRadius: theme.radius.full,
     },
   });

--- a/features/jobs/components/DayAgendaSheet.tsx
+++ b/features/jobs/components/DayAgendaSheet.tsx
@@ -20,7 +20,9 @@ import JobCard from "@/components/JobCard";
 import { ErrorBanner } from "@/components/ui";
 import type { AppTheme } from "@/constants/theme";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import type { Absence } from "@/types/absence";
 import type { Job } from "@/types/job";
+import { formatAbsenceDateRange } from "@/utils/absenceFormat";
 import { formatDayLabel } from "@/utils/calendarMonth";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
@@ -64,6 +66,20 @@ type Props = {
    * ("dir keine Aufträge zugewiesen") — unverändert, wenn nicht übergeben.
    */
   emptyMessage?: string;
+  /**
+   * Phase D — Abwesenheiten dieses Tages, GETRENNT von den Aufträgen
+   * angezeigt (eigener "Abwesenheiten"-Abschnitt, nie als JobCard). `undefined`
+   * (Default) = bestehendes Verhalten unverändert, KEIN zweiter Abschnitt —
+   * bestehende Aufrufer, die das nicht übergeben, sehen keine Änderung.
+   * Ein leeres Array zeigt bewusst ebenfalls keinen Abschnitt (nichts zu zeigen).
+   */
+  absences?: Absence[];
+  /**
+   * Tippen auf eine Abwesenheits-Zeile. Ohne Handler ist die Zeile nicht
+   * antippbar (z. B. im Mitarbeiter-Kalender: rein lesend, siehe dortigen
+   * Screen-Kommentar).
+   */
+  onOpenAbsence?: (absence: Absence) => void;
 };
 
 export function DayAgendaSheet({
@@ -79,11 +95,18 @@ export function DayAgendaSheet({
   onDismissError,
   showEmployeeName = false,
   emptyMessage = "Für diesen Tag sind dir keine Aufträge zugewiesen.",
+  absences,
+  onOpenAbsence,
 }: Props) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const dayLabel = useMemo(() => (dayKey ? formatDayLabel(dayKey) : ""), [dayKey]);
+  // Zwei-Abschnitte-Layout nur, wenn der Aufrufer absences überhaupt
+  // übergibt (auch leeres Array zählt) — ein Aufrufer, der die Prop
+  // weglässt, sieht exakt das bisherige Ein-Abschnitt-Layout.
+  const showSections = absences !== undefined;
+  const hasAbsences = !!absences && absences.length > 0;
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
@@ -124,6 +147,13 @@ export function DayAgendaSheet({
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
+            {/* Phase D: eigener "Aufträge"-Titel nur im Zwei-Abschnitte-
+                Layout — sonst bliebe "Keine Aufträge" unten mehrdeutig,
+                sobald daneben ein Abwesenheiten-Abschnitt steht. */}
+            {showSections ? (
+              <Text style={styles.sectionLabel}>Aufträge</Text>
+            ) : null}
+
             {/* Kann eintreten, wenn der letzte Auftrag des Tages bei offenem
                 Sheet per Realtime verschwindet — dann hier eine ruhige Zeile
                 statt einer leeren Fläche. */}
@@ -143,10 +173,89 @@ export function DayAgendaSheet({
                 onComplete={canRunActions(job) ? () => onComplete(job.id) : undefined}
               />
             ))}
+
+            {hasAbsences ? (
+              <>
+                <Text style={[styles.sectionLabel, styles.absenceSectionLabel]}>
+                  Abwesenheiten
+                </Text>
+                {absences!.map((absence) => (
+                  <AbsenceAgendaRow
+                    key={absence.id}
+                    absence={absence}
+                    onPress={onOpenAbsence ? () => onOpenAbsence(absence) : undefined}
+                    theme={theme}
+                    styles={styles}
+                  />
+                ))}
+              </>
+            ) : null}
           </ScrollView>
         </Pressable>
       </Pressable>
     </Modal>
+  );
+}
+
+// Phase D — eine Zeile im "Abwesenheiten"-Abschnitt. Bewusst KEIN JobCard-
+// Nachbau: Absenz ist kein Auftrag (siehe CLAUDE.md), eine schlichte Zeile
+// reicht (Name, Typ, Zeitraum). Keine Genehmigen/Ablehnen-Aktionen — der
+// Kalender ist Überblick, nicht der Review-Workflow (siehe
+// features/absences/admin/AdminAbsencesScreen.tsx dafür).
+function AbsenceAgendaRow({
+  absence,
+  onPress,
+  theme,
+  styles,
+}: {
+  absence: Absence;
+  onPress?: () => void;
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  const isVacation = absence.type === "vacation";
+
+  return (
+    <TouchableOpacity
+      style={styles.absenceRow}
+      onPress={onPress}
+      disabled={!onPress}
+      activeOpacity={0.7}
+      accessibilityRole={onPress ? "button" : undefined}
+      accessibilityLabel={
+        onPress
+          ? `${absence.employeeName}, ${isVacation ? "Urlaub" : "Krank"}, Details öffnen`
+          : undefined
+      }
+    >
+      <View
+        style={[
+          styles.absenceRowIcon,
+          {
+            backgroundColor: isVacation
+              ? theme.colors.primaryContainer
+              : theme.colors.statusOpenBg,
+          },
+        ]}
+      >
+        <Ionicons
+          name={isVacation ? "sunny-outline" : "medkit-outline"}
+          size={15}
+          color={isVacation ? theme.colors.primary : theme.colors.statusOpen}
+        />
+      </View>
+      <View style={styles.absenceRowText}>
+        <Text style={styles.absenceRowName} numberOfLines={1}>
+          {absence.employeeName}
+        </Text>
+        <Text style={styles.absenceRowMeta} numberOfLines={1}>
+          {isVacation ? "Urlaub" : "Krank"} · {formatAbsenceDateRange(absence)}
+        </Text>
+      </View>
+      {onPress ? (
+        <Ionicons name="chevron-forward" size={16} color={theme.colors.onSurfaceVariant} />
+      ) : null}
+    </TouchableOpacity>
   );
 }
 
@@ -219,6 +328,51 @@ function createStyles(theme: AppTheme) {
       paddingVertical: theme.spacing.md,
       textAlign: "center",
       fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+
+    // ── Phase D: Abschnitts-Titel + Abwesenheits-Zeilen
+    sectionLabel: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurfaceVariant,
+      textTransform: "uppercase",
+      letterSpacing: theme.typography.letterSpacing.wide,
+    },
+    // Etwas Abstand zum vorherigen Abschnitt (Aufträge/leere Zeile davor).
+    absenceSectionLabel: {
+      marginTop: theme.spacing.xs,
+    },
+    absenceRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.sm,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.surfaceContainerHigh,
+    },
+    absenceRowIcon: {
+      width: 30,
+      height: 30,
+      borderRadius: theme.radius.md,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    absenceRowText: {
+      flex: 1,
+    },
+    absenceRowName: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    absenceRowMeta: {
+      marginTop: 1,
+      fontSize: theme.typography.size.xs,
       fontFamily: theme.typography.family.regular,
       color: theme.colors.onSurfaceVariant,
     },

--- a/features/jobs/components/MonthGrid.tsx
+++ b/features/jobs/components/MonthGrid.tsx
@@ -20,6 +20,7 @@
 import type { AppTheme } from "@/constants/theme";
 import { CalendarDayCell } from "@/features/jobs/components/CalendarDayCell";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AbsenceType } from "@/types/absence";
 import { buildMonthMatrix, type DaySummary } from "@/utils/calendarMonth";
 import { WEEKDAYS } from "@/utils/recurrence";
 import React, { useMemo } from "react";
@@ -34,6 +35,12 @@ type Props = {
   todayKey: string;
   /** Verdichtete Tagesinfo je Kalendertag (fehlt = keine Aufträge). */
   summaries: Map<string, DaySummary>;
+  /**
+   * Phase D — vorkommende Abwesenheits-TYPEN je Kalendertag (fehlt = keine
+   * aktive Abwesenheit). Additiv: Aufrufer ohne diese Prop verhalten sich
+   * unverändert (Employee-Kalender kann sie weglassen).
+   */
+  absenceMarkers?: Map<string, AbsenceType[]>;
   onSelectDay: (key: string) => void;
 };
 
@@ -42,6 +49,7 @@ export function MonthGrid({
   selectedKey,
   todayKey,
   summaries,
+  absenceMarkers,
   onSelectDay,
 }: Props) {
   const theme = useAppTheme();
@@ -76,6 +84,7 @@ export function MonthGrid({
                 isToday={cell.key === todayKey}
                 isSelected={cell.key === selectedKey}
                 summary={summaries.get(cell.key)}
+                absenceTypes={absenceMarkers?.get(cell.key)}
                 onSelectDay={onSelectDay}
               />
             ))}

--- a/features/jobs/hooks/useAssignmentAbsenceGuard.ts
+++ b/features/jobs/hooks/useAssignmentAbsenceGuard.ts
@@ -1,0 +1,71 @@
+// features/jobs/hooks/useAssignmentAbsenceGuard.ts
+// Phase D — EIN wiederverwendbarer Speichern-Ablauf für Job erstellen/
+// bearbeiten (single UND recurring, Create UND Edit): prüft Zuweisung ×
+// Abwesenheit einmal vor dem eigentlichen Speichern, zeigt bei Konflikten
+// EINE Warnung, übergibt danach unverändert an performSave().
+//
+// attemptSave() → checkAbsenceConflicts() → keine Konflikte → performSave()
+//                                          → Konflikte → Warnung
+//                                              → bestätigt → performSave()
+//                                              → abgebrochen → nichts (Formular unangetastet)
+//
+// Die Konflikt-Prüfung SPEICHERT SELBST NICHTS — sie ruft ausschließlich
+// die übergebene performSave() auf, nie eigene Schreib-Operationen.
+
+import { useCallback, useRef } from "react";
+import {
+  checkAssignmentAbsenceConflicts,
+  formatAssignmentAbsenceWarning,
+  type AssignmentAbsenceCheckInput,
+} from "@/features/jobs/utils/assignmentAbsenceWarning";
+import { confirmDialog } from "@/utils/dialogs";
+
+export function useAssignmentAbsenceGuard() {
+  // Re-Entrancy-Schutz für den Prüfungs-/Warnungs-Ablauf selbst (getrennt
+  // vom submittingRef der Aufrufer-Screens, der das eigentliche
+  // Doppel-Absenden abdeckt): verhindert eine zweite Prüfung, während der
+  // Warn-Dialog der ersten noch auf eine Antwort wartet.
+  const checkingRef = useRef(false);
+
+  const guardSave = useCallback(
+    async (
+      input: AssignmentAbsenceCheckInput,
+      performSave: () => Promise<void>,
+    ): Promise<void> => {
+      if (checkingRef.current) return;
+      checkingRef.current = true;
+      try {
+        let conflicts: Awaited<ReturnType<typeof checkAssignmentAbsenceConflicts>>;
+        try {
+          conflicts = await checkAssignmentAbsenceConflicts(input);
+        } catch {
+          // Die Prüfung ist rein informativ (WARNUNG, NIE SPERRE). Ein
+          // Fehler hier (z. B. Netzwerk) darf das Speichern nicht
+          // verhindern — der Admin muss immer speichern können.
+          conflicts = [];
+        }
+
+        if (conflicts.length === 0) {
+          await performSave();
+          return;
+        }
+
+        const { title, message, confirmLabel } = formatAssignmentAbsenceWarning(
+          conflicts,
+          input.jobType,
+        );
+        const confirmed = await confirmDialog({ title, message, confirmLabel });
+        if (confirmed) {
+          await performSave();
+        }
+        // Abbrechen: bewusst kein performSave(), keine Fehlermeldung — das
+        // Formular bleibt exakt so stehen, wie der Admin es verlassen hat.
+      } finally {
+        checkingRef.current = false;
+      }
+    },
+    [],
+  );
+
+  return { guardSave };
+}

--- a/features/jobs/utils/assignmentAbsenceWarning.ts
+++ b/features/jobs/utils/assignmentAbsenceWarning.ts
@@ -1,0 +1,162 @@
+// features/jobs/utils/assignmentAbsenceWarning.ts
+// Phase D — orchestriert die Zuweisungs-Konflikt-Prüfung (Termin(e) ×
+// aktive Abwesenheiten) für Job erstellen/bearbeiten und formatiert das
+// Ergebnis als EINE Warnung (nie eine je Mitarbeiter/Termin).
+//
+// WARNUNG, NIE SPERRE: ein Fehler bei der Prüfung selbst (Netzwerk etc.)
+// blockiert das Speichern NICHT — die Prüfung ist rein informativ, siehe
+// useAssignmentAbsenceGuard.
+
+import { getActiveAbsencesForEmployeesInRange } from "@/services/absences/absenceConflicts";
+import type { AbsenceType } from "@/types/absence";
+import type { EmployeeOption, JobType } from "@/types/job";
+import {
+  findAssignmentConflicts,
+  type AssignmentAbsenceConflict,
+} from "@/utils/absenceConflicts";
+import { formatDayMonth } from "@/utils/absenceFormat";
+import { previewRecurringOccurrenceDates } from "@/utils/recurringOccurrencePreview";
+import type { WeekdayKey } from "@/utils/recurrence";
+
+export type AssignmentAbsenceCheckInput = {
+  employeeIds: string[];
+  employees: EmployeeOption[];
+  jobType: JobType;
+  /** "YYYY-MM-DD" — nur bei jobType "single" relevant. */
+  singleDate: string | null;
+  /** nur bei jobType "recurring" relevant. */
+  recurringDays: WeekdayKey[];
+  recurrenceStartDate: string | null;
+  recurrenceEndDate: string | null;
+};
+
+/**
+ * Ermittelt Kandidaten-Termine aus den AKTUELLEN Formularwerten (single:
+ * genau ein Tag; recurring: über previewRecurringOccurrenceDates — spiegelt
+ * exakt den Server-Horizont, siehe dort) und prüft sie in EINER gebündelten
+ * Abfrage gegen aktive Abwesenheiten der ausgewählten Mitarbeiter.
+ *
+ * Leeres Ergebnis bei: keine Zuweisung, keine gültigen Kandidaten-Termine
+ * (z. B. Datum noch nicht gewählt), oder keine Konflikte gefunden.
+ */
+export async function checkAssignmentAbsenceConflicts(
+  input: AssignmentAbsenceCheckInput,
+): Promise<AssignmentAbsenceConflict[]> {
+  if (input.employeeIds.length === 0) return [];
+
+  const candidateDates =
+    input.jobType === "single"
+      ? input.singleDate
+        ? [input.singleDate]
+        : []
+      : previewRecurringOccurrenceDates({
+          recurringDays: input.recurringDays,
+          recurrenceStartDate: input.recurrenceStartDate,
+          recurrenceEndDate: input.recurrenceEndDate,
+        });
+
+  if (candidateDates.length === 0) return [];
+
+  let from = candidateDates[0];
+  let to = candidateDates[0];
+  for (const date of candidateDates) {
+    if (date < from) from = date;
+    if (date > to) to = date;
+  }
+
+  const absences = await getActiveAbsencesForEmployeesInRange({
+    employeeIds: input.employeeIds,
+    from,
+    to,
+  });
+  if (absences.length === 0) return [];
+
+  const nameById = new Map(input.employees.map((e) => [e.id, e.fullName]));
+  const assignments = input.employeeIds.flatMap((employeeId) =>
+    candidateDates.map((date) => ({
+      employeeId,
+      employeeName: nameById.get(employeeId) ?? "Unbekannt",
+      date,
+    })),
+  );
+
+  return findAssignmentConflicts(absences, assignments);
+}
+
+export type AssignmentAbsenceWarningText = {
+  title: string;
+  message: string;
+  confirmLabel: string;
+};
+
+const MAX_PREVIEW_ROWS = 5;
+
+function typeLabel(type: AbsenceType): string {
+  return type === "vacation" ? "Urlaub" : "Krank";
+}
+
+/**
+ * Formatiert die gefundenen Konflikte als EINE Warnung — nie eine je
+ * Mitarbeiter/Termin (siehe CLAUDE.md-Vorgabe / Phase-D-Anforderung 8).
+ * Drei Formen, je nach Auftragstyp und Konfliktzahl:
+ *   - recurring: "Bei N geplanten Einsätzen gibt es Abwesenheiten: …"
+ *   - single, genau ein Konflikt: "Lena ist am 18.08. im Urlaub."
+ *   - single, mehrere Konflikte: "N Mitarbeiter sind an diesem Tag abwesend: …"
+ */
+export function formatAssignmentAbsenceWarning(
+  conflicts: AssignmentAbsenceConflict[],
+  jobType: JobType,
+): AssignmentAbsenceWarningText {
+  if (jobType === "recurring") {
+    const rows = conflicts
+      .slice(0, MAX_PREVIEW_ROWS)
+      .map((c) => `• ${formatDayMonth(c.date)} — ${c.employeeName} (${typeLabel(c.type)})`);
+    const remaining = conflicts.length - rows.length;
+
+    const lines = [
+      `Bei ${conflicts.length} geplanten ${
+        conflicts.length === 1 ? "Einsatz" : "Einsätzen"
+      } gibt es Abwesenheiten:`,
+      "",
+      ...rows,
+      ...(remaining > 0 ? [`+ ${remaining} weitere`] : []),
+    ];
+
+    return {
+      title: "Abwesenheiten gefunden",
+      message: lines.join("\n"),
+      confirmLabel: "Trotzdem erstellen",
+    };
+  }
+
+  // single: genau ein Mitarbeiter, ein Termin, ein Konflikt → Satzform.
+  if (conflicts.length === 1) {
+    const c = conflicts[0];
+    return {
+      title: "Abwesenheit gefunden",
+      message: `${c.employeeName} ist am ${formatDayMonth(c.date)} ${
+        c.type === "vacation" ? "im Urlaub" : "krank gemeldet"
+      }.`,
+      confirmLabel: "Trotzdem zuweisen",
+    };
+  }
+
+  const uniqueEmployees = new Set(conflicts.map((c) => c.employeeId)).size;
+  const rows = conflicts
+    .slice(0, MAX_PREVIEW_ROWS)
+    .map((c) => `• ${c.employeeName} — ${typeLabel(c.type)}`);
+  const remaining = conflicts.length - rows.length;
+
+  const lines = [
+    `${uniqueEmployees} Mitarbeiter sind an diesem Tag abwesend:`,
+    "",
+    ...rows,
+    ...(remaining > 0 ? [`+ ${remaining} weitere`] : []),
+  ];
+
+  return {
+    title: "Abwesenheiten gefunden",
+    message: lines.join("\n"),
+    confirmLabel: "Trotzdem zuweisen",
+  };
+}

--- a/services/absences/absenceConflicts.ts
+++ b/services/absences/absenceConflicts.ts
@@ -1,0 +1,57 @@
+// services/absences/absenceConflicts.ts
+// Phase D — Kalender-Abwesenheiten + Zuweisungs-Warnung.
+//
+// Eine gebündelte Abfrage für die Zuweisungs-Konflikt-Prüfung: aktive
+// Abwesenheiten mehrerer Mitarbeiter über einen begrenzten Zeitraum, in
+// EINEM Query statt einer Abfrage je Mitarbeiter. RLS ("admin read company
+// absences") beschränkt bereits auf die eigene Firma — kein RPC nötig,
+// gleiches Muster wie getCompanyAbsencesInRange().
+//
+// Nur für den Admin-Zuweisungspfad (JobFormFields/EditJobScreen) gedacht.
+// Die reine Konflikt-Zuordnung (Abwesenheit × Termin-Datum) lebt getrennt in
+// utils/absenceConflicts.ts — dort ohne Supabase-Abhängigkeit, hier nur die
+// Netzwerk-Abfrage.
+
+import { supabase } from "@/lib/supabase";
+import {
+  ABSENCE_SELECT,
+  ACTIVE_ABSENCE_FILTER_OR,
+  mapAbsence,
+  type AbsenceRow,
+} from "@/services/absences/absences.service";
+import type { Absence } from "@/types/absence";
+import { toUserMessage } from "@/utils/userMessages";
+
+/**
+ * Aktive Abwesenheiten (genehmigter Urlaub / gemeldete Krankheit) der
+ * übergebenen Mitarbeiter mit echter Zeitraum-Überschneidung zu [from, to].
+ * EIN Query für alle übergebenen IDs (kein Loop pro Mitarbeiter).
+ *
+ * Leeres employeeIds-Array → leeres Ergebnis, ohne Netzwerk-Aufruf (kein
+ * Job ohne Zuweisung kann einen Konflikt haben).
+ */
+export async function getActiveAbsencesForEmployeesInRange(params: {
+  employeeIds: string[];
+  /** "YYYY-MM-DD", inklusive */
+  from: string;
+  /** "YYYY-MM-DD", inklusive */
+  to: string;
+}): Promise<Absence[]> {
+  const uniqueIds = Array.from(new Set(params.employeeIds));
+  if (uniqueIds.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .in("employee_id", uniqueIds)
+    .or(ACTIVE_ABSENCE_FILTER_OR)
+    .lte("start_date", params.to)
+    .or(`end_date.is.null,end_date.gte.${params.from}`);
+
+  if (error) {
+    throw new Error(
+      toUserMessage(error, "Die Abwesenheiten konnten nicht geprüft werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}

--- a/services/absences/absences.service.ts
+++ b/services/absences/absences.service.ts
@@ -135,6 +135,15 @@ function translateRpcError(err: unknown, fallback: string): string {
 export const ABSENCE_SELECT =
   "id, company_id, employee_id, employee_name_snapshot, type, status, start_date, end_date, employee_note, admin_note, reviewed_at, created_at, updated_at";
 
+// "Aktive Abwesenheit" (Phase D, Kalender/Zuweisungs-Warnung): NUR
+// genehmigter Urlaub oder gemeldete Krankheit — dieselbe Definition wie in
+// getCurrentCompanyAbsences() (adminAbsences.service.ts, Architektur-Audit
+// Phase C, Abschnitt 3B). Als Konstante exportiert statt den literalen
+// PostgREST-.or()-Ausdruck an drei Stellen zu wiederholen (hier,
+// adminAbsences.service.ts, absenceConflicts.ts).
+export const ACTIVE_ABSENCE_FILTER_OR =
+  "and(type.eq.vacation,status.eq.approved),and(type.eq.sickness,status.eq.reported)";
+
 /** Lädt die eigenen Abwesenheiten des aktuellen Mitarbeiters (RLS-skopiert). */
 export async function getMyAbsences(): Promise<Absence[]> {
   const { data, error } = await supabase
@@ -142,6 +151,42 @@ export async function getMyAbsences(): Promise<Absence[]> {
     .select(ABSENCE_SELECT)
     .order("start_date", { ascending: false });
 
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/**
+ * Eigene Abwesenheiten mit ECHTER Zeitraum-Überschneidung zu [from, to]
+ * (Phase D, Kalenderansicht) — anders als getMyAbsences() (unbegrenzt, kein
+ * Zeitraum) oder ein naiver start_date-Filter (siehe getCompanyAbsencesInRange
+ * für die ausführliche Begründung des Überschneidungs-Prädikats). RLS
+ * beschränkt bereits auf die eigenen Zeilen ("employee read own absences").
+ */
+export async function getOwnAbsencesInRange(params: {
+  /** "YYYY-MM-DD", inklusive */
+  from: string;
+  /** "YYYY-MM-DD", inklusive */
+  to: string;
+  /** true = nur genehmigter Urlaub / gemeldete Krankheit (siehe ACTIVE_ABSENCE_FILTER_OR). */
+  activeOnly?: boolean;
+}): Promise<Absence[]> {
+  let query = supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .lte("start_date", params.to)
+    .or(`end_date.is.null,end_date.gte.${params.from}`)
+    .order("start_date", { ascending: true });
+
+  if (params.activeOnly) {
+    query = query.or(ACTIVE_ABSENCE_FILTER_OR);
+  }
+
+  const { data, error } = await query;
   if (error) {
     throw new Error(
       translateRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),

--- a/services/absences/adminAbsences.service.ts
+++ b/services/absences/adminAbsences.service.ts
@@ -18,6 +18,7 @@
 import { supabase } from "@/lib/supabase";
 import {
   ABSENCE_SELECT,
+  ACTIVE_ABSENCE_FILTER_OR,
   mapAbsence,
   type AbsenceRow,
 } from "@/services/absences/absences.service";
@@ -139,6 +140,49 @@ export async function getCompanyAbsences(params?: {
   if (params?.to) query = query.lte("start_date", params.to);
   if (params?.type) query = query.eq("type", params.type);
   if (params?.status?.length) query = query.in("status", params.status);
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(
+      translateAdminRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
+/**
+ * Firmenweite Abwesenheiten mit ECHTER Zeitraum-Überschneidung zu [from, to]
+ * (Phase D, Admin-Kalender) — bewusst additiv neben getCompanyAbsences()
+ * statt dessen from/to zu verändern (bestehende Aufrufer bleiben unberührt).
+ *
+ * WARUM NICHT getCompanyAbsences({from, to}) WIEDERVERWENDEN:
+ * dessen from/to filtert NUR start_date (Zeilen mit start_date >= from UND
+ * <= to). Ein Urlaub, der VOR dem sichtbaren Monat begann und noch andauert,
+ * würde damit für die Kalenderansicht fälschlich unsichtbar. Das korrekte
+ * Überschneidungs-Prädikat (identisch zu getCurrentCompanyAbsences(), nur
+ * über einen Zeitraum statt einen einzelnen Tag):
+ *   start_date <= to AND (end_date IS NULL OR end_date >= from)
+ */
+export async function getCompanyAbsencesInRange(params: {
+  /** "YYYY-MM-DD", inklusive */
+  from: string;
+  /** "YYYY-MM-DD", inklusive */
+  to: string;
+  /** true = nur genehmigter Urlaub / gemeldete Krankheit (siehe ACTIVE_ABSENCE_FILTER_OR). */
+  activeOnly?: boolean;
+  limit?: number;
+}): Promise<Absence[]> {
+  let query = supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .lte("start_date", params.to)
+    .or(`end_date.is.null,end_date.gte.${params.from}`)
+    .order("start_date", { ascending: true })
+    .limit(params.limit ?? COMPANY_ABSENCES_LIMIT);
+
+  if (params.activeOnly) {
+    query = query.or(ACTIVE_ABSENCE_FILTER_OR);
+  }
 
   const { data, error } = await query;
   if (error) {

--- a/utils/absenceCalendarMarkers.ts
+++ b/utils/absenceCalendarMarkers.ts
@@ -1,0 +1,68 @@
+// utils/absenceCalendarMarkers.ts
+// Phase D — reine Zuordnung "Kalendertag × aktive Abwesenheiten" für den
+// Monatskalender (Zellen-Marker + Tages-Agenda). Getrennt von
+// utils/calendarMonth.ts, weil Absenzen über ZEITRÄUME laufen (start_date/
+// end_date), nicht über ein einzelnes Datumsfeld wie job.date — die
+// Job-Gruppierung dort (groupJobsByDateKey) passt für Absenzen nicht.
+//
+// Bewusst OHNE React/Theme-Import: rein und testbar, gleiches Prinzip wie
+// calendarMonth.ts.
+
+import type { Absence, AbsenceType } from "@/types/absence";
+import { keyToDate } from "@/utils/calendarMonth";
+import { formatDateISO } from "@/utils/date";
+
+function addDaysToKey(dateKey: string, days: number): string {
+  const d = keyToDate(dateKey);
+  const next = new Date(d.getFullYear(), d.getMonth(), d.getDate() + days);
+  return formatDateISO(next) ?? dateKey;
+}
+
+/**
+ * Verteilt jede Abwesenheit auf jeden Kalendertag, den sie innerhalb von
+ * [range.from, range.to] abdeckt (offen-endige Krankheit: bis range.to
+ * geklammert — weiter muss nicht iteriert werden, außerhalb der Sichtbarkeit
+ * ist ohnehin nichts zu zeigen). Ein Tag mit mehreren Abwesenheiten trägt
+ * mehrere Einträge — die Verdichtung auf Marker-Typen passiert erst in
+ * `absenceTypesForDay`.
+ */
+export function buildAbsenceDayIndex(
+  absences: Absence[],
+  range: { from: string; to: string },
+): Map<string, Absence[]> {
+  const map = new Map<string, Absence[]>();
+
+  for (const absence of absences) {
+    const start = absence.startDate > range.from ? absence.startDate : range.from;
+    const end =
+      absence.endDate && absence.endDate < range.to ? absence.endDate : range.to;
+    if (start > end) continue;
+
+    let cursor = start;
+    while (cursor <= end) {
+      const list = map.get(cursor);
+      if (list) list.push(absence);
+      else map.set(cursor, [absence]);
+      cursor = addDaysToKey(cursor, 1);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Vorkommende Abwesenheits-TYPEN eines Tages, kanonisch geordnet
+ * (Urlaub → Krank) — höchstens einer je Typ, unabhängig davon, wie viele
+ * Mitarbeiter betroffen sind (Phase-D-Anforderung: nie ein Marker je
+ * Mitarbeiter).
+ */
+export function absenceTypesForDay(
+  dayAbsences: Absence[] | undefined,
+): AbsenceType[] {
+  if (!dayAbsences || dayAbsences.length === 0) return [];
+  const types = new Set(dayAbsences.map((a) => a.type));
+  const ordered: AbsenceType[] = [];
+  if (types.has("vacation")) ordered.push("vacation");
+  if (types.has("sickness")) ordered.push("sickness");
+  return ordered;
+}

--- a/utils/absenceConflicts.ts
+++ b/utils/absenceConflicts.ts
@@ -1,0 +1,74 @@
+// utils/absenceConflicts.ts
+// Phase D — reine Zuordnung "Termin-Datum × aktive Abwesenheit", ohne
+// Supabase-Abhängigkeit (testbar, wiederverwendbar für Einzel-Zuweisung UND
+// Recurring-Vorschau). Die Netzwerk-Abfrage lebt getrennt in
+// services/absences/absenceConflicts.ts.
+//
+// ZEITZONEN-SEMANTIK: reine "YYYY-MM-DD"-String-Vergleiche, kein
+// `new Date(dateString)` — Absenzen und Job-Termine sind beides
+// zeitzonenfreie Kalendertage (siehe CLAUDE.md, Abschnitt "Datum/Zeit").
+
+import type { Absence, AbsenceType } from "@/types/absence";
+
+export type AssignmentAbsenceConflict = {
+  employeeId: string;
+  employeeName: string;
+  absenceId: string;
+  type: AbsenceType;
+  /** "YYYY-MM-DD" — der konkrete Termin-/Occurrence-Tag, der kollidiert. */
+  date: string;
+  startDate: string;
+  endDate: string | null;
+};
+
+export type CandidateAssignment = {
+  employeeId: string;
+  employeeName: string;
+  /** "YYYY-MM-DD" */
+  date: string;
+};
+
+/**
+ * Findet jede Kombination aus geplantem Termin und aktiver Abwesenheit
+ * desselben Mitarbeiters. `absences` sollte bereits nur aktive (genehmigter
+ * Urlaub / gemeldete Krankheit) Zeilen enthalten (siehe
+ * getActiveAbsencesForEmployeesInRange) — diese Funktion prüft das NICHT
+ * erneut, sie ordnet nur zu.
+ *
+ * Mehrfachtreffer bewusst NICHT auf einen pro Mitarbeiter eingedampft:
+ * unterschiedliche Termin-Tage oder unterschiedliche Abwesenheits-Zeilen
+ * (z. B. Urlaub UND Krankheit desselben Mitarbeiters) sind je ein echter,
+ * eigener Konflikt. Nur exakte Duplikate (gleicher Mitarbeiter, gleiche
+ * Abwesenheit, gleicher Termin-Tag) werden einmalig gezählt.
+ */
+export function findAssignmentConflicts(
+  absences: Absence[],
+  assignments: CandidateAssignment[],
+): AssignmentAbsenceConflict[] {
+  const conflicts: AssignmentAbsenceConflict[] = [];
+  const seen = new Set<string>();
+
+  for (const assignment of assignments) {
+    for (const absence of absences) {
+      if (absence.employeeId !== assignment.employeeId) continue;
+      if (assignment.date < absence.startDate) continue;
+      if (absence.endDate !== null && assignment.date > absence.endDate) continue;
+
+      const key = `${assignment.employeeId}|${absence.id}|${assignment.date}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      conflicts.push({
+        employeeId: assignment.employeeId,
+        employeeName: assignment.employeeName,
+        absenceId: absence.id,
+        type: absence.type,
+        date: assignment.date,
+        startDate: absence.startDate,
+        endDate: absence.endDate,
+      });
+    }
+  }
+
+  return conflicts;
+}

--- a/utils/recurringOccurrencePreview.ts
+++ b/utils/recurringOccurrencePreview.ts
@@ -1,0 +1,96 @@
+// utils/recurringOccurrencePreview.ts
+// Phase D — spiegelt die Horizont-/Wochentag-Logik der SQL-Funktion
+// generate_job_occurrences client-seitig, um VOR dem Speichern zu wissen,
+// welche Termine der Server gleich materialisieren wird (für die
+// Abwesenheits-Konflikt-Vorschau bei Recurring-Jobs, Create UND Edit).
+//
+// Verifizierte Quelle (nicht angenommen, direkt im SQL gelesen):
+// supabase/migrations/20260813000000_planned_duration_foundation.sql,
+// Funktion generate_job_occurrences — die aktuell gültige Fassung
+// (unveraendert gegenueber 20260728000000_occurrence_assignment_inheritance.sql
+// bis auf die dort NICHT relevante planned_duration_minutes-Spalte).
+//
+//   generation_start := greatest(
+//     coalesce(recurrence_start_date, current_date),
+//     current_date
+//   );
+//   hard_limit := generation_start + interval '730 days';
+//   generation_end := least(
+//     coalesce(recurrence_end_date, generation_start + interval '3 months'),
+//     hard_limit
+//   );
+//   -- Schleife check_date von generation_start bis generation_end (inklusiv,
+//   -- <=), Wochentag über isodow (Mo=1…So=7) gegen recurring_days geprüft.
+//
+// Diese Funktion ruft die RPC NICHT auf — reine Terminvorschau aus den
+// AKTUELLEN Formularwerten, damit Edit (wo bereits materialisierte
+// Occurrences existieren können, die den ungespeicherten Formularstand aber
+// noch nicht widerspiegeln) genau wie Create funktioniert.
+
+import { keyToDate } from "@/utils/calendarMonth";
+import { formatDateISO } from "@/utils/date";
+import { getWeekdayKey, type WeekdayKey } from "@/utils/recurrence";
+
+// Bounded wie die Server-Funktion — verhindert eine unbegrenzte Schleife bei
+// fehlendem Enddatum.
+const HARD_LIMIT_DAYS = 730;
+const DEFAULT_HORIZON_MONTHS = 3;
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
+}
+
+function startOfToday(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+/**
+ * Liefert die "YYYY-MM-DD"-Termine, die generate_job_occurrences für die
+ * übergebene Regel JETZT materialisieren würde — begrenzt auf den echten
+ * Server-Horizont (min. Regel-Ende bzw. +3 Monate, hart gedeckelt auf
+ * 730 Tage ab Start). Leeres Array bei fehlenden Wochentagen oder wenn der
+ * Zeitraum bereits vollständig in der Vergangenheit liegt (Server generiert
+ * dann ebenfalls nichts).
+ */
+export function previewRecurringOccurrenceDates(params: {
+  recurringDays: WeekdayKey[];
+  /** "YYYY-MM-DD" oder null */
+  recurrenceStartDate: string | null;
+  /** "YYYY-MM-DD" oder null */
+  recurrenceEndDate: string | null;
+}): string[] {
+  if (params.recurringDays.length === 0) return [];
+
+  const today = startOfToday();
+  const ruleStart = params.recurrenceStartDate
+    ? keyToDate(params.recurrenceStartDate)
+    : today;
+
+  const generationStart = ruleStart.getTime() > today.getTime() ? ruleStart : today;
+  const hardLimit = addDays(generationStart, HARD_LIMIT_DAYS);
+
+  const ruleEnd = params.recurrenceEndDate
+    ? keyToDate(params.recurrenceEndDate)
+    : addMonths(generationStart, DEFAULT_HORIZON_MONTHS);
+
+  const generationEnd = ruleEnd.getTime() < hardLimit.getTime() ? ruleEnd : hardLimit;
+
+  const days = new Set(params.recurringDays);
+  const dates: string[] = [];
+
+  let cursor = generationStart;
+  while (cursor.getTime() <= generationEnd.getTime()) {
+    if (days.has(getWeekdayKey(cursor))) {
+      const key = formatDateISO(cursor);
+      if (key) dates.push(key);
+    }
+    cursor = addDays(cursor, 1);
+  }
+
+  return dates;
+}


### PR DESCRIPTION
## Summary

Implements the approved Phase D plan: calendar absence visibility + warning-only assignment conflict checks. No backend change (no migration, no new RPC, no notification/timesheet/realtime changes) — everything is built against existing `employee_absences` RLS and the already-materialized recurring occurrence rows.

### Calendar behavior
- **Admin Calendar** ([AdminJobsCalendarScreen.tsx](features/jobs/AdminJobsCalendarScreen.tsx)): one bounded absence query per visible grid range (alongside the existing job-occurrence query), month-cell markers (≤1 Urlaub dot + ≤1 Krank dot per day, never one per employee), and a new **Alle / Urlaub / Krank** filter row, independent of the existing employee/status filters.
- **Filter semantics**: the absence filter controls only which absence markers/agenda rows are visible — it never hides jobs. "Alle" shows both active absence types. The employee filter also narrows absence rows (e.g. Employee=Lena + Absence=Urlaub → only Lena's vacation).
- **Day agenda** ([DayAgendaSheet.tsx](features/jobs/components/DayAgendaSheet.tsx)): additive `absences`/`onOpenAbsence` props add a separate "Abwesenheiten" section below "Aufträge" — never rendered as a `JobCard`. Existing callers that don't pass `absences` are unaffected (single-section layout unchanged). Admin rows are tappable → Employee Detail; Employee Calendar rows are read-only.
- **Employee Calendar**: shows only the employee's own active (approved vacation / reported sickness) absences via RLS-scoped `getOwnAbsencesInRange`; requested vacation is never shown as an absence marker.

### Assignment warnings
- Runs at **save time** (not on every field change), via a single reusable guard (`useAssignmentAbsenceGuard` → `checkAssignmentAbsenceConflicts` → `formatAssignmentAbsenceWarning`), wired into both job create ([AdminScreen.tsx](features/admin/AdminScreen.tsx)) and edit ([EditJobScreen.tsx](features/jobs/EditJobScreen.tsx)).
- One bounded query (`getActiveAbsencesForEmployeesInRange`) covers all selected employees and all candidate dates — no per-employee/per-occurrence queries.
- Single conflict → sentence warning; multiple employees/dates → one summary (max 5 rows + "+N weitere"), never one dialog per employee.
- **Recurring jobs**: candidate occurrence dates are computed client-side via `previewRecurringOccurrenceDates`, which mirrors the verified `generate_job_occurrences` SQL (`supabase/migrations/20260813000000_planned_duration_foundation.sql`) horizon/weekday logic exactly — since occurrence rows for a brand-new rule don't exist yet at save time, this is the only way to preview conflicts before the RPC runs. Edit reflects the *current* form state, not stale materialized rows.
- Warning uses the existing `confirmDialog` (`utils/dialogs.ts`) — already the app's web-safe `Alert.alert` replacement — rather than a new bespoke modal component.
- Warning-only: cancelling leaves the form untouched; a failure in the conflict check itself never blocks saving.

### Service/query architecture
- `getCompanyAbsencesInRange` / `getOwnAbsencesInRange` (new, additive — existing `getCompanyAbsences`/`getMyAbsences` untouched): true range-overlap predicate (`start_date <= to AND (end_date IS NULL OR end_date >= from)`), not a naive start-date filter.
- `getActiveAbsencesForEmployeesInRange`: one bounded query for N employees.
- `findAssignmentConflicts` / `absenceTypesForDay` / `buildAbsenceDayIndex`: pure, Supabase-free utilities — YYYY-MM-DD string comparisons only, no `new Date(dateString)` UTC-shift risk.

### Security
- Admin reads stay company-scoped via the existing `"admin read company absences"` RLS policy.
- Employee reads stay own-row-scoped via `"employee read own absences"`.
- No new RPC, no SECURITY DEFINER function, no absence writes anywhere in this change.

### Verification
- `npx tsc --noEmit` — clean.
- `npm run lint` (`expo lint`) — clean.
- Diff reviewed for scope: no migration, notification, or timesheet files touched.
- **Not verified in a live browser/simulator** — the local Expo web port was already occupied by another process and this session had no simulator access; recommend the manual QA checklist below before merge.

## Manual QA checklist (not yet run)

**Admin Calendar**: normal jobs unchanged · Urlaub marker · Krank marker · both same day · employee+absence filter combos · job-status+absence filter combo · selected day shows separate Aufträge/Abwesenheiten sections.

**Employee Calendar**: approved Urlaub visible · reported Krank visible · requested Urlaub NOT shown as active · own data only.

**Single assignment**: no absence → saves normally · Urlaub → warning · Krank → warning · cancel → form unchanged · confirm → saves.

**Multiple employees**: one absent · multiple absent · one combined modal only.

**Recurring**: absence on one occurrence date · absence spanning multiple dates · open-ended sickness · no false warning on non-occurrence days · edit recurrence reflects current form dates.

**Regression**: normal job create/edit · recurring create/edit · Employee Calendar job rendering · Admin Calendar job rendering/filtering · no flicker/endless refresh · Android layout.

## Remaining risks
- Absence check can go stale mid-session (approved/cancelled while a form is open) — acceptable since the check is advisory-only, never a hard gate.
- No live-device verification performed in this session (see above) — the checklist above should be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)