### PR TITLE
feat(timesheet): Phase E — Abwesenheiten im Stundenzettel

### DIFF
--- a/features/timesheets/TimesheetScreen.tsx
+++ b/features/timesheets/TimesheetScreen.tsx
@@ -28,6 +28,7 @@ import {
   TimeCorrectionSheet,
   type TimeCorrectionTarget,
 } from "@/features/timesheets/components/TimeCorrectionSheet";
+import { TimesheetAbsenceSection } from "@/features/timesheets/components/TimesheetAbsenceSection";
 import { useTimesheet } from "@/features/timesheets/hooks/useTimesheet";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import type { TimesheetGap } from "@/types/timesheet";
@@ -253,6 +254,15 @@ export default function TimesheetScreen() {
             ))}
           </Card>
         </View>
+      ) : null}
+
+      {/* ── Hinweise + Abwesenheiten (Phase E) ──
+          Für Admin und Mitarbeiter identisch — beide sehen die
+          Abwesenheiten/Hinweise des gewählten Mitarbeiters (in der
+          Eigen-Sicht immer die eigenen). Rendert nichts, solange kein
+          Mitarbeiter/Monat mit Daten geladen ist. */}
+      {data ? (
+        <TimesheetAbsenceSection summary={data.absenceSummary} notices={data.notices} />
       ) : null}
 
       {/* ── Vorschau ── */}

--- a/features/timesheets/components/TimesheetAbsenceSection.tsx
+++ b/features/timesheets/components/TimesheetAbsenceSection.tsx
@@ -1,0 +1,192 @@
+// features/timesheets/components/TimesheetAbsenceSection.tsx
+// Phase E — Abwesenheiten-Abschnitt im Stundenzettel. Additiv, für Admin- UND
+// Mitarbeiter-Sicht identisch (TimesheetScreen übergibt für beide dieselbe
+// TimesheetData) — kein separates Admin-/Employee-Bauteil nötig.
+//
+// WICHTIG (siehe Architektur-Audit Phase E, Abschnitt 4 + CLAUDE.md-Prinzip
+// "keine erfundenen Zahlen"): geplante Minuten werden NIE als "Arbeitszeit"/
+// "Bezahlte Zeit"/"Entgeltfortzahlung" beschriftet — ausschließlich als
+// "Geplante Einsatzzeit". Kalendertage werden NIE als verbrauchte
+// Urlaubstage/Urlaubskonto dargestellt, sondern als reine Kalendertag-Zahl,
+// getrennt von der Zahl der Tage mit tatsächlich geplanten Einsätzen.
+
+import { Card, SectionHeader } from "@/components/ui";
+import type { AppTheme } from "@/constants/theme";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { TimesheetAbsenceSummary, TimesheetNotice } from "@/types/timesheetAbsence";
+import { formatDayMonth } from "@/utils/absenceFormat";
+import { formatDurationHm } from "@/utils/date";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  summary: TimesheetAbsenceSummary | undefined;
+  notices: TimesheetNotice[] | undefined;
+};
+
+function typeLabel(type: "vacation" | "sickness"): string {
+  return type === "vacation" ? "Urlaub" : "Krank";
+}
+
+export function TimesheetAbsenceSection({ summary, notices }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const hasVacation = !!summary && summary.vacationCalendarDays > 0;
+  const hasSickness = !!summary && summary.sicknessCalendarDays > 0;
+  const hasNotices = !!notices && notices.length > 0;
+
+  if (!hasVacation && !hasSickness && !hasNotices) return null;
+
+  return (
+    <>
+      {hasNotices ? (
+        <View style={styles.section}>
+          <SectionHeader
+            title="Hinweise"
+            subtitle="Erfordert keine Aktion, nur zur Information"
+          />
+          <Card padding={0}>
+            {notices!.map((notice, idx) => (
+              <View
+                key={`${notice.date}-${notice.type}`}
+                style={[styles.noticeRow, idx > 0 && styles.rowDivider]}
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={18}
+                  color={theme.colors.onSurfaceVariant}
+                  style={styles.noticeIcon}
+                />
+                <Text style={styles.noticeText}>
+                  Arbeit trotz {notice.absenceType === "vacation" ? "Urlaub" : "gemeldeter Abwesenheit"} am{" "}
+                  {formatDayMonth(notice.date)} ({typeLabel(notice.absenceType)})
+                </Text>
+              </View>
+            ))}
+          </Card>
+        </View>
+      ) : null}
+
+      {hasVacation || hasSickness ? (
+        <View style={styles.section}>
+          <SectionHeader
+            title="Abwesenheiten"
+            subtitle="Urlaub und Krankheit im gewählten Zeitraum"
+          />
+          <Card padding={0}>
+            {hasVacation ? (
+              <AbsenceTypeRow
+                theme={theme}
+                styles={styles}
+                label="Urlaub"
+                calendarDays={summary!.vacationCalendarDays}
+                plannedWorkDays={summary!.vacationPlannedWorkDays}
+                plannedMinutes={summary!.vacationPlannedMinutes}
+              />
+            ) : null}
+            {hasSickness ? (
+              <AbsenceTypeRow
+                theme={theme}
+                styles={styles}
+                label="Krank"
+                calendarDays={summary!.sicknessCalendarDays}
+                plannedWorkDays={summary!.sicknessPlannedWorkDays}
+                plannedMinutes={summary!.sicknessPlannedMinutes}
+                withDivider={hasVacation}
+              />
+            ) : null}
+          </Card>
+        </View>
+      ) : null}
+    </>
+  );
+}
+
+function AbsenceTypeRow({
+  theme,
+  styles,
+  label,
+  calendarDays,
+  plannedWorkDays,
+  plannedMinutes,
+  withDivider,
+}: {
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+  label: string;
+  calendarDays: number;
+  plannedWorkDays: number;
+  plannedMinutes: number;
+  withDivider?: boolean;
+}) {
+  return (
+    <View style={[styles.absenceRow, withDivider && styles.rowDivider]}>
+      <Text style={styles.absenceLabel}>{label}</Text>
+      {plannedWorkDays > 0 ? (
+        <Text style={styles.absencePrimary}>
+          {plannedWorkDays} geplante{plannedWorkDays === 1 ? "r" : ""} Einsatztag
+          {plannedWorkDays === 1 ? "" : "e"} · Geplante Einsatzzeit{" "}
+          {formatDurationHm(plannedMinutes)} h
+        </Text>
+      ) : (
+        <Text style={styles.absencePrimary}>Keine geplanten Einsätze</Text>
+      )}
+      <Text style={styles.absenceSecondary}>
+        {calendarDays} Kalendertag{calendarDays === 1 ? "" : "e"}
+      </Text>
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    section: {
+      marginTop: theme.spacing.lg,
+    },
+    rowDivider: {
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.outlineVariant,
+    },
+
+    // ── Hinweise
+    noticeRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: theme.spacing.sm,
+      padding: theme.spacing.md,
+    },
+    noticeIcon: {
+      marginTop: 2,
+    },
+    noticeText: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+
+    // ── Abwesenheiten
+    absenceRow: {
+      padding: theme.spacing.md,
+      gap: 4,
+    },
+    absenceLabel: {
+      fontSize: theme.typography.size.md,
+      fontFamily: theme.typography.family.semibold,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    absencePrimary: {
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurface,
+    },
+    absenceSecondary: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });
+}

