### PR TITLE
feat(notifications): Push für neue Job-Kommentare

### DIFF
--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -318,10 +318,14 @@ create table if not exists public.notification_outbox (
   -- absence_end_date NULL heißt bei Krankheit bewusst "Ende offen".
   absence_start_date date,
   absence_end_date date,
+  -- 'comment' (seit 20260822000000): entity_id = job_comments.id (Dedupe),
+  -- job_id zusätzlich gesetzt, damit der Tap den Auftrag öffnen kann.
   constraint chk_notification_outbox_entity check (
     (entity_type = 'job'     and job_id is not null and entity_id is not null)
     or
     (entity_type = 'absence' and job_id is null     and entity_id is not null)
+    or
+    (entity_type = 'comment' and job_id is not null and entity_id is not null)
   )
 );
 
@@ -345,6 +349,14 @@ create unique index if not exists uq_notification_outbox_assignment
 create unique index if not exists uq_notification_outbox_absence_event
   on public.notification_outbox(entity_id, event_type)
   where entity_type = 'absence' and event_type <> 'sickness_updated';
+
+-- Kommentar-Events: eine Zeile pro Kommentar (entity_id = job_comments.id).
+-- Zwei verschiedene Kommentare am selben Auftrag ergeben zwei Events.
+-- Geschrieben vom AFTER-INSERT-Trigger trg_notify_job_comment auf
+-- job_comments (siehe 20260822000000_comment_notifications.sql).
+create unique index if not exists uq_notification_outbox_comment_event
+  on public.notification_outbox(entity_id, event_type)
+  where entity_type = 'comment';
 
 create index if not exists idx_notif_outbox_entity
   on public.notification_outbox(entity_type, entity_id);

--- a/supabase/functions/dispatch-notifications/index.ts
+++ b/supabase/functions/dispatch-notifications/index.ts
@@ -71,7 +71,12 @@ type ClaimedDelivery = {
 // hier ein, die Partitionierung unten bleibt unverändert.
 //   Job-Lifecycle -> Admin, Job-Zuweisung -> Mitarbeiter,
 //   Abwesenheit gemeldet/beantragt -> Admin, Review-Ergebnis -> Mitarbeiter.
-const EVENT_RECIPIENT_ROLE: Record<string, "admin" | "employee"> = {
+// "any" = beide Rollen zulässig. Das braucht genau ein Event: comment_added
+// geht je nach Autor an zugewiesene Mitarbeiter UND/ODER Admins. Die konkrete
+// Empfängermenge wurde dabei bereits serverseitig im Trigger abgeleitet
+// (firmengescopt, Autor ausgeschlossen) — hier bleibt deshalb nur zu prüfen,
+// dass der Empfänger noch aktiv ist.
+const EVENT_RECIPIENT_ROLE: Record<string, "admin" | "employee" | "any"> = {
   job_started: "admin",
   job_completed: "admin",
   job_assigned: "employee",
@@ -80,12 +85,25 @@ const EVENT_RECIPIENT_ROLE: Record<string, "admin" | "employee"> = {
   sickness_updated: "admin",
   vacation_approved: "employee",
   vacation_rejected: "employee",
+  comment_added: "any",
 };
 
 // Unbekanntes Event -> "admin" als konservativer Rückfall (entspricht dem
 // Verhalten vor dieser Änderung, als alles an Admins ging).
-function expectedRoleFor(eventType: string): "admin" | "employee" {
+function expectedRoleFor(eventType: string): "admin" | "employee" | "any" {
   return EVENT_RECIPIENT_ROLE[eventType] ?? "admin";
+}
+
+// Empfänger zustellbar? Immer: Konto aktiv. Zusätzlich muss die Rolle zum
+// Event passen — außer bei "any"-Events, deren Empfängermenge serverseitig
+// bereits exakt bestimmt wurde.
+function isEligible(row: ClaimedDelivery): boolean {
+  if (row.recipient_active !== true) return false;
+  const expected = expectedRoleFor(row.event_type);
+  if (expected === "any") {
+    return row.recipient_role === "admin" || row.recipient_role === "employee";
+  }
+  return row.recipient_role === expected;
 }
 
 // "2026-08-25" -> "25.08.2026". Der Dispatcher bekommt reine Datumsstrings
@@ -191,7 +209,30 @@ function buildAbsenceContent(row: ClaimedDelivery): { title: string; body: strin
   }
 }
 
+// Kommentar-Push. Der Kommentartext selbst steht BEWUSST NICHT drin:
+// Datenschutz (Push landet auf dem Sperrbildschirm), unbekannte Länge und
+// unnötiges Rauschen. Der Nutzer öffnet den Auftrag und liest dort.
+function buildCommentContent(row: ClaimedDelivery): { title: string; body: string } {
+  const who = row.employee_name?.trim() || "Jemand";
+  const service = row.service_name?.trim();
+  const customer = row.customer_name?.trim();
+
+  // Gleiche Fallback-Kette wie bei den Job-Events: fehlt die Leistung, rückt
+  // der Kunde nach und darf dann nicht zusätzlich als "bei …" erscheinen.
+  const what = jobTitle(row);
+  const at = service && customer ? ` bei ${customer}` : "";
+
+  return {
+    title: "Neuer Kommentar",
+    body: `${who} hat einen Kommentar zu „${what}“${at} geschrieben.`,
+  };
+}
+
 function buildContent(row: ClaimedDelivery): { title: string; body: string } {
+  if (row.entity_type === "comment") {
+    return buildCommentContent(row);
+  }
+
   if (row.entity_type === "absence") {
     return buildAbsenceContent(row);
   }
@@ -334,11 +375,8 @@ Deno.serve(async (req) => {
       //  - aktiver, passender Empfänger MIT Token -> senden
       const sendable: ClaimedDelivery[] = [];
       for (const d of claimed) {
-        const expectedRole = expectedRoleFor(d.event_type);
-        const isEligibleRecipient =
-          d.recipient_active === true && d.recipient_role === expectedRole;
-        if (!isEligibleRecipient) {
-          await markDelivery(adminClient, d.delivery_id, "permanent_fail", `recipient not eligible (inactive/not ${expectedRole})`);
+        if (!isEligible(d)) {
+          await markDelivery(adminClient, d.delivery_id, "permanent_fail", `recipient not eligible (inactive/not ${expectedRoleFor(d.event_type)})`);
           failed++;
         } else if (!d.expo_push_token) {
           await markDelivery(adminClient, d.delivery_id, "missing_token", "missing_push_token");
@@ -371,6 +409,10 @@ Deno.serve(async (req) => {
             status: d.job_status,
             entityType: d.entity_type,
             absenceId: d.entity_type === "absence" ? d.entity_id : null,
+            // Kommentar-Events tragen zusätzlich job_id — der Tap öffnet
+            // deshalb über den bestehenden jobId-Pfad den Auftrag. commentId
+            // wird für ein späteres Anspringen des Kommentars mitgeführt.
+            commentId: d.entity_type === "comment" ? d.entity_id : null,
           },
           channelId: "default",
           priority: "high",

--- a/supabase/migrations/20260822000000_comment_notifications.sql
+++ b/supabase/migrations/20260822000000_comment_notifications.sql
@@ -1,0 +1,166 @@
+-- =========================================================
+-- Comment Notifications (job_comments) über Outbox/Dispatcher
+-- =========================================================
+-- Neue Kommentare erzeugen bisher nur den In-App-Ungelesen-Punkt, aber keine
+-- Push-Benachrichtigung. Dieses Event schließt die Lücke über dieselbe
+-- notification_outbox/notification_deliveries-Pipeline wie Job- und
+-- Abwesenheits-Events.
+--
+-- WARUM TRIGGER STATT RPC (bewusste Abweichung von den bisherigen Events):
+--   Job- und Abwesenheits-Events brauchten eine RPC, weil RLS den fachlichen
+--   Schreibvorgang selbst blockierte (Employees duerfen jobs/employee_absences
+--   nicht direkt schreiben). Kommentare sind anders: der Client INSERTet
+--   bereits direkt in job_comments und die vier INSERT-Policies regeln die
+--   Autorisierung vollstaendig und korrekt.
+--   Eine neue RPC muesste diese Policy-Logik in SECURITY DEFINER-Code
+--   nachbauen (und damit duplizieren/riskieren), oder den Schreibpfad an den
+--   Policies vorbeifuehren. Ein AFTER-INSERT-Trigger ist dagegen
+--   transaktional per Konstruktion, laesst den bestehenden, RLS-geschuetzten
+--   Schreibpfad UNVERAENDERT und braucht keine Client-Aenderung.
+--   Trigger sind hier ein etabliertes Muster (set_updated_at,
+--   enforce_profile_field_guard, notification_outbox_fill_entity).
+--
+-- FAN-OUT (Option A: EIN Event, N Zustellungen):
+--   Ein Kommentar = eine Outbox-Zeile + eine Zustellung je Empfaenger. Das
+--   entspricht der bestehenden Architektur. fanout_notification_events() ist
+--   allerdings fest auf Admins verdrahtet und kann die GEMISCHTE
+--   Empfaengermenge (Admins UND zugewiesene Mitarbeiter) nicht abbilden —
+--   deshalb schreibt der Trigger die Zustellungen direkt und setzt
+--   fanned_out_at sofort, exakt wie job_assigned und die
+--   mitarbeitergerichteten Abwesenheits-Events. fanout_notification_events
+--   bleibt damit UNVERAENDERT.
+--
+-- DEDUPE: entity_id = job_comments.id. Jeder Kommentar ist eine eigene Zeile
+--   mit eigener id, also erzeugt jeder Kommentar genau ein Event; zwei
+--   verschiedene Kommentare am selben Job erzeugen zwei Events. Die
+--   Zustellungs-Eindeutigkeit (outbox_id, recipient_id) verhindert zusaetzlich
+--   doppelte Empfaenger, falls jemand in zwei Empfaengergruppen faellt.
+
+-- ---------------------------------------------------------
+-- 1. entity_type 'comment' erlauben
+-- ---------------------------------------------------------
+-- Ein Kommentar-Event traegt BEIDES: entity_id = Kommentar-ID (Dedupe) und
+-- job_id (Deep-Link auf den Auftrag).
+alter table public.notification_outbox
+  drop constraint if exists chk_notification_outbox_entity;
+alter table public.notification_outbox
+  add constraint chk_notification_outbox_entity check (
+    (entity_type = 'job'     and job_id is not null and entity_id is not null)
+    or
+    (entity_type = 'absence' and job_id is null     and entity_id is not null)
+    or
+    (entity_type = 'comment' and job_id is not null and entity_id is not null)
+  );
+
+create unique index if not exists uq_notification_outbox_comment_event
+  on public.notification_outbox(entity_id, event_type)
+  where entity_type = 'comment';
+
+-- ---------------------------------------------------------
+-- 2. Trigger: Kommentar -> Outbox-Event + Zustellungen
+-- ---------------------------------------------------------
+-- SECURITY DEFINER ist noetig, weil der Trigger als der EINFUEGENDE Nutzer
+-- laeuft: ein Mitarbeiter darf weder fremde profiles-Zeilen lesen (um die
+-- Admins zu finden) noch in die notification_*-Tabellen schreiben (RLS an,
+-- keine Policies). Die Empfaengermenge wird ausschliesslich serverseitig aus
+-- NEW.job_id / NEW.company_id / NEW.author_id abgeleitet — es gibt keinen
+-- Client-Parameter, dem hier vertraut wird.
+create or replace function public.notify_job_comment()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_author_role   text;
+  v_author_name   text;
+  v_customer_name text;
+  v_service_name  text;
+  v_outbox_id     uuid;
+begin
+  select p.role::text, coalesce(nullif(btrim(p.full_name), ''), 'Unbekannt')
+    into v_author_role, v_author_name
+  from public.profiles p
+  where p.id = new.author_id;
+
+  -- Autor nicht auffindbar (z. B. geloeschtes Konto) -> kein Event, aber der
+  -- Kommentar selbst bleibt bestehen. Die Benachrichtigung ist additiv und
+  -- darf den fachlichen Schreibvorgang nie scheitern lassen.
+  if v_author_role is null then
+    return new;
+  end if;
+
+  select j.customer_name, j.service_name
+    into v_customer_name, v_service_name
+  from public.jobs j
+  where j.id = new.job_id;
+
+  insert into public.notification_outbox (
+    company_id, job_id, event_type, job_status,
+    employee_id, employee_name, customer_name, service_name,
+    entity_type, entity_id, fanned_out_at
+  )
+  values (
+    new.company_id, new.job_id, 'comment_added', null,
+    new.author_id, v_author_name, v_customer_name, v_service_name,
+    'comment', new.id, now()
+  )
+  on conflict (entity_id, event_type) where entity_type = 'comment'
+  do nothing
+  returning id into v_outbox_id;
+
+  if v_outbox_id is null then
+    return new;
+  end if;
+
+  -- Empfaenger A: alle AKTIVEN Mitarbeiter, die dem Auftrag zugewiesen sind
+  -- (volle Zuweisungsmenge, nicht nur der Legacy-Primaer), ohne den Autor.
+  -- Firmenscope doppelt geprueft (Verteidigung in der Tiefe).
+  insert into public.notification_deliveries (
+    outbox_id, company_id, recipient_id, next_attempt_at
+  )
+  select distinct v_outbox_id, new.company_id, p.id, now()
+  from public.job_assignments ja
+  join public.profiles p on p.id = ja.employee_id
+  where ja.job_id      = new.job_id
+    and ja.employee_id is not null
+    and p.is_active    = true
+    and p.role         = 'employee'
+    and p.company_id   = new.company_id
+    and p.id          <> new.author_id
+  on conflict (outbox_id, recipient_id) do nothing;
+
+  -- Empfaenger B: bei einem MITARBEITER-Kommentar zusaetzlich alle aktiven
+  -- Admins der Firma. Kommentiert ein Admin, werden andere Admins bewusst
+  -- NICHT benachrichtigt (Beta-Scope: keine Admin-zu-Admin-Benachrichtigung).
+  if v_author_role = 'employee' then
+    insert into public.notification_deliveries (
+      outbox_id, company_id, recipient_id, next_attempt_at
+    )
+    select v_outbox_id, new.company_id, p.id, now()
+    from public.profiles p
+    where p.company_id = new.company_id
+      and p.role       = 'admin'
+      and p.is_active  = true
+      and p.id        <> new.author_id
+    on conflict (outbox_id, recipient_id) do nothing;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.notify_job_comment() is
+'AFTER-INSERT-Trigger auf job_comments: erzeugt transaktional ein '
+'comment_added-Outbox-Event (entity_type=''comment'', entity_id=Kommentar-ID, '
+'job_id fuer den Deep-Link) und die Zustellungen. Empfaenger werden '
+'ausschliesslich serverseitig abgeleitet: zugewiesene aktive Mitarbeiter, bei '
+'Mitarbeiter-Autoren zusaetzlich alle aktiven Admins der Firma; der Autor '
+'wird immer ausgeschlossen.';
+
+revoke all on function public.notify_job_comment() from public, anon, authenticated;
+
+drop trigger if exists trg_notify_job_comment on public.job_comments;
+create trigger trg_notify_job_comment
+  after insert on public.job_comments
+  for each row execute function public.notify_job_comment();


### PR DESCRIPTION
## Problem

Neue Job-Kommentare erzeugten bisher **nur** den In-App-Ungelesen-Punkt. Wer die App nicht offen hatte, erfuhr nichts von einem neuen Kommentar — weder Admin noch zugewiesener Mitarbeiter.

## Architektur

**Trigger statt RPC — bewusste Abweichung von den bisherigen Events.** Job- und Abwesenheits-Events brauchten eine RPC, weil RLS den fachlichen Schreibvorgang selbst blockierte. Kommentare sind anders: der Client INSERTet bereits direkt in `job_comments`, und die vier INSERT-Policies regeln die Autorisierung vollständig. Eine neue RPC müsste diese Policy-Logik in `SECURITY DEFINER`-Code **duplizieren** (und damit riskieren) oder am Schutz vorbeischreiben. Ein `AFTER INSERT`-Trigger ist dagegen transaktional per Konstruktion, lässt den bestehenden RLS-Pfad **unverändert** und braucht **keine Client-Änderung**. Trigger sind hier ein etabliertes Muster (`set_updated_at`, `enforce_profile_field_guard`, `notification_outbox_fill_entity`).

**Fan-out (Option A):** ein Event pro Kommentar + N Zustellungen. `fanout_notification_events` ist fest auf Admins verdrahtet und kann die **gemischte** Empfängermenge nicht abbilden — deshalb schreibt der Trigger die Zustellungen direkt (wie `job_assigned`). `fanout_notification_events` bleibt unverändert.

## Empfänger-Matrix

| Autor | Empfänger | Nicht-Empfänger |
|---|---|---|
| **Admin** | alle aktiven, dem Auftrag zugewiesenen Mitarbeiter | Autor, andere Admins, nicht zugewiesene, inaktive, fremde Firma |
| **Employee** | alle aktiven Admins der Firma + die übrigen aktiven Zugewiesenen | Autor, inaktive, fremde Firma |

Beispiel A/B/C zugewiesen, A kommentiert → Admin(s) + B + C; **nicht** A.

## Transaktion

Kommentar-INSERT und Notification-Event liegen in **derselben** Transaktion (Trigger). Der Fehlermodus „Kommentar gespeichert, Benachrichtigung still verloren" ist strukturell ausgeschlossen. Umgekehrt lässt der Trigger den Kommentar nie scheitern: ist der Autor nicht auffindbar (gelöschtes Konto), entsteht kein Event, der Kommentar bleibt.

## Dedupe

`entity_id = job_comments.id` über einen partiellen Unique-Index. Jeder Kommentar ist eine eigene Zeile mit eigener id → ein Event pro Kommentar; zwei verschiedene Kommentare am selben Auftrag ergeben zwei Events. Die Zustellungs-Eindeutigkeit `(outbox_id, recipient_id)` verhindert doppelte Empfänger, falls jemand in zwei Gruppen fällt.

## Security

Empfänger werden **ausschließlich** aus `NEW.job_id` / `NEW.company_id` / `NEW.author_id` abgeleitet — kein Client-Parameter. Firmenscope doppelt geprüft. `SECURITY DEFINER` mit gehärtetem `search_path`, für `anon`/`authenticated` revoked. Die bestehenden RLS-Policies auf `job_comments` bleiben unangetastet und regeln weiterhin, wer überhaupt kommentieren darf.

## Dispatcher

`comment_added` ist das erste Event mit **gemischter** Empfängerrolle. `expectedRoleFor` kennt dafür `"any"`; die neue `isEligible()`-Funktion prüft weiterhin strikt auf aktives Konto und passende Rolle. Copy für `job_assigned`, `job_started`, `job_completed`, `vacation_*` und `sickness_*` ist **byte-identisch** geblieben (verifiziert).

Der Kommentartext steht **bewusst nicht** im Push (Datenschutz auf dem Sperrbildschirm, unbekannte Länge, Rauschen).

## Staging-Evidenz

**A–Q alle PASS.** Highlights:
- Admin-Kommentar, 3 Zugewiesene → 1 Event, 3 Zustellungen, 3 verschiedene Empfänger, kein Admin-Empfänger
- Employee-Kommentar auf A/B/C-Auftrag → 4 Zustellungen (2 Admins + B + C), Autor ausgeschlossen
- Inaktiver Admin, inaktiver Zugewiesener und firmenfremder Admin: **nichts**
- 3 verschiedene Kommentare → 3 Events mit 3 verschiedenen `entity_id`
- Doppelte Zustellung und doppeltes Event: beide durch Unique-Constraint blockiert
- **Recurring:** 66 Occurrences, Kommentar auf **einer** Occurrence → 1 Event, 2 Zustellungen, **0** Geschwister-Events
- Regression: Ungelesen-Logik, `job_assigned`, `job_started`/`job_completed`, Abwesenheits-Events alle unverändert

`npx tsc --noEmit` und `npm run lint` sauber. Staging wurde auf den exakten Ausgangszustand zurückgesetzt; Production nachweislich unberührt.

## Device-Push-Limitierung

**Keine echte Gerätezustellung verifiziert.** Staging hat weiterhin keine Push-Tokens und `dispatch-notifications` ist dort nicht deployed. Verifiziert: DB-Event-Erzeugung, Zustellungs-Fan-out, Dispatcher-Quelllogik (echte Funktionsrümpfe gegen echte geclaimte Zeilen). Der physische Push ist **nicht** belegt.

## Deployment-Abhängigkeiten

⚠️ Production steht auf `20260816000000`. Vor einem echten Release müssen **alle drei** Migrationen laufen — `20260820000000`, `20260821000000` und `20260822000000` — **und** `dispatch-notifications` neu deployed werden (der Dispatcher liest Spalten und Event-Typen, die es auf Prod noch nicht gibt).

## Bekannte Einschränkung

Der Push erreicht **alle** Zugewiesenen, der In-App-Ungelesen-Punkt weiterhin nur den Legacy-Primär (`jobs.assigned_to`) — die in CLAUDE.md dokumentierte Asymmetrie. Beides ist konsistent mit dem heutigen Stand, aber ein Sekundär-Zugewiesener bekommt künftig einen Push zu einem Auftrag, dessen Ungelesen-Punkt er nicht sieht. Bewusst **nicht** in diesem PR geändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)