### PR TITLE
feat: add vacation entitlement configuration foundation

### DIFF
--- a/app/employees/[id]/employment.tsx
+++ b/app/employees/[id]/employment.tsx
@@ -1,0 +1,3 @@
+import EmployeeEmploymentScreen from "@/features/employees/EmployeeEmploymentScreen";
+
+export default EmployeeEmploymentScreen;

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -32,7 +32,15 @@ import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Alert, ScrollView, StatusBar, StyleSheet, Text, View } from "react-native";
+import {
+  Alert,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { toUserMessage } from "@/utils/userMessages";
 import { AdminAbsenceRow } from "@/features/absences/admin/components/AdminAbsenceRow";
@@ -354,6 +362,20 @@ export default function EmployeeDetailScreen() {
               />
             </>
           ) : null}
+          <View style={styles.rowDivider} />
+          {/* Beschäftigung & Urlaub liegt auf einem eigenen Screen: die
+              Stammdaten-Karte bleibt eine reine Übersicht, und die
+              Konfiguration ist ein Admin-Formular mit eigener Validierung. */}
+          <TouchableOpacity
+            onPress={() => router.push(`/employees/${employee.id}/employment`)}
+            accessibilityRole="button"
+          >
+            <InfoRow
+              label="Beschäftigung & Urlaub"
+              value="Konfigurieren"
+              icon="calendar-outline"
+            />
+          </TouchableOpacity>
         </Card>
 
         {/* ── Aktueller Job ── */}

--- a/features/employees/EmployeeEmploymentScreen.tsx
+++ b/features/employees/EmployeeEmploymentScreen.tsx
@@ -1,0 +1,393 @@
+// features/employees/EmployeeEmploymentScreen.tsx
+// "Beschäftigung & Urlaub" — Admin-Konfiguration eines Mitarbeiters.
+//
+// BEWUSST NUR KONFIGURATION: hier steht kein Saldo, kein Resturlaub, kein
+// Verbrauch. Diese Zahlen existieren noch nicht (Ledger folgt im nächsten
+// Arbeitspaket) — sie hier anzudeuten würde Werte vortäuschen, die niemand
+// pflegt.
+//
+// Struktur/Konventionen wie AdminCreateAbsenceScreen (AppHeader, ErrorBanner,
+// Input, DateTimeField, KeyboardAvoidingView).
+
+import { AppHeader, ErrorBanner, Input } from "@/components/ui";
+import { DateTimeField } from "@/components/ui/DateTimeField";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import {
+  getCompanyVacationDefaults,
+  getEmploymentConfig,
+  updateEmploymentConfig,
+} from "@/services/employees/employmentConfig.service";
+import type { AppTheme } from "@/constants/theme";
+import type {
+  CompanyVacationDefaults,
+  EmploymentConfig,
+  EmploymentType,
+} from "@/types/employment";
+import { EMPLOYMENT_TYPES, EMPLOYMENT_TYPE_LABELS } from "@/types/employment";
+import { describeSource, resolveEffectiveVacationConfig } from "@/utils/vacationConfig";
+import { formatDateISO, parseToDate } from "@/utils/date";
+import { alertDialog } from "@/utils/dialogs";
+import { toUserMessage } from "@/utils/userMessages";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+// Leerer Text -> null (= Firmen-Default gilt). Wichtig, damit ein geleertes
+// Feld den Override wirklich ENTFERNT und nicht als 0 gespeichert wird.
+function parseOptionalNumber(text: string): number | null {
+  const trimmed = text.trim().replace(",", ".");
+  if (!trimmed) return null;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : NaN;
+}
+
+function numberToText(value: number | null): string {
+  return value === null ? "" : String(value);
+}
+
+export default function EmployeeEmploymentScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [defaults, setDefaults] = useState<CompanyVacationDefaults | null>(null);
+
+  const [employmentType, setEmploymentType] = useState<EmploymentType | null>(null);
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [endDate, setEndDate] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [entitlementText, setEntitlementText] = useState("");
+  const [referenceText, setReferenceText] = useState("");
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [config, companyDefaults] = await Promise.all([
+        getEmploymentConfig(id),
+        getCompanyVacationDefaults(),
+      ]);
+      setEmploymentType(config.employmentType);
+      setStartDate(config.employmentStartDate);
+      setEndDate(config.employmentEndDate);
+      setEnabled(config.vacationManagementEnabled);
+      setEntitlementText(numberToText(config.vacationAnnualEntitlementDays));
+      setReferenceText(numberToText(config.vacationReferenceDaysPerWeek));
+      setDefaults(companyDefaults);
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Vorschau der EFFEKTIVEN Konfiguration mit den aktuell eingegebenen Werten,
+  // damit der Admin sofort sieht, ob ein Wert vom Firmen-Standard kommt oder
+  // individuell gesetzt ist — und ob noch etwas fehlt.
+  const preview = useMemo(() => {
+    if (!defaults) return null;
+    const entitlement = parseOptionalNumber(entitlementText);
+    const reference = parseOptionalNumber(referenceText);
+    if (Number.isNaN(entitlement) || Number.isNaN(reference)) return null;
+
+    const config: EmploymentConfig = {
+      employmentType,
+      employmentStartDate: startDate,
+      employmentEndDate: endDate,
+      vacationManagementEnabled: enabled,
+      vacationAnnualEntitlementDays: entitlement,
+      vacationReferenceDaysPerWeek: reference,
+    };
+    return resolveEffectiveVacationConfig(config, defaults);
+  }, [defaults, employmentType, startDate, endDate, enabled, entitlementText, referenceText]);
+
+  const handleSave = async () => {
+    if (!id) return;
+
+    const entitlement = parseOptionalNumber(entitlementText);
+    const reference = parseOptionalNumber(referenceText);
+
+    if (Number.isNaN(entitlement)) {
+      setError("Jahresanspruch: bitte eine Zahl eingeben (oder leer lassen).");
+      return;
+    }
+    if (Number.isNaN(reference)) {
+      setError("Referenz-Arbeitstage: bitte eine Zahl eingeben (oder leer lassen).");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updateEmploymentConfig({
+        employeeId: id,
+        employmentType,
+        employmentStartDate: startDate,
+        employmentEndDate: endDate,
+        vacationManagementEnabled: enabled,
+        vacationAnnualEntitlementDays: entitlement,
+        vacationReferenceDaysPerWeek: reference,
+      });
+      alertDialog("Gespeichert", "Die Konfiguration wurde übernommen.");
+      router.back();
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={["top"]}>
+        <AppHeader title="Beschäftigung & Urlaub" onBack={() => router.back()} />
+        <View style={styles.center}>
+          <ActivityIndicator color={theme.colors.primary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <AppHeader title="Beschäftigung & Urlaub" onBack={() => router.back()} />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          {error ? <ErrorBanner message={error} /> : null}
+
+          {/* ── Beschäftigung ── */}
+          <Text style={styles.sectionTitle}>Beschäftigung</Text>
+          <Text style={styles.hint}>
+            Die Beschäftigungsart ist rein beschreibend und beeinflusst den
+            Urlaubsanspruch nicht.
+          </Text>
+
+          <Text style={styles.label}>Beschäftigungsart</Text>
+          <View style={styles.chipRow}>
+            {EMPLOYMENT_TYPES.map((type) => {
+              const active = employmentType === type;
+              return (
+                <TouchableOpacity
+                  key={type}
+                  style={[styles.chip, active && styles.chipActive]}
+                  onPress={() => setEmploymentType(active ? null : type)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                >
+                  <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                    {EMPLOYMENT_TYPE_LABELS[type]}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+
+          <DateTimeField
+            label="Eintrittsdatum"
+            mode="date"
+            value={parseToDate(startDate)}
+            onChange={(d) => setStartDate(formatDateISO(d))}
+            placeholder="Nicht gesetzt"
+          />
+          <DateTimeField
+            label="Austrittsdatum (optional)"
+            mode="date"
+            value={parseToDate(endDate)}
+            onChange={(d) => setEndDate(formatDateISO(d))}
+            placeholder="Nicht gesetzt"
+          />
+
+          {/* ── Urlaub ── */}
+          <Text style={styles.sectionTitle}>Urlaub</Text>
+
+          <View style={styles.switchRow}>
+            <View style={styles.flex}>
+              <Text style={styles.label}>Urlaubsverwaltung aktiv</Text>
+              <Text style={styles.hint}>
+                Steuert nur, ob TaskOps ein Urlaubskonto führt — nicht, ob ein
+                gesetzlicher Anspruch besteht. Urlaubsanträge funktionieren
+                unabhängig davon.
+              </Text>
+            </View>
+            <Switch value={enabled} onValueChange={setEnabled} />
+          </View>
+
+          {enabled ? (
+            <>
+              <Input
+                label="Jahresanspruch (Tage)"
+                value={entitlementText}
+                onChangeText={setEntitlementText}
+                keyboardType="decimal-pad"
+                placeholder={
+                  defaults?.defaultAnnualEntitlementDays !== null &&
+                  defaults?.defaultAnnualEntitlementDays !== undefined
+                    ? `Firmen-Standard: ${defaults.defaultAnnualEntitlementDays}`
+                    : "Kein Firmen-Standard hinterlegt"
+                }
+              />
+              <Input
+                label="Referenz-Arbeitstage/Woche"
+                value={referenceText}
+                onChangeText={setReferenceText}
+                keyboardType="decimal-pad"
+                placeholder={
+                  defaults?.defaultReferenceDaysPerWeek !== null &&
+                  defaults?.defaultReferenceDaysPerWeek !== undefined
+                    ? `Firmen-Standard: ${defaults.defaultReferenceDaysPerWeek}`
+                    : "Kein Firmen-Standard hinterlegt"
+                }
+              />
+              <Text style={styles.hint}>
+                Leer lassen = Firmen-Standard verwenden.
+              </Text>
+
+              {preview?.status === "configured" ? (
+                <View style={styles.previewBox}>
+                  <Text style={styles.previewLine}>
+                    Jahresanspruch: {preview.annualEntitlementDays.value} Tage (
+                    {describeSource(preview.annualEntitlementDays.source)})
+                  </Text>
+                  <Text style={styles.previewLine}>
+                    Referenz-Arbeitstage: {preview.referenceDaysPerWeek.value}/Woche (
+                    {describeSource(preview.referenceDaysPerWeek.source)})
+                  </Text>
+                  <Text style={styles.previewNote}>
+                    Konfiguration — kein Resturlaub. Die Verbrauchsrechnung folgt später.
+                  </Text>
+                </View>
+              ) : null}
+
+              {preview?.status === "incomplete" ? (
+                <View style={[styles.previewBox, styles.previewWarn]}>
+                  <Text style={styles.previewLine}>
+                    Konfiguration unvollständig — es fehlt:{" "}
+                    {preview.missing
+                      .map((m) =>
+                        m === "entitlement" ? "Jahresanspruch" : "Referenz-Arbeitstage",
+                      )
+                      .join(", ")}
+                    .
+                  </Text>
+                  <Text style={styles.previewNote}>
+                    Entweder hier eintragen oder einen Firmen-Standard hinterlegen.
+                  </Text>
+                </View>
+              ) : null}
+            </>
+          ) : (
+            <Text style={styles.hint}>
+              Urlaubsverwaltung ist deaktiviert. Es wird kein Urlaubskonto
+              angezeigt oder berechnet.
+            </Text>
+          )}
+
+          <TouchableOpacity
+            style={[styles.saveButton, saving && styles.saveButtonDisabled]}
+            onPress={handleSave}
+            disabled={saving}
+            accessibilityRole="button"
+          >
+            {saving ? (
+              <ActivityIndicator color={theme.colors.onPrimary} />
+            ) : (
+              <Text style={styles.saveText}>Speichern</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    flex: { flex: 1 },
+    center: { flex: 1, alignItems: "center", justifyContent: "center" },
+    content: { padding: theme.spacing.lg, gap: theme.spacing.sm },
+    sectionTitle: {
+      fontSize: theme.typography.size.lg,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+      marginTop: theme.spacing.lg,
+    },
+    label: {
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    hint: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.xs,
+    },
+    chipRow: { flexDirection: "row", flexWrap: "wrap", gap: theme.spacing.xs },
+    chip: {
+      paddingVertical: theme.spacing.xs,
+      paddingHorizontal: theme.spacing.md,
+      borderRadius: theme.radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    chipActive: {
+      backgroundColor: theme.colors.primary,
+      borderColor: theme.colors.primary,
+    },
+    chipText: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    chipTextActive: { color: theme.colors.onPrimary },
+    switchRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+    },
+    previewBox: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      gap: theme.spacing.xs,
+    },
+    previewWarn: { borderColor: theme.colors.error },
+    previewLine: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    previewNote: { fontSize: theme.typography.size.xs, color: theme.colors.onSurfaceVariant },
+    saveButton: {
+      marginTop: theme.spacing.xl,
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+    },
+    saveButtonDisabled: { opacity: 0.6 },
+    saveText: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onPrimary,
+    },
+  });
+}

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -48,6 +48,19 @@ create table if not exists public.companies (
   id uuid primary key default gen_random_uuid(),
   name text not null,
   slug text not null unique,
+  -- Urlaubs-Defaults (20260823000000): greifen für jeden Mitarbeiter, dessen
+  -- eigener Wert NULL ist. default_vacation_management_enabled ist nur ein
+  -- Vorschlagswert für neu angelegte Mitarbeiter, kein rückwirkender Schalter.
+  default_vacation_annual_entitlement_days numeric(5,2),
+  default_vacation_reference_days_per_week numeric(3,2),
+  default_vacation_management_enabled boolean not null default false,
+  constraint chk_companies_vacation_defaults check (
+    (default_vacation_annual_entitlement_days is null
+      or (default_vacation_annual_entitlement_days >= 0 and default_vacation_annual_entitlement_days <= 365))
+    and
+    (default_vacation_reference_days_per_week is null
+      or (default_vacation_reference_days_per_week > 0 and default_vacation_reference_days_per_week <= 7))
+  ),
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
@@ -72,6 +85,30 @@ create table if not exists public.profiles (
   -- vorbehalten bleibt.
   account_deletion_token uuid,
   account_deletion_reserved_at timestamptz,
+  -- Beschäftigungs-/Urlaubskonfiguration (20260823000000). REIN KONFIGURATION —
+  -- KEIN Saldo: verbrauchter/verbleibender Urlaub existiert bewusst nicht
+  -- (Ledger folgt separat). employment_type ist rein beschreibend und leitet
+  -- NIE einen Anspruch ab (Minijob/Aushilfe haben gesetzlichen Anspruch).
+  -- Override NULL = Firmen-Default aus companies gilt.
+  employment_type public.employment_type,
+  employment_start_date date,
+  employment_end_date date,
+  vacation_management_enabled boolean not null default false,
+  vacation_annual_entitlement_days numeric(5,2),
+  vacation_reference_days_per_week numeric(3,2),
+  constraint chk_profiles_vacation_entitlement check (
+    vacation_annual_entitlement_days is null
+    or (vacation_annual_entitlement_days >= 0 and vacation_annual_entitlement_days <= 365)
+  ),
+  constraint chk_profiles_vacation_reference_days check (
+    vacation_reference_days_per_week is null
+    or (vacation_reference_days_per_week > 0 and vacation_reference_days_per_week <= 7)
+  ),
+  constraint chk_profiles_employment_dates check (
+    employment_start_date is null
+    or employment_end_date is null
+    or employment_end_date >= employment_start_date
+  ),
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );

--- a/services/employees/employmentConfig.service.ts
+++ b/services/employees/employmentConfig.service.ts
@@ -1,0 +1,179 @@
+// services/employees/employmentConfig.service.ts
+// ─────────────────────────────────────────────────────────────────
+// Lesen/Schreiben der Beschäftigungs- und Urlaubskonfiguration eines
+// Mitarbeiters (nur Admin).
+//
+// KEINE eigene RPC — bewusst: profiles hat keine "update own profile"-Policy,
+// ein Mitarbeiter kann seine Zeile also gar nicht per UPDATE anfassen. Die
+// einzige UPDATE-Policy ist "admin update profiles in own company"
+// (firmengescopet in USING UND WITH CHECK), und der erweiterte Feld-Guard
+// (20260823000000) schützt die neuen Spalten zusätzlich. Die Validierung
+// liegt als CHECK-Constraint in der DB und greift damit auf JEDEM Schreibpfad.
+// Eine zusätzliche SECURITY DEFINER-RPC brächte hier keine Sicherheit, nur
+// mehr Angriffsfläche — gleiche Bauform wie setEmployeeActive().
+// ─────────────────────────────────────────────────────────────────
+
+import { supabase } from "@/lib/supabase";
+import type {
+  CompanyVacationDefaults,
+  EmploymentConfig,
+  EmploymentType,
+} from "@/types/employment";
+
+type ProfileConfigRow = {
+  employment_type: EmploymentType | null;
+  employment_start_date: string | null;
+  employment_end_date: string | null;
+  vacation_management_enabled: boolean | null;
+  vacation_annual_entitlement_days: number | string | null;
+  vacation_reference_days_per_week: number | string | null;
+};
+
+type CompanyDefaultsRow = {
+  default_vacation_annual_entitlement_days: number | string | null;
+  default_vacation_reference_days_per_week: number | string | null;
+  default_vacation_management_enabled: boolean | null;
+};
+
+const PROFILE_CONFIG_SELECT =
+  "employment_type, employment_start_date, employment_end_date, " +
+  "vacation_management_enabled, vacation_annual_entitlement_days, " +
+  "vacation_reference_days_per_week";
+
+// PostgREST liefert numeric als STRING (Präzision geht sonst verloren).
+// Ohne diese Umwandlung wären Vergleiche/Anzeigen subtil falsch.
+function toNumber(value: number | string | null): number | null {
+  if (value === null) return null;
+  const parsed = typeof value === "string" ? Number(value) : value;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function mapConfig(row: ProfileConfigRow): EmploymentConfig {
+  return {
+    employmentType: row.employment_type,
+    employmentStartDate: row.employment_start_date,
+    employmentEndDate: row.employment_end_date,
+    vacationManagementEnabled: row.vacation_management_enabled ?? false,
+    vacationAnnualEntitlementDays: toNumber(row.vacation_annual_entitlement_days),
+    vacationReferenceDaysPerWeek: toNumber(row.vacation_reference_days_per_week),
+  };
+}
+
+/** Konfiguration eines Mitarbeiters laden. */
+export async function getEmploymentConfig(
+  employeeId: string,
+): Promise<EmploymentConfig> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(PROFILE_CONFIG_SELECT)
+    .eq("id", employeeId)
+    .single();
+
+  if (error) throw error;
+  if (!data) throw new Error("Mitarbeiter nicht gefunden.");
+
+  return mapConfig(data as unknown as ProfileConfigRow);
+}
+
+/** Firmen-Defaults des aktuell eingeloggten Admins laden. */
+export async function getCompanyVacationDefaults(): Promise<CompanyVacationDefaults> {
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+  if (authError) throw authError;
+
+  const userId = authData.user?.id;
+  if (!userId) throw new Error("Kein eingeloggter Benutzer gefunden.");
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("company_id")
+    .eq("id", userId)
+    .single();
+
+  if (profileError) throw new Error("Profil konnte nicht geladen werden.");
+  if (!profile?.company_id) throw new Error("Kein company_id im Profil gefunden.");
+
+  const { data, error } = await supabase
+    .from("companies")
+    .select(
+      "default_vacation_annual_entitlement_days, default_vacation_reference_days_per_week, default_vacation_management_enabled",
+    )
+    .eq("id", profile.company_id)
+    .single();
+
+  if (error) throw error;
+
+  const row = (data ?? {}) as CompanyDefaultsRow;
+  return {
+    defaultAnnualEntitlementDays: toNumber(row.default_vacation_annual_entitlement_days ?? null),
+    defaultReferenceDaysPerWeek: toNumber(row.default_vacation_reference_days_per_week ?? null),
+    defaultVacationManagementEnabled: row.default_vacation_management_enabled ?? false,
+  };
+}
+
+export type UpdateEmploymentConfigInput = {
+  employeeId: string;
+} & EmploymentConfig;
+
+/**
+ * Konfiguration speichern (nur Admin — serverseitig über RLS + Feld-Guard).
+ *
+ * Clientseitige Vorprüfung, damit der Nutzer eine verständliche deutsche
+ * Meldung bekommt statt eines rohen Constraint-Fehlers. Die DB-CHECKs bleiben
+ * die maßgebliche Instanz — diese Prüfung ersetzt sie NICHT.
+ */
+export async function updateEmploymentConfig(
+  input: UpdateEmploymentConfigInput,
+): Promise<EmploymentConfig> {
+  const {
+    employeeId,
+    employmentStartDate,
+    employmentEndDate,
+    vacationAnnualEntitlementDays,
+    vacationReferenceDaysPerWeek,
+  } = input;
+
+  if (
+    employmentStartDate &&
+    employmentEndDate &&
+    employmentEndDate < employmentStartDate
+  ) {
+    throw new Error("Das Austrittsdatum darf nicht vor dem Eintrittsdatum liegen.");
+  }
+
+  if (
+    vacationAnnualEntitlementDays !== null &&
+    (vacationAnnualEntitlementDays < 0 || vacationAnnualEntitlementDays > 365)
+  ) {
+    throw new Error("Der Jahresanspruch muss zwischen 0 und 365 Tagen liegen.");
+  }
+
+  if (
+    vacationReferenceDaysPerWeek !== null &&
+    (vacationReferenceDaysPerWeek <= 0 || vacationReferenceDaysPerWeek > 7)
+  ) {
+    throw new Error("Die Referenz-Arbeitstage müssen zwischen 0 und 7 pro Woche liegen.");
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .update({
+      employment_type: input.employmentType,
+      employment_start_date: employmentStartDate,
+      employment_end_date: employmentEndDate,
+      vacation_management_enabled: input.vacationManagementEnabled,
+      vacation_annual_entitlement_days: vacationAnnualEntitlementDays,
+      vacation_reference_days_per_week: vacationReferenceDaysPerWeek,
+    })
+    .eq("id", employeeId)
+    .select(PROFILE_CONFIG_SELECT)
+    .single();
+
+  if (error) throw error;
+  if (!data) {
+    throw new Error(
+      "Die Konfiguration konnte nicht gespeichert werden. Bitte prüfe deine Berechtigung.",
+    );
+  }
+
+  return mapConfig(data as unknown as ProfileConfigRow);
+}

--- a/supabase/migrations/20260823000000_vacation_entitlement_foundation.sql
+++ b/supabase/migrations/20260823000000_vacation_entitlement_foundation.sql
@@ -1,0 +1,184 @@
+-- =========================================================
+-- Urlaubsanspruch-Konfiguration — Grundlage (NUR Konfiguration)
+-- =========================================================
+-- Legt die Beschäftigungs- und Urlaubs-KONFIGURATION an. BEWUSST NICHT
+-- enthalten: Saldo, verbrauchter/verbleibender Urlaub, Übertrag,
+-- Snapshot-bei-Genehmigung, AU-Nachweise, Anteilsberechnung. Diese gehören in
+-- das nachfolgende Ledger-Arbeitspaket.
+--
+-- KERNENTSCHEIDUNG — Beschäftigungsart ist REIN BESCHREIBEND:
+--   employment_type steuert NICHTS. Kein Urlaubsanspruch wird daraus
+--   abgeleitet, kein Default, keine Verzweigung. Minijob und Aushilfe haben
+--   in Deutschland sehr wohl gesetzlichen Urlaubsanspruch — eine automatische
+--   Ableitung "Minijob => 0 Tage" wäre schlicht falsch. Deshalb sind
+--   Beschäftigungsart und Urlaubsverwaltung zwei UNABHÄNGIGE Konzepte:
+--   jede Kombination ist gültig (Vollzeit ohne Urlaubskonto, Minijob mit
+--   Urlaubskonto, …).
+--
+-- VERERBUNG (bewusst einfach):
+--   Mitarbeiter-Override NULL  -> Firmen-Default gilt.
+--   Mitarbeiter-Override gesetzt -> gewinnt.
+--   Es wird NICHTS beim Speichern materialisiert; die effektive Konfiguration
+--   wird immer frisch aufgelöst (utils/vacationConfig.ts). Damit wirkt eine
+--   Änderung des Firmen-Defaults sofort für alle, die keinen Override haben.
+--
+-- SICHERHEIT: keine neuen Policies, keine neue RPC. profiles hat bewusst
+--   KEINE "update own profile"-Policy — ein Mitarbeiter kann seine eigene
+--   Zeile ueberhaupt nicht per UPDATE anfassen. Die einzige UPDATE-Policy ist
+--   "admin update profiles in own company" (firmengescopet in USING UND WITH
+--   CHECK). Die neuen Spalten erben diesen Schutz vollstaendig. Zusaetzlich
+--   wird der bestehende Feld-Guard unten ERWEITERT (nie abgeschwaecht).
+
+-- ---------------------------------------------------------
+-- 1. Beschäftigungsart (rein beschreibend)
+-- ---------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'employment_type') then
+    create type public.employment_type as enum
+      ('vollzeit', 'teilzeit', 'minijob', 'aushilfe', 'sonstiges');
+  end if;
+end $$;
+
+comment on type public.employment_type is
+'Beschäftigungsart — REIN BESCHREIBEND. Steuert ausdruecklich KEINE '
+'Urlaubslogik: kein Anspruch, kein Default, keine Verzweigung wird daraus '
+'abgeleitet (Minijob/Aushilfe haben gesetzlichen Urlaubsanspruch).';
+
+-- ---------------------------------------------------------
+-- 2. profiles: Beschäftigung + Urlaubs-Konfiguration
+-- ---------------------------------------------------------
+-- Alles nullable bzw. mit sicherem Default -> Bestandszeilen bleiben ohne
+-- Backfill gueltig. vacation_management_enabled ist bewusst DEFAULT false:
+-- Urlaubskonto ist ein Opt-in je Mitarbeiter.
+alter table public.profiles
+  add column if not exists employment_type       public.employment_type,
+  add column if not exists employment_start_date date,
+  add column if not exists employment_end_date   date,
+  add column if not exists vacation_management_enabled boolean not null default false,
+  -- numeric, nicht int: halbe Tage (27.5) und Teilzeit-Referenzwerte (2.5
+  -- Tage/Woche) sind fachlich realistisch und spaeter im Ledger noetig.
+  add column if not exists vacation_annual_entitlement_days numeric(5,2),
+  add column if not exists vacation_reference_days_per_week numeric(3,2);
+
+comment on column public.profiles.employment_type is
+'Beschäftigungsart, rein beschreibend (siehe Typkommentar). NIE Grundlage fuer Urlaubslogik.';
+comment on column public.profiles.vacation_management_enabled is
+'Rechnet/zeigt TaskOps fuer diesen Mitarbeiter ein Urlaubskonto? Opt-in. '
+'FALSE heisst NICHT "kein gesetzlicher Anspruch" — nur, dass die App ihn '
+'nicht fuehrt. Der Antrags-/Genehmigungs-Flow funktioniert unabhaengig davon.';
+comment on column public.profiles.vacation_annual_entitlement_days is
+'Individueller Jahresanspruch in Tagen. NULL = Firmen-Default gilt.';
+comment on column public.profiles.vacation_reference_days_per_week is
+'Individuelle Referenz-Arbeitstage/Woche. NULL = Firmen-Default gilt.';
+
+-- ---------------------------------------------------------
+-- 3. companies: Defaults
+-- ---------------------------------------------------------
+alter table public.companies
+  add column if not exists default_vacation_annual_entitlement_days numeric(5,2),
+  add column if not exists default_vacation_reference_days_per_week numeric(3,2),
+  add column if not exists default_vacation_management_enabled boolean not null default false;
+
+comment on column public.companies.default_vacation_annual_entitlement_days is
+'Firmen-Default Jahresanspruch. Greift fuer jeden Mitarbeiter ohne eigenen Wert.';
+comment on column public.companies.default_vacation_reference_days_per_week is
+'Firmen-Default Referenz-Arbeitstage/Woche. Greift ohne eigenen Wert.';
+comment on column public.companies.default_vacation_management_enabled is
+'Vorschlagswert fuer neu angelegte Mitarbeiter. Aktiviert NICHT rueckwirkend '
+'bestehende Mitarbeiter — deren profiles-Wert bleibt massgeblich.';
+
+-- ---------------------------------------------------------
+-- 4. Validierung (greift bei JEDEM Schreibpfad)
+-- ---------------------------------------------------------
+-- Bewusst KEINE Regel, die einen Anspruch aus employment_type ableitet.
+alter table public.profiles
+  drop constraint if exists chk_profiles_vacation_entitlement;
+alter table public.profiles
+  add constraint chk_profiles_vacation_entitlement check (
+    vacation_annual_entitlement_days is null
+    or (vacation_annual_entitlement_days >= 0 and vacation_annual_entitlement_days <= 365)
+  );
+
+-- > 0: null Referenztage waeren als Divisor im spaeteren Ledger sinnlos.
+-- <= 7: mehr Arbeitstage als Kalendertage/Woche gibt es nicht.
+alter table public.profiles
+  drop constraint if exists chk_profiles_vacation_reference_days;
+alter table public.profiles
+  add constraint chk_profiles_vacation_reference_days check (
+    vacation_reference_days_per_week is null
+    or (vacation_reference_days_per_week > 0 and vacation_reference_days_per_week <= 7)
+  );
+
+alter table public.profiles
+  drop constraint if exists chk_profiles_employment_dates;
+alter table public.profiles
+  add constraint chk_profiles_employment_dates check (
+    employment_start_date is null
+    or employment_end_date is null
+    or employment_end_date >= employment_start_date
+  );
+
+alter table public.companies
+  drop constraint if exists chk_companies_vacation_defaults;
+alter table public.companies
+  add constraint chk_companies_vacation_defaults check (
+    (default_vacation_annual_entitlement_days is null
+      or (default_vacation_annual_entitlement_days >= 0 and default_vacation_annual_entitlement_days <= 365))
+    and
+    (default_vacation_reference_days_per_week is null
+      or (default_vacation_reference_days_per_week > 0 and default_vacation_reference_days_per_week <= 7))
+  );
+
+-- ---------------------------------------------------------
+-- 5. Feld-Guard ERWEITERN (Verteidigung in der Tiefe)
+-- ---------------------------------------------------------
+-- Heute koennen Mitarbeiter ihre profiles-Zeile ohnehin nicht per UPDATE
+-- anfassen (es gibt keine Self-Update-Policy). Sollte je eine solche Policy
+-- ergaenzt werden, sollen diese Felder trotzdem Admin-only bleiben — deshalb
+-- wandern sie jetzt in denselben Guard wie role/company_id/is_active.
+-- Logik und Ausnahmen (service_role, DEFINER-Funktionen) UNVERAENDERT.
+create or replace function public.enforce_profile_field_guard()
+returns trigger
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  if current_user not in ('authenticated', 'anon') then
+    return new;
+  end if;
+
+  if new.role       is not distinct from old.role
+     and new.company_id is not distinct from old.company_id
+     and new.is_active  is not distinct from old.is_active
+     -- Beschäftigungs-/Urlaubskonfiguration (20260823000000)
+     and new.employment_type       is not distinct from old.employment_type
+     and new.employment_start_date is not distinct from old.employment_start_date
+     and new.employment_end_date   is not distinct from old.employment_end_date
+     and new.vacation_management_enabled is not distinct from old.vacation_management_enabled
+     and new.vacation_annual_entitlement_days is not distinct from old.vacation_annual_entitlement_days
+     and new.vacation_reference_days_per_week is not distinct from old.vacation_reference_days_per_week
+  then
+    return new;
+  end if;
+
+  if public.current_user_role() = 'admin'
+     and old.company_id is not distinct from public.current_user_company_id() then
+    return new;
+  end if;
+
+  raise exception
+    'Nicht erlaubt: role, company_id, is_active sowie Beschäftigungs- und Urlaubskonfiguration dürfen nur von einem Admin derselben Firma geändert werden.'
+    using errcode = '42501';
+end;
+$$;
+
+alter function public.enforce_profile_field_guard() owner to postgres;
+
+comment on function public.enforce_profile_field_guard() is
+'BEFORE UPDATE Guard auf profiles: blockiert Änderungen an role/company_id/'
+'is_active sowie an der Beschäftigungs-/Urlaubskonfiguration aus einem '
+'direkten authenticated-Schreibvorgang, außer der Aufrufer ist ein aktiver '
+'Admin der Firma der betroffenen Zeile. service_role und SECURITY DEFINER-'
+'Funktionen (anderer current_user) sind ausgenommen.';

--- a/types/employment.ts
+++ b/types/employment.ts
@@ -1,0 +1,89 @@
+// types/employment.ts
+// ─────────────────────────────────────────────────────────────────
+// Beschäftigungs- und Urlaubs-KONFIGURATION eines Mitarbeiters.
+//
+// WICHTIG — dieser Typ trägt bewusst KEINEN Saldo: kein verbrauchter, kein
+// verbleibender Urlaub, kein Übertrag. Das ist reine Konfiguration. Die
+// Verbrauchsrechnung (Ledger) kommt im nächsten Arbeitspaket; sie hier
+// vorwegzunehmen würde eine Zahl erzeugen, die niemand pflegt.
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Beschäftigungsart — REIN BESCHREIBEND.
+ *
+ * Aus diesem Wert wird NIE ein Urlaubsanspruch abgeleitet. Minijob und
+ * Aushilfe haben gesetzlichen Urlaubsanspruch; eine automatische Zuordnung
+ * „Minijob = 0 Tage" wäre fachlich falsch. Beschäftigungsart und
+ * Urlaubsverwaltung sind zwei unabhängige Schalter.
+ */
+export type EmploymentType =
+  | "vollzeit"
+  | "teilzeit"
+  | "minijob"
+  | "aushilfe"
+  | "sonstiges";
+
+export const EMPLOYMENT_TYPES: EmploymentType[] = [
+  "vollzeit",
+  "teilzeit",
+  "minijob",
+  "aushilfe",
+  "sonstiges",
+];
+
+export const EMPLOYMENT_TYPE_LABELS: Record<EmploymentType, string> = {
+  vollzeit: "Vollzeit",
+  teilzeit: "Teilzeit",
+  minijob: "Minijob",
+  aushilfe: "Aushilfe",
+  sonstiges: "Sonstiges",
+};
+
+/** Konfiguration, wie sie am Mitarbeiter gespeichert ist (Overrides = null-fähig). */
+export type EmploymentConfig = {
+  employmentType: EmploymentType | null;
+  employmentStartDate: string | null; // "YYYY-MM-DD"
+  employmentEndDate: string | null; // "YYYY-MM-DD"
+  vacationManagementEnabled: boolean;
+  /** null = Firmen-Default gilt. */
+  vacationAnnualEntitlementDays: number | null;
+  /** null = Firmen-Default gilt. */
+  vacationReferenceDaysPerWeek: number | null;
+};
+
+/** Firmenweite Vorgabewerte. */
+export type CompanyVacationDefaults = {
+  defaultAnnualEntitlementDays: number | null;
+  defaultReferenceDaysPerWeek: number | null;
+  defaultVacationManagementEnabled: boolean;
+};
+
+/** Woher ein effektiver Wert stammt — die UI zeigt das explizit an. */
+export type ConfigSource = "employee" | "company";
+
+export type ResolvedValue = {
+  value: number;
+  source: ConfigSource;
+};
+
+/**
+ * Ergebnis der Auflösung. Drei klar getrennte Zustände statt stiller
+ * Ersatzwerte:
+ *
+ *  - `disabled`    → Urlaubskonto ist für diesen Mitarbeiter nicht aktiv.
+ *                    Die UI zeigt dann KEINE Zahl (insbesondere kein „0 Tage",
+ *                    das fälschlich wie „kein Anspruch" gelesen würde).
+ *  - `incomplete`  → aktiv, aber es fehlt mindestens ein Pflichtwert (weder
+ *                    Override noch Firmen-Default gesetzt). Bewusst ein
+ *                    eigener Zustand: einen Default zu erfinden würde einen
+ *                    Konfigurationsfehler verstecken.
+ *  - `configured`  → aktiv und vollständig.
+ */
+export type EffectiveVacationConfig =
+  | { status: "disabled" }
+  | { status: "incomplete"; missing: ("entitlement" | "referenceDays")[] }
+  | {
+      status: "configured";
+      annualEntitlementDays: ResolvedValue;
+      referenceDaysPerWeek: ResolvedValue;
+    };

--- a/utils/vacationConfig.ts
+++ b/utils/vacationConfig.ts
@@ -1,0 +1,75 @@
+// utils/vacationConfig.ts
+// ─────────────────────────────────────────────────────────────────
+// Auflösung der EFFEKTIVEN Urlaubs-Konfiguration eines Mitarbeiters.
+//
+// Reine Funktion, kein Supabase-Zugriff — gleiche Bauform wie
+// utils/jobSchedule.ts und utils/resolveEffectiveAbsenceDays.ts, damit die
+// Regel ohne Netzwerk nachvollziehbar und testbar bleibt.
+//
+// ABSICHTLICH NICHT HIER: verbrauchter Urlaub, Resturlaub, Übertrag,
+// Anteilsberechnung. Diese Datei beantwortet ausschließlich „welche
+// Konfiguration gilt für diesen Mitarbeiter?" — nicht „wie viel hat er noch?".
+// Die Verbrauchsrechnung folgt im Ledger-Arbeitspaket.
+// ─────────────────────────────────────────────────────────────────
+
+import type {
+  CompanyVacationDefaults,
+  EffectiveVacationConfig,
+  EmploymentConfig,
+  ResolvedValue,
+} from "@/types/employment";
+
+// Override gewinnt, sonst Firmen-Default, sonst „fehlt". Bewusst KEIN
+// erfundener Ersatzwert: ein stiller Default würde einen echten
+// Konfigurationsfehler unsichtbar machen.
+function resolve(
+  override: number | null,
+  companyDefault: number | null,
+): ResolvedValue | null {
+  if (override !== null) return { value: override, source: "employee" };
+  if (companyDefault !== null) return { value: companyDefault, source: "company" };
+  return null;
+}
+
+/**
+ * Ermittelt die geltende Urlaubs-Konfiguration.
+ *
+ * Die Beschäftigungsart wird hier BEWUSST nicht gelesen — sie darf den
+ * Anspruch nicht beeinflussen (siehe types/employment.ts).
+ */
+export function resolveEffectiveVacationConfig(
+  employee: EmploymentConfig,
+  companyDefaults: CompanyVacationDefaults,
+): EffectiveVacationConfig {
+  if (!employee.vacationManagementEnabled) {
+    return { status: "disabled" };
+  }
+
+  const entitlement = resolve(
+    employee.vacationAnnualEntitlementDays,
+    companyDefaults.defaultAnnualEntitlementDays,
+  );
+  const referenceDays = resolve(
+    employee.vacationReferenceDaysPerWeek,
+    companyDefaults.defaultReferenceDaysPerWeek,
+  );
+
+  const missing: ("entitlement" | "referenceDays")[] = [];
+  if (!entitlement) missing.push("entitlement");
+  if (!referenceDays) missing.push("referenceDays");
+
+  if (missing.length > 0) {
+    return { status: "incomplete", missing };
+  }
+
+  return {
+    status: "configured",
+    annualEntitlementDays: entitlement!,
+    referenceDaysPerWeek: referenceDays!,
+  };
+}
+
+/** Kurzlabel für die Herkunft eines Wertes (Admin-UI). */
+export function describeSource(source: ResolvedValue["source"]): string {
+  return source === "employee" ? "individuell" : "Firmen-Standard";
+}


### PR DESCRIPTION
## Problem

Es gibt heute **keinerlei** Beschäftigungs- oder Urlaubs-Stammdaten: `profiles` kennt weder Beschäftigungsart noch Eintrittsdatum, `companies` keine Vorgabewerte. Ein Urlaubskonto lässt sich damit nicht bauen — und ohne bewusste Modellierung entstünde genau die falsche Abkürzung „Minijob = kein Urlaub".

## Datenmodell

**`profiles`** (alles nullable bzw. sicherer Default → kein Backfill nötig):
`employment_type` (Enum), `employment_start_date`, `employment_end_date`, `vacation_management_enabled` (default `false`), `vacation_annual_entitlement_days` `numeric(5,2)`, `vacation_reference_days_per_week` `numeric(3,2)`.

**`companies`:** `default_vacation_annual_entitlement_days`, `default_vacation_reference_days_per_week`, `default_vacation_management_enabled`.

`numeric` statt `int`, weil halbe Tage (27.5) und Teilzeit-Referenzwerte (2.5 Tage/Woche) fachlich realistisch und im späteren Ledger nötig sind.

## Beschäftigungsart ist unabhängig

`employment_type` ist **rein beschreibend** und steuert nichts: kein Anspruch, kein Default, keine Verzweigung. Minijob und Aushilfe haben gesetzlichen Urlaubsanspruch — eine automatische Ableitung „Minijob ⇒ 0 Tage" wäre schlicht falsch. Beschäftigungsart und Urlaubsverwaltung sind zwei unabhängige Schalter; **jede** Kombination ist gültig (Vollzeit ohne Urlaubskonto, Minijob mit Urlaubskonto, …). Das ist per Test C/D und im Resolver abgesichert.

## Optionales Urlaubskonto

`vacation_management_enabled` ist ein Opt-in **pro Mitarbeiter** und bedeutet ausschließlich „führt TaskOps hierfür ein Konto?" — **nicht** „kein gesetzlicher Anspruch". Der bestehende Antrags-/Genehmigungs-Flow funktioniert unabhängig davon unverändert weiter (Test O/P).

**Vererbung:** Override `NULL` → Firmen-Default. Es wird nichts materialisiert; `resolveEffectiveVacationConfig()` löst immer frisch auf, sodass eine Änderung des Firmen-Defaults sofort für alle ohne Override wirkt. Drei klar getrennte Zustände:

| Status | Bedeutung |
|---|---|
| `disabled` | kein Konto → **keine Zahl**, insbesondere kein „0 Tage" |
| `incomplete` | aktiv, aber Pflichtwert fehlt → benennt explizit, was fehlt |
| `configured` | aktiv und vollständig, inkl. Herkunft je Wert |

`incomplete` ist bewusst ein eigener Zustand: einen Default zu erfinden würde einen Konfigurationsfehler verstecken.

## Security

**Keine neue RPC — bewusst.** `profiles` hat absichtlich keine „update own profile"-Policy; ein Mitarbeiter kann seine Zeile gar nicht per UPDATE anfassen. Die einzige UPDATE-Policy ist „admin update profiles in own company", firmengescopet in `USING` **und** `WITH CHECK`. Die neuen Spalten erben diesen Schutz vollständig. Zusätzlich wurde der bestehende Feld-Guard **erweitert** (nie abgeschwächt), damit die Felder auch dann Admin-only bleiben, falls je eine Self-Update-Policy ergänzt wird. Validierung liegt als `CHECK`-Constraint in der DB und greift auf **jedem** Schreibpfad — eine DEFINER-RPC hätte hier nur Angriffsfläche ohne Sicherheitsgewinn.

Live belegt: Selbst-Bearbeitung `42501` abgelehnt, firmenfremder Admin 0 Zeilen, Wert jeweils unverändert.

## Rückwärtskompatibilität

Migration läuft ohne Backfill: alle 3 Bestandsprofile blieben gültig, `vacation_management_enabled=false`, alle übrigen Felder `NULL`. Urlaub, Krankheit, Timesheet, Recurrence und sämtliche Notification-Events unverändert.

## Test-Evidenz (Staging)

**A–Q alle PASS.** DB-Tests: Bestandszeilen gültig; Vollzeit/Minijob/Aushilfe je mit aktivem Urlaubskonto speicherbar (Minijob behielt 12 Tage, **nicht** genullt); Vollzeit mit deaktiviertem Konto unterstützt; negative Ansprüche, 0 und >7 Referenztage sowie Austritt-vor-Eintritt abgelehnt; Admin-Bearbeitung erlaubt, Selbst- und Fremdfirmen-Bearbeitung abgelehnt; Urlaubsantrag und Krankmeldung inkl. Notifications unverändert; Timesheet-Quellen unberührt.

Resolver: 9/9 Assertions, u. a. Firmen-Default, Override gewinnt, gemischte Herkunft, `incomplete` benennt nur das Fehlende, und ein **explizit gesetztes 0** wird korrekt von `null` unterschieden.

`npx tsc --noEmit` und `npm run lint` sauber. Staging auf den Ausgangszustand zurückgesetzt, Production nachweislich unberührt (weiterhin `20260816000000`).

## Ausdrückliche Nicht-Ziele

Nicht enthalten und bewusst **nicht** vorweggenommen: `vacation_years`, `vacation_ledger`, verbrauchter/verbleibender Urlaub, Übertrag, Snapshot bei Genehmigung, AU-Nachweise, Urlaubs-Rückgabe, Anteilsberechnung. Es gibt insbesondere **keine** Spalte `remaining_vacation_days` — ein mutabler Saldo wäre genau die Falle, die dieses Fundament vermeiden soll.

## Nächste Phase

Ledger-Arbeitspaket: `vacation_years` + append-only `vacation_ledger` (Anspruch, Übertrag, Abzug bei Genehmigung, manuelle Korrektur), Snapshot des Abzugs zum Genehmigungszeitpunkt und die Admin-/Employee-Ansichten mit echtem Resturlaub.

## Deployment-Hinweis (unverändert, separate Aufgabe)

Production benötigt vor einem echten Release weiterhin `20260820000000`, `20260821000000`, `20260822000000`, einen Redeploy von `dispatch-notifications` und einen Push-Smoketest auf einem echten Gerät. Diese Migration (`20260823000000`) kommt hinzu. Nichts davon wurde hier deployt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)