--- a/features/timesheets/hooks/useTimesheet.ts
+++ b/features/timesheets/hooks/useTimesheet.ts
@@ -9,7 +9,8 @@ import {
 } from "@/services/timesheets/timesheet.service";
 import type { TimesheetData } from "@/types/timesheet";
 import type { EmployeeOption } from "@/types/job";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toUserMessage } from "@/utils/userMessages";
 
 // In Version 1 neutraler, fest hinterlegter Firmenname (kein company.name-Fetch).
@@ -91,6 +92,24 @@ export function useTimesheet(
   // bestehenden Dependencies ändert.
   const [reloadToken, setReloadToken] = useState(0);
   const reload = useCallback(() => setReloadToken((n) => n + 1), []);
+
+  // ── Focus-Refresh (Phase E) ──────────────────────────────────────────
+  // Abwesenheiten können auf einem anderen Screen entstehen/sich ändern
+  // (z. B. Admin genehmigt einen Urlaubsantrag) — beim Zurückkehren auf den
+  // Stundenzettel soll das ohne neue Realtime-Verbindung sichtbar werden.
+  // Gleiches Muster wie AbsencesScreen (useFocusEffect + Ref, um den ERSTEN
+  // Fokus beim initialen Mount zu überspringen): der normale Lade-Effekt
+  // unten feuert bereits beim ersten Render — ein zusätzlicher reload() beim
+  // allerersten Fokus wäre ein redundanter Doppel-Request/Flackern.
+  const hasFocusedOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (hasFocusedOnceRef.current) {
+        reload();
+      }
+      hasFocusedOnceRef.current = true;
+    }, [reload]),
+  );
 
   const monthLabel = useMemo(
     () =>

--- a/services/absences/absences.service.ts
+++ b/services/absences/absences.service.ts
@@ -196,6 +196,47 @@ export async function getOwnAbsencesInRange(params: {
   return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
 }
 
+/**
+ * Abwesenheiten EINES Mitarbeiters mit echter Zeitraum-Überschneidung zu
+ * [from, to] (Phase E, Stundenzettel-Abwesenheiten) — bewusst KEIN
+ * `activeOnly`-Filter hier: resolveEffectiveAbsenceDays() filtert selbst
+ * nach dem operativen Aktiv-Prädikat (siehe dort), diese Abfrage liefert
+ * bewusst alle Status, damit ein künftig anderes Prädikat ohne Änderung
+ * dieser Funktion greifen kann.
+ *
+ * FUNKTIONIERT UNVERÄNDERT FÜR BEIDE ROLLEN — keine Rollen-Verzweigung
+ * nötig: RLS beschränkt Mitarbeitende ohnehin auf `employee_id = auth.uid()`
+ * ("employee read own absences"), unabhängig vom hier übergebenen
+ * `employeeId` — ein Mitarbeiter, der (fälschlich) eine fremde ID übergibt,
+ * bekommt schlicht ein leeres Ergebnis. Admins sind firmenweit gelesen
+ * ("admin read company absences"), der `employeeId`-Filter grenzt hier nur
+ * client-seitig auf den gewählten Mitarbeiter ein. Siehe
+ * supabase/migrations/20260816000000_absences_foundation.sql (RLS-Policies).
+ */
+export async function getEmployeeAbsencesInRange(params: {
+  employeeId: string;
+  /** "YYYY-MM-DD", inklusive */
+  from: string;
+  /** "YYYY-MM-DD", inklusive */
+  to: string;
+}): Promise<Absence[]> {
+  const { data, error } = await supabase
+    .from("employee_absences")
+    .select(ABSENCE_SELECT)
+    .eq("employee_id", params.employeeId)
+    .lte("start_date", params.to)
+    .or(`end_date.is.null,end_date.gte.${params.from}`)
+    .order("start_date", { ascending: true });
+
+  if (error) {
+    throw new Error(
+      translateRpcError(error, "Die Abwesenheiten konnten nicht geladen werden."),
+    );
+  }
+
+  return (data ?? []).map((row) => mapAbsence(row as AbsenceRow));
+}
+
 function firstRow(data: AbsenceRow[] | null): Absence {
   const row = data?.[0];
   if (!row) {

--- a/services/timesheets/timesheet.service.ts
+++ b/services/timesheets/timesheet.service.ts
@@ -38,6 +38,7 @@
 // angezeigt (kein 0:00-Eintrag, kein Fallback), siehe mapEntry.
 
 import { supabase } from "@/lib/supabase";
+import { buildTimesheetAbsence } from "@/services/timesheets/timesheetAbsence.service";
 import { buildTimesheetHtml } from "@/services/timesheets/timesheetHtml";
 import type {
   TimesheetData,
@@ -360,6 +361,29 @@ export async function getTimesheet(params: {
     year: "numeric",
   });
 
+  // ── Abwesenheiten (Phase E) ──────────────────────────────────────────
+  // Vollständig ADDITIV und von der obigen Ist-Zeit-Berechnung entkoppelt:
+  // eigene Datei, eigene Abfragen (employee_absences + Occurrences), eigenes
+  // Ergebnis, das hier nur noch ins zurückgegebene Objekt gemerged wird.
+  // `entries`/`totalMinutes`/`needsAttention` oben sind zu diesem Zeitpunkt
+  // bereits vollständig berechnet und werden durch diesen Block nicht mehr
+  // verändert. Dieselben lokalen Monatsgrenzen wie oben, nur als
+  // "YYYY-MM-DD"-Strings (Absenzen/Occurrences sind zeitzonenfreie
+  // Kalendertage, siehe utils/resolveEffectiveAbsenceDays.ts).
+  const monthStartKey = formatDateISO(monthStart)!;
+  // new Date(year, month, 0): `month` ist hier bereits 1-basiert (Parameter),
+  // der Date-Konstruktor erwartet 0-basierte Monate — `month` als Index
+  // adressiert damit bereits den FOLGEMONAT, Tag 0 davon ist der letzte Tag
+  // des gewählten Monats (Standard-JS-Idiom für "letzter Tag des Monats").
+  const monthEndKey = formatDateISO(new Date(year, month, 0))!;
+
+  const { summary: absenceSummary, notices } = await buildTimesheetAbsence({
+    employeeId,
+    from: monthStartKey,
+    to: monthEndKey,
+    entries,
+  });
+
   return {
     companyName,
     employeeId,
@@ -372,6 +396,8 @@ export async function getTimesheet(params: {
     totalLabel: formatDurationHm(totalMinutes),
     jobCount: entries.length,
     needsAttention,
+    absenceSummary,
+    notices,
   };
 }
 

--- a/services/timesheets/timesheetAbsence.service.ts
+++ b/services/timesheets/timesheetAbsence.service.ts
@@ -1,0 +1,132 @@
+// services/timesheets/timesheetAbsence.service.ts
+// Phase E — Stundenzettel-Abwesenheiten: Orchestrierung getrennt von der
+// bestehenden Ist-Zeit-Berechnung (services/timesheets/timesheet.service.ts).
+//
+// WARUM EINE EIGENE DATEI: die bestehende Ist-Zeit-Logik (mapEntry/mapGap,
+// Legacy-Cutoff, geteilte Job-Uhr) ist abrechnungskritisch und darf durch
+// diese rein additive Abwesenheits-Ableitung nicht berührt werden — getrennte
+// Datei macht das strukturell offensichtlich, statt es nur per Kommentar zu
+// behaupten. getTimesheet() ruft am Ende lediglich buildTimesheetAbsence()
+// zusätzlich auf und merged das Ergebnis additiv in TimesheetData.
+//
+// QUELLEN (siehe Architektur-Audit Phase E):
+//   * employee_absences (via getEmployeeAbsencesInRange, RLS-skopiert)
+//   * jobs.planned_duration_minutes der materialisierten Occurrences
+//     (via getScheduleOccurrences, NIE aus tatsächlicher Arbeitszeit oder
+//     scheduled_end abgeleitet)
+//
+// KEINE Occurrence-Abfrage, wenn es im Zeitraum keinen wirksamen
+// Abwesenheitstag gibt (siehe buildTimesheetAbsence) — der Regelfall
+// "Mitarbeiter ohne Abwesenheit in diesem Monat" kostet damit keine
+// zusätzliche Anfrage.
+
+import { getEmployeeAbsencesInRange } from "@/services/absences/absences.service";
+import { getScheduleOccurrences } from "@/services/jobs/jobs.service";
+import type { TimesheetEntry } from "@/types/timesheet";
+import type {
+  TimesheetAbsenceDay,
+  TimesheetAbsenceSummary,
+  TimesheetNotice,
+} from "@/types/timesheetAbsence";
+import { resolveEffectiveAbsenceDays } from "@/utils/resolveEffectiveAbsenceDays";
+
+function emptySummary(): TimesheetAbsenceSummary {
+  return {
+    vacationCalendarDays: 0,
+    sicknessCalendarDays: 0,
+    vacationPlannedWorkDays: 0,
+    sicknessPlannedWorkDays: 0,
+    vacationPlannedMinutes: 0,
+    sicknessPlannedMinutes: 0,
+    days: [],
+  };
+}
+
+/**
+ * Lädt Abwesenheiten + geplante Einsatzzeit für einen Mitarbeiter/Zeitraum
+ * und baut daraus Zusammenfassung + Hinweise (Phase E).
+ *
+ * @param entries Bereits geladene Ist-Zeit-Einträge desselben Aufrufs
+ *   (getTimesheet) — ausschließlich für den "Arbeit trotz Abwesenheit"-
+ *   Hinweis genutzt (Schnittmenge der Tage), NIE für die Planzeit-Berechnung.
+ */
+export async function buildTimesheetAbsence(params: {
+  employeeId: string;
+  /** "YYYY-MM-DD", inklusive — identische Monatsgrenzen wie getTimesheet. */
+  from: string;
+  /** "YYYY-MM-DD", inklusive */
+  to: string;
+  entries: TimesheetEntry[];
+}): Promise<{ summary: TimesheetAbsenceSummary; notices: TimesheetNotice[] }> {
+  const { employeeId, from, to, entries } = params;
+
+  const absences = await getEmployeeAbsencesInRange({ employeeId, from, to });
+  const effectiveDays = resolveEffectiveAbsenceDays(absences, from, to);
+
+  if (effectiveDays.length === 0) {
+    return { summary: emptySummary(), notices: [] };
+  }
+
+  // Nur EINE Occurrence-Abfrage für den gesamten Zeitraum, nicht pro Tag.
+  const occurrences = await getScheduleOccurrences({
+    from,
+    to,
+    employee: { employeeId },
+  });
+
+  // Geplante Minuten je Kalendertag, NUR aus planned_duration_minutes
+  // zugewiesener Occurrences — null-Dauer wird ignoriert (Regel 5, nie 8h
+  // annehmen, nie aus Ist-Zeit oder scheduled_end ableiten).
+  const plannedMinutesByDate = new Map<string, number>();
+  for (const job of occurrences) {
+    if (!job.date) continue;
+    if (job.plannedDurationMinutes == null) continue;
+    plannedMinutesByDate.set(
+      job.date,
+      (plannedMinutesByDate.get(job.date) ?? 0) + job.plannedDurationMinutes,
+    );
+  }
+
+  const days: TimesheetAbsenceDay[] = effectiveDays.map((day) => {
+    const plannedMinutes = plannedMinutesByDate.get(day.date) ?? 0;
+    return {
+      ...day,
+      plannedMinutes,
+      hasPlannedWork: plannedMinutes > 0,
+    };
+  });
+
+  const summary = days.reduce<TimesheetAbsenceSummary>((acc, day) => {
+    if (day.type === "vacation") {
+      acc.vacationCalendarDays += 1;
+      if (day.hasPlannedWork) acc.vacationPlannedWorkDays += 1;
+      acc.vacationPlannedMinutes += day.plannedMinutes;
+    } else {
+      acc.sicknessCalendarDays += 1;
+      if (day.hasPlannedWork) acc.sicknessPlannedWorkDays += 1;
+      acc.sicknessPlannedMinutes += day.plannedMinutes;
+    }
+    return acc;
+  }, emptySummary());
+  summary.days = days;
+
+  // "Arbeit trotz Abwesenheit": Schnittmenge Ist-Zeit-Einträge × wirksame
+  // Abwesenheitstage. Rein informativ — ändert weder entries noch
+  // totalMinutes noch die Abwesenheits-Klassifizierung.
+  const effectiveByDate = new Map(effectiveDays.map((d) => [d.date, d.type]));
+  const notices: TimesheetNotice[] = [];
+  const seenNoticeDates = new Set<string>();
+  for (const entry of entries) {
+    const absenceType = effectiveByDate.get(entry.date);
+    if (!absenceType || seenNoticeDates.has(entry.date)) continue;
+    seenNoticeDates.add(entry.date);
+    notices.push({
+      type: "work_during_absence",
+      date: entry.date,
+      absenceType,
+    });
+  }
+  notices.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  return { summary, notices };
+}

--- a/types/timesheet.ts
+++ b/types/timesheet.ts
@@ -3,6 +3,8 @@
 // Quelle ist ausschließlich die jobs-Tabelle (abgeschlossene Aufträge) — es gibt
 // keine eigene Timesheet-Tabelle. Aggregation passiert clientseitig.
 
+import type { TimesheetAbsenceSummary, TimesheetNotice } from "@/types/timesheetAbsence";
+
 /**
  * Eine Zeile im Stundenzettel = ein abgeschlossener Job.
  * Mehrere Jobs am selben Tag ergeben mehrere Einträge (mehrere Zeilen).
@@ -95,4 +97,18 @@ export type TimesheetData = {
    * sie sind nicht abrechenbar, solange sie nicht korrigiert wurden.
    */
   needsAttention: TimesheetGap[];
+
+  /**
+   * Abwesenheits-Zusammenfassung (Urlaub/Krankheit) für denselben Zeitraum
+   * (Phase E). ADDITIV — beeinflusst `entries`/`totalMinutes` nicht. Optional,
+   * damit ältere Aufrufer/Tests ohne dieses Feld weiter kompilieren.
+   */
+  absenceSummary?: TimesheetAbsenceSummary;
+
+  /**
+   * Informative Hinweise (z. B. "Arbeit trotz Abwesenheit"), bewusst GETRENNT
+   * von `needsAttention` — keine Korrektur-Aktion, kein Eingriff in die
+   * Ist-Zeit-Berechnung (Phase E).
+   */
+  notices?: TimesheetNotice[];
 };

--- a/types/timesheetAbsence.ts
+++ b/types/timesheetAbsence.ts
@@ -1,0 +1,68 @@
+// types/timesheetAbsence.ts
+// Phase E — Stundenzettel-Abwesenheiten: additive Typen. Ergänzen TimesheetData
+// (types/timesheet.ts) um Urlaub/Krankheit, ohne dessen bestehende Felder
+// (entries/totalMinutes/needsAttention) anzufassen.
+//
+// WICHTIG (siehe CLAUDE.md-Grundsatz + Architektur-Audit Phase E): dies ist
+// eine rein OPERATIVE Klassifizierung für die Stundenzettel-Anzeige. Eine
+// gemeldete Krankheit (status=reported) ist KEIN medizinischer Nachweis und
+// stellt keinen Urlaubsanspruch wieder her — siehe resolveEffectiveAbsenceDays.
+
+/**
+ * Ein Kalendertag, an dem für einen Mitarbeiter genau EINE Abwesenheitsart
+ * "wirksam" ist (Krank > Urlaub bei Überschneidung, siehe
+ * utils/resolveEffectiveAbsenceDays.ts). Reine Ableitung — die zugrunde
+ * liegenden employee_absences-Zeilen werden dabei nie verändert.
+ */
+export type EffectiveAbsenceDay = {
+  /** "YYYY-MM-DD", lokal */
+  date: string;
+  type: "vacation" | "sickness";
+  /** IDs der employee_absences-Zeilen, aus denen dieser Tag resultiert (>1 bei überlappenden Zeilen gleichen Typs). */
+  sourceAbsenceIds: string[];
+};
+
+/**
+ * Ein effektiver Abwesenheitstag angereichert um die geplante Einsatzzeit
+ * (Summe von jobs.planned_duration_minutes der an diesem Tag zugewiesenen
+ * Occurrences, NIE aus tatsächlicher Arbeitszeit oder scheduled_end
+ * abgeleitet — siehe services/timesheets/timesheetAbsence.service.ts).
+ */
+export type TimesheetAbsenceDay = EffectiveAbsenceDay & {
+  /** Summe der geplanten Minuten zugewiesener Occurrences an diesem Tag (0 = keine geplant, oder alle ohne Dauer). */
+  plannedMinutes: number;
+  /** true, wenn an diesem Tag mindestens eine zugewiesene Occurrence mit geplanter Dauer existiert. */
+  hasPlannedWork: boolean;
+};
+
+/**
+ * Zusammenfassung für einen Mitarbeiter/Monat. Trennt bewusst:
+ *   * Kalendertage   — reine Abwesenheits-Kalendertage (KEINE Urlaubskonto-Aussage).
+ *   * PlannedWorkDays — Tage mit tatsächlich geplanten Einsätzen an diesem Tag.
+ *   * PlannedMinutes  — die daraus resultierende geplante Einsatzzeit.
+ * Niemals als "Arbeitszeit"/"Bezahlte Zeit" beschriften — siehe UI-Komponente.
+ */
+export type TimesheetAbsenceSummary = {
+  vacationCalendarDays: number;
+  sicknessCalendarDays: number;
+
+  vacationPlannedWorkDays: number;
+  sicknessPlannedWorkDays: number;
+
+  vacationPlannedMinutes: number;
+  sicknessPlannedMinutes: number;
+
+  days: TimesheetAbsenceDay[];
+};
+
+/**
+ * Informativer Hinweis, KEIN Korrektur-Datensatz (siehe TimesheetGap in
+ * types/timesheet.ts — bewusst getrennt, damit needsAttention semantisch
+ * sauber "erfordert eine Korrektur-Aktion" bedeutet).
+ */
+export type TimesheetNotice = {
+  type: "work_during_absence";
+  /** "YYYY-MM-DD" — der Tag, an dem sowohl ein tatsächlicher Eintrag als auch eine wirksame Abwesenheit vorliegen. */
+  date: string;
+  absenceType: "vacation" | "sickness";
+};

--- a/utils/resolveEffectiveAbsenceDays.ts
+++ b/utils/resolveEffectiveAbsenceDays.ts
@@ -1,0 +1,106 @@
+// utils/resolveEffectiveAbsenceDays.ts
+// Phase E — reine Ableitung "welche Abwesenheitsart gilt an diesem
+// Kalendertag?", ohne Supabase-Abhängigkeit (testbar, wiederverwendbar für
+// Stundenzettel-Anzeige UND -Berechnung). Analoges Muster zu
+// utils/absenceConflicts.ts (Phase D): pure Zuordnung, Netzwerk-Abfrage lebt
+// getrennt in services/absences/*.
+//
+// ZEITZONEN-SEMANTIK: ausschließlich "YYYY-MM-DD"-String-Vergleiche/-Iteration.
+// KEIN `new Date("YYYY-MM-DD")` (verschiebt in manchen Zeitzonen auf den
+// Vor-/Folgetag) — Datumskomponenten werden stattdessen einzeln geparst und
+// über `new Date(y, m-1, d)` (lokal, sicher) konstruiert, exakt wie
+// TimesheetScreen.formatDayShort es bereits tut.
+//
+// PRIORITÄT BEI ÜBERSCHNEIDUNG: Krank > Urlaub (siehe Architektur-Audit Phase
+// E, Abschnitt 11). Ein Kalendertag hat NIE zwei wirksame Abwesenheitsarten.
+// Beide zugrunde liegenden employee_absences-Zeilen bleiben dabei unverändert
+// in der DB — diese Funktion verändert nichts, sie ordnet nur zu.
+//
+// WICHTIG — KEINE RECHTLICHE AUSSAGE: "wirksam" bedeutet hier ausschließlich
+// "für die Stundenzettel-Anzeige berücksichtigt". Eine gemeldete Krankheit
+// (status=reported) ist kein medizinischer Nachweis (Arbeitsunfähigkeit) und
+// stellt keinen Urlaubsanspruch wieder her — siehe Kopfkommentar in
+// types/timesheetAbsence.ts.
+
+import type { Absence, AbsenceType } from "@/types/absence";
+import type { EffectiveAbsenceDay } from "@/types/timesheetAbsence";
+import { formatDateISO } from "@/utils/date";
+
+/**
+ * Entscheidet, ob eine Abwesenheits-Zeile für die Stundenzettel-Ableitung
+ * überhaupt in Frage kommt. Als austauschbarer Parameter (statt fest verdrahtet)
+ * gehalten, damit eine künftige Unterscheidung "gemeldet" vs. "medizinisch
+ * bestätigt" (Architektur-Audit Phase E, Abschnitt 17) später nachgerüstet
+ * werden kann, ohne resolveEffectiveAbsenceDays oder dessen Aufrufer
+ * umzuschreiben — nur dieses Prädikat müsste sich ändern.
+ *
+ * requested/rejected/cancelled sind NIE aktiv — unabhängig vom Datum.
+ */
+export type AbsenceEligibilityPredicate = (absence: Absence) => boolean;
+
+export const isOperationallyActiveAbsence: AbsenceEligibilityPredicate = (
+  absence,
+) =>
+  (absence.type === "vacation" && absence.status === "approved") ||
+  (absence.type === "sickness" && absence.status === "reported");
+
+// Ordnet, welcher Typ bei Überschneidung gewinnt. Krank zuerst = höhere Prio.
+const TYPE_PRIORITY: AbsenceType[] = ["sickness", "vacation"];
+
+// "YYYY-MM-DD" → Folgetag als "YYYY-MM-DD", lokal berechnet (kein UTC-Drift).
+function nextDateKey(dateKey: string): string {
+  const [year, month, day] = dateKey.split("-").map((n) => parseInt(n, 10));
+  const next = new Date(year, month - 1, day + 1);
+  return formatDateISO(next)!;
+}
+
+// Deckt eine Abwesenheit den gegebenen Kalendertag ab? offene Krankheit
+// (end_date = null) deckt ab start_date jeden Folgetag ab.
+function covers(absence: Absence, dateKey: string): boolean {
+  if (dateKey < absence.startDate) return false;
+  if (absence.endDate !== null && dateKey > absence.endDate) return false;
+  return true;
+}
+
+/**
+ * Leitet für jeden Kalendertag in [from, to] (inklusive, lokal) die wirksame
+ * Abwesenheitsart eines EINZELNEN Mitarbeiters ab. `absences` sollte bereits
+ * auf diesen Mitarbeiter eingegrenzt sein (Aufrufer-Verantwortung, siehe
+ * getEmployeeAbsencesInRange) — diese Funktion filtert nur nach `isActive`
+ * und Zeitraum, nicht nach employee_id.
+ *
+ * Tage ohne wirksame Abwesenheit fehlen im Ergebnis (kein Eintrag mit
+ * type=null). Iteration ist strikt auf [from, to] begrenzt — eine Abwesenheit,
+ * die vor `from` beginnt oder nach `to` endet, trägt nur innerhalb dieses
+ * Fensters bei (siehe Monatsgrenzen-Fall im Architektur-Audit, Abschnitt 5).
+ */
+export function resolveEffectiveAbsenceDays(
+  absences: Absence[],
+  from: string,
+  to: string,
+  isActive: AbsenceEligibilityPredicate = isOperationallyActiveAbsence,
+): EffectiveAbsenceDay[] {
+  if (from > to) return [];
+
+  const active = absences.filter(isActive);
+  if (active.length === 0) return [];
+
+  const result: EffectiveAbsenceDay[] = [];
+
+  for (let dateKey = from; dateKey <= to; dateKey = nextDateKey(dateKey)) {
+    const covering = active.filter((absence) => covers(absence, dateKey));
+    if (covering.length === 0) continue;
+
+    const winningType = TYPE_PRIORITY.find((type) =>
+      covering.some((absence) => absence.type === type),
+    )!;
+
+    const sourceAbsenceIds = covering
+      .filter((absence) => absence.type === winningType)
+      .map((absence) => absence.id);
+
+    result.push({ date: dateKey, type: winningType, sourceAbsenceIds });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds an additive Urlaub/Krankheit summary to the Stundenzettel (both employee and admin views), computed entirely client-side from the existing `employee_absences` table and `jobs.planned_duration_minutes` on materialized occurrences.
- Introduces `resolveEffectiveAbsenceDays` (pure utility): resolves, per calendar day, which absence type is *effective* when an approved vacation overlaps a reported sickness — **Krank always wins**, never double-counted, both underlying DB rows stay untouched.
- Planned absence minutes are derived dynamically per day from assigned occurrences' `planned_duration_minutes` (never 8h assumed, never derived from actual worked time or `scheduled_end`, `null` durations ignored).
- Adds a non-blocking "Arbeit trotz Abwesenheit" notice when an actual worked entry falls on an effective absence day — kept as a separate `notices[]` field, not mixed into the existing `needsAttention`/`TimesheetGap` correction list.
- Adds focus-refresh to the Stundenzettel hook (same `useFocusEffect` + first-focus-skip pattern already used by `AbsencesScreen`), so absence changes made elsewhere become visible on return without a new realtime channel.

## Explicit invariants preserved
- `TimesheetEntry`, `totalMinutes`, `mapEntry`/`mapGap`, the Phase-1 legacy cutoff, and `admin_correct_assignment_time` are **untouched** — new logic lives in separate files (`utils/resolveEffectiveAbsenceDays.ts`, `services/timesheets/timesheetAbsence.service.ts`) and is merged into `TimesheetData` only as new optional fields (`absenceSummary?`, `notices?`).
- No DB migration, no new RPC, no notifications, no PDF/export changes, no Urlaub-balance/payroll logic. Verified via `git diff --stat` — only `types/`, `services/timesheets/`, `services/absences/`, and `features/timesheets/` files changed.
- Security: reuses existing RLS ("employee read own absences" / "admin read company absences", `job_assignments` policies) via a new **generic** `getEmployeeAbsencesInRange(employeeId, from, to)` — verified against the migration SQL that RLS scopes correctly for both roles without any role branching in application code.
- UI wording follows the spec: "Geplante Einsatzzeit" (never "Arbeitszeit"/"Bezahlte Zeit"/"Entgeltfortzahlung"), calendar-day counts kept visually secondary to planned-work-day counts (no implied Urlaubskonto deduction).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (`expo lint`) — clean
- [x] Pure-logic verification script run against spec test matrix A–M, P, and the critical §8 Krank>Urlaub double-count regression (vacation 17–23, sickness 19–21, planned jobs 17=120/19=180/20=60/22=90 → vacation=210min/2 days, sickness=240min/2 days, no overlap) — all pass
- [ ] Manual QA on device/simulator (see below) — not yet run in this session, recommended before merge

### Manual QA checklist (recommended before merge)
1. Employee with no absences this month → no "Abwesenheiten"/"Hinweise" sections render, existing Stundenzettel unchanged.
2. Employee with an approved vacation this month, no assigned jobs on those days → "Urlaub" row shows "Keine geplanten Einsätze" + calendar-day count, 0 planned minutes.
3. Employee with a reported sickness overlapping an approved vacation → confirm the overlap days show under Krank only (admin view, selecting that employee).
4. Employee who actually started/completed a job on an effective absence day → confirm the job still appears normally in "Deine Zeiten"/"Vorschau" and totals, AND a "Hinweis" row appears; confirm no correction button/CTA on that notice.
5. Admin: approve a vacation request on the Abwesenheiten screen, then navigate to Stundenzettel for that employee without a manual reload → confirm focus-refresh picks it up.
6. Multi-assignee occurrence on an absence day, assigned to two employees → confirm each employee's own Stundenzettel counts the full planned duration independently (not halved).
7. Recurring rule with a materialized occurrence on an absence day → confirm it's picked up (same as a single job).
8. Existing PDF export (`PDF exportieren`) still produces the unchanged actual-time-only document.
9. Dark mode / theme check on the new section (uses `useAppTheme()`, no hardcoded colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)