### PR TITLE
feat: add vacation ledger and balance foundation

### DIFF
--- a/app/employees/[id]/vacation.tsx
+++ b/app/employees/[id]/vacation.tsx
@@ -1,0 +1,3 @@
+import AdminVacationAccountScreen from "@/features/vacation/AdminVacationAccountScreen";
+
+export default AdminVacationAccountScreen;

--- a/features/absences/AbsencesScreen.tsx
+++ b/features/absences/AbsencesScreen.tsx
@@ -28,6 +28,8 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { AbsenceCard } from "./components/AbsenceCard";
+import { VacationBalanceCard } from "./components/VacationBalanceCard";
+import { useOwnVacationBalance } from "./hooks/useOwnVacationBalance";
 import { useAbsences } from "./hooks/useAbsences";
 import { groupAbsences } from "@/utils/absenceGrouping";
 
@@ -70,6 +72,14 @@ export default function AbsencesScreen() {
     [absences],
   );
 
+  // Urlaubskonto: liefert null, solange es nicht aktiv UND initialisiert ist —
+  // die Karte rendert dann bewusst gar nichts (kein erfundenes "0 Tage").
+  const vacationBalance = useOwnVacationBalance();
+  const pendingVacations = useMemo(
+    () => absences.filter((a) => a.type === "vacation" && a.status === "requested"),
+    [absences],
+  );
+
   if (loading) return <LoadingScreen />;
 
   return (
@@ -95,6 +105,8 @@ export default function AbsencesScreen() {
           />
         }
       >
+        <VacationBalanceCard balance={vacationBalance} pending={pendingVacations} />
+
         {loadError ? (
           <View style={styles.bannerWrap}>
             <ErrorBanner

--- a/features/absences/admin/components/AdminAbsenceRow.tsx
+++ b/features/absences/admin/components/AdminAbsenceRow.tsx
@@ -10,6 +10,8 @@
 
 import { Card } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { isVacationAccountingEnabled } from "@/services/vacation/vacationLedger.service";
+import { VacationDeductionSheet } from "./VacationDeductionSheet";
 import type { AppTheme } from "@/constants/theme";
 import type { Absence } from "@/types/absence";
 import { formatAbsenceDateRange } from "@/utils/absenceFormat";
@@ -25,7 +27,7 @@ type Props = {
   busy: boolean;
   /** Standard true — EmployeeDetail blendet den Namen aus (steht bereits im Screen-Kontext). */
   showEmployeeName?: boolean;
-  onApprove: (absenceId: string) => void;
+  onApprove: (absenceId: string, deductions?: Record<string, number> | null) => void;
   onReject: (absenceId: string, adminNote: string) => void;
 };
 
@@ -39,6 +41,7 @@ export function AdminAbsenceRow({
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [rejectSheetOpen, setRejectSheetOpen] = useState(false);
+  const [deductionSheetOpen, setDeductionSheetOpen] = useState(false);
 
   const isVacation = absence.type === "vacation";
   const isPendingVacation = isVacation && absence.status === "requested";
@@ -47,7 +50,27 @@ export function AdminAbsenceRow({
       ? absence.adminNote
       : null;
 
+  // Wird fuer diesen Mitarbeiter ein Urlaubskonto gefuehrt, muss der Admin
+  // die Abzugsmenge bestaetigen (sie ist nicht berechenbar, siehe
+  // VacationDeductionSheet). Ohne Urlaubskonto bleibt der bisherige,
+  // einfache Bestaetigungsdialog.
   const handleApprove = async () => {
+    if (!absence.employeeId) return;
+
+    let accountingEnabled = false;
+    try {
+      accountingEnabled = await isVacationAccountingEnabled(absence.employeeId);
+    } catch {
+      // Konnte der Status nicht geladen werden, NICHT stillschweigend ohne
+      // Abzug genehmigen — die RPC wuerde bei aktivem Konto ohnehin ablehnen.
+      accountingEnabled = true;
+    }
+
+    if (accountingEnabled) {
+      setDeductionSheetOpen(true);
+      return;
+    }
+
     const confirmed = await confirmDialog({
       title: "Urlaub genehmigen",
       message: `Urlaubsantrag von ${absence.employeeName} (${formatAbsenceDateRange(absence)}) genehmigen?`,
@@ -141,7 +164,19 @@ export function AdminAbsenceRow({
           handleConfirmReject(note);
         }}
       />
-    </Card>
+          <VacationDeductionSheet
+        visible={deductionSheetOpen}
+        employeeName={absence.employeeName}
+        rangeLabel={formatAbsenceDateRange(absence)}
+        startDate={absence.startDate}
+        endDate={absence.endDate ?? absence.startDate}
+        onCancel={() => setDeductionSheetOpen(false)}
+        onConfirm={(deductions) => {
+          setDeductionSheetOpen(false);
+          onApprove(absence.id, deductions);
+        }}
+      />
+</Card>
   );
 }
 

--- a/features/absences/admin/components/VacationDeductionSheet.tsx
+++ b/features/absences/admin/components/VacationDeductionSheet.tsx
@@ -1,0 +1,189 @@
+// features/absences/admin/components/VacationDeductionSheet.tsx
+// Bestätigung der Abzugsmenge bei der Urlaubsgenehmigung.
+//
+// WARUM EINE EINGABE STATT EINER BERECHNUNG: aus den Referenz-Arbeitstagen
+// pro Woche (eine ANZAHL, nicht konkrete Wochentage) lässt sich nicht
+// ableiten, welche Tage eines Zeitraums Anspruch verbrauchen. Die
+// Einsatzplanung taugt ebenfalls nicht als Quelle — sie ist nachträglich
+// änderbar und nur ~3 Monate im Voraus materialisiert. Der Admin bestätigt
+// deshalb bewusst; der bestätigte Wert wird unveränderlich festgeschrieben.
+//
+// Bei einem Urlaub über den Jahreswechsel gibt es je Kalenderjahr ein
+// eigenes Feld — dadurch ist es unmöglich, versehentlich alle Tage ins
+// Startjahr zu buchen.
+
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import { yearsInRange } from "@/utils/vacationBalance";
+import React, { useMemo, useState } from "react";
+import {
+  Modal,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+type Props = {
+  visible: boolean;
+  employeeName: string;
+  rangeLabel: string;
+  startDate: string;
+  endDate: string;
+  onCancel: () => void;
+  onConfirm: (deductions: Record<string, number>) => void;
+};
+
+export function VacationDeductionSheet({
+  visible,
+  employeeName,
+  rangeLabel,
+  startDate,
+  endDate,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const years = useMemo(() => yearsInRange(startDate, endDate), [startDate, endDate]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+
+  const handleConfirm = () => {
+    const result: Record<string, number> = {};
+    for (const year of years) {
+      const raw = (values[String(year)] ?? "").trim().replace(",", ".");
+      if (!raw) {
+        setError(`Bitte die Tage für ${year} angeben (0 ist erlaubt).`);
+        return;
+      }
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        setError(`Ungültiger Wert für ${year}.`);
+        return;
+      }
+      result[String(year)] = parsed;
+    }
+    setError("");
+    setValues({});
+    onConfirm(result);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <Text style={styles.title}>Urlaub genehmigen</Text>
+          <Text style={styles.subtitle}>
+            {employeeName} · {rangeLabel}
+          </Text>
+          <Text style={styles.hint}>
+            Bitte bestätige, wie viele Urlaubstage abgezogen werden. Der Wert
+            wird dauerhaft festgeschrieben und später nicht neu berechnet.
+          </Text>
+
+          {years.map((year) => (
+            <View key={year} style={styles.field}>
+              <Text style={styles.label}>
+                {years.length > 1 ? `Tage für ${year}` : "Urlaubstage"}
+              </Text>
+              <TextInput
+                style={styles.input}
+                keyboardType="decimal-pad"
+                value={values[String(year)] ?? ""}
+                onChangeText={(text) =>
+                  setValues((prev) => ({ ...prev, [String(year)]: text }))
+                }
+                placeholder="z. B. 3"
+                placeholderTextColor={theme.colors.onSurfaceVariant}
+              />
+            </View>
+          ))}
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <View style={styles.actions}>
+            <TouchableOpacity style={styles.cancelBtn} onPress={onCancel}>
+              <Text style={styles.cancelText}>Abbrechen</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.confirmBtn} onPress={handleConfirm}>
+              <Text style={styles.confirmText}>Genehmigen</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.5)",
+      justifyContent: "center",
+      padding: theme.spacing.lg,
+    },
+    sheet: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.lg,
+      padding: theme.spacing.lg,
+      gap: theme.spacing.sm,
+    },
+    title: {
+      fontSize: theme.typography.size.lg,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    subtitle: { fontSize: theme.typography.size.sm, color: theme.colors.onSurfaceVariant },
+    hint: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.xs,
+      marginBottom: theme.spacing.xs,
+    },
+    field: { gap: theme.spacing.xs },
+    label: {
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+      color: theme.colors.onSurface,
+      fontSize: theme.typography.size.md,
+    },
+    error: { fontSize: theme.typography.size.xs, color: theme.colors.error },
+    actions: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+      marginTop: theme.spacing.md,
+    },
+    cancelBtn: {
+      flex: 1,
+      paddingVertical: theme.spacing.md,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      alignItems: "center",
+    },
+    cancelText: { color: theme.colors.onSurface, fontSize: theme.typography.size.sm },
+    confirmBtn: {
+      flex: 1,
+      paddingVertical: theme.spacing.md,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.primary,
+      alignItems: "center",
+    },
+    confirmText: {
+      color: theme.colors.onPrimary,
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.semibold,
+    },
+  });
+}

--- a/features/absences/admin/hooks/useVacationReview.ts
+++ b/features/absences/admin/hooks/useVacationReview.ts
@@ -28,12 +28,14 @@ export function useVacationReview(onReviewed: (updated: Absence) => void) {
     };
   }, []);
 
+  // `deductions` = vom Admin bestätigte Tage je Jahr. Bei aktivem
+  // Urlaubskonto Pflicht (serverseitig erzwungen), sonst irrelevant.
   const approve = useCallback(
-    async (absenceId: string) => {
+    async (absenceId: string, deductions?: Record<string, number> | null) => {
       setBusyId(absenceId);
       setError("");
       try {
-        const updated = await reviewVacation(absenceId, "approved");
+        const updated = await reviewVacation(absenceId, "approved", undefined, deductions);
         onReviewed(updated);
         return updated;
       } catch (err) {

--- a/features/absences/components/VacationBalanceCard.tsx
+++ b/features/absences/components/VacationBalanceCard.tsx
@@ -1,0 +1,120 @@
+// features/absences/components/VacationBalanceCard.tsx
+// Kompakte Urlaubskonto-Anzeige für den Mitarbeiter (nur Lesen).
+//
+// RENDERT BEWUSST NICHTS, solange nicht beides gilt: Urlaubskonto aktiv UND
+// Jahr initialisiert. Ein "Resturlaub: 0" nur weil die Buchhaltung aus oder
+// noch nicht eingerichtet ist, wäre schlicht falsch — der Mitarbeiter hätte
+// gesetzlich sehr wohl Anspruch. Lieber gar keine Zahl als eine erfundene.
+//
+// "Offene Anträge" zeigt absichtlich nur die ZEITRÄUME, keine Tagessumme:
+// wie viele Tage ein Antrag verbraucht, steht erst mit der Bestätigung des
+// Admins bei der Genehmigung fest.
+
+import { useAppTheme } from "@/hooks/useAppTheme";
+import type { AppTheme } from "@/constants/theme";
+import type { Absence } from "@/types/absence";
+import type { VacationBalance } from "@/types/vacationLedger";
+import { formatDays } from "@/utils/vacationBalance";
+import { formatForDisplay } from "@/utils/date";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  balance: VacationBalance | null;
+  pending: Absence[];
+};
+
+export function VacationBalanceCard({ balance, pending }: Props) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  // Kein Konto / nicht eingerichtet -> gar nichts anzeigen (siehe Kopf).
+  if (!balance) return null;
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Urlaub {balance.year}</Text>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Jahresanspruch</Text>
+        <Text style={styles.value}>{formatDays(balance.annualEntitlement)} Tage</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Verbraucht</Text>
+        <Text style={styles.value}>{formatDays(balance.usedDays)} Tage</Text>
+      </View>
+      {balance.adjustments !== 0 ? (
+        <View style={styles.row}>
+          <Text style={styles.label}>Korrekturen</Text>
+          <Text style={styles.value}>{formatDays(balance.adjustments)} Tage</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.divider} />
+      <View style={styles.row}>
+        <Text style={styles.strongLabel}>Resturlaub</Text>
+        <Text style={styles.strongValue}>{formatDays(balance.remaining)} Tage</Text>
+      </View>
+
+      {pending.length > 0 ? (
+        <>
+          <View style={styles.divider} />
+          <Text style={styles.label}>Offene Anträge</Text>
+          {pending.map((absence) => (
+            <Text key={absence.id} style={styles.pendingLine}>
+              {formatForDisplay(absence.startDate)}
+              {absence.endDate ? ` – ${formatForDisplay(absence.endDate)}` : ""}
+            </Text>
+          ))}
+          <Text style={styles.footnote}>
+            Die angerechneten Tage stehen erst mit der Genehmigung fest.
+          </Text>
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    card: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      gap: 2,
+      marginBottom: theme.spacing.md,
+    },
+    title: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+      marginBottom: theme.spacing.xs,
+    },
+    row: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 2 },
+    label: { fontSize: theme.typography.size.sm, color: theme.colors.onSurfaceVariant },
+    value: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    strongLabel: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    strongValue: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: theme.colors.outlineVariant,
+      marginVertical: theme.spacing.xs,
+    },
+    pendingLine: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    footnote: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.onSurfaceVariant,
+      marginTop: 2,
+    },
+  });
+}

--- a/features/absences/hooks/useOwnVacationBalance.ts
+++ b/features/absences/hooks/useOwnVacationBalance.ts
@@ -1,0 +1,50 @@
+// features/absences/hooks/useOwnVacationBalance.ts
+// Lädt das eigene Urlaubskonto des laufenden Jahres.
+//
+// Gibt null zurück, solange NICHT beides gilt: Urlaubskonto aktiv UND Jahr
+// initialisiert. Der Aufrufer zeigt dann gar keine Zahlen — ein "Resturlaub:
+// 0" wäre falsch, weil ein gesetzlicher Anspruch unabhängig davon besteht.
+//
+// Rein lesend: der Mitarbeiter darf sein Konto nie verändern (RLS erlaubt
+// ausschließlich SELECT auf den eigenen Zeilen).
+
+import { useAuth } from "@/context/AuthContext";
+import {
+  getVacationLedger,
+  getVacationYearId,
+} from "@/services/vacation/vacationLedger.service";
+import type { VacationBalance } from "@/types/vacationLedger";
+import { buildVacationBalance } from "@/utils/vacationBalance";
+import { useCallback, useEffect, useState } from "react";
+
+export function useOwnVacationBalance(): VacationBalance | null {
+  const { profile } = useAuth();
+  const [balance, setBalance] = useState<VacationBalance | null>(null);
+  const employeeId = profile?.id ?? null;
+
+  const load = useCallback(async () => {
+    if (!employeeId) {
+      setBalance(null);
+      return;
+    }
+    const year = new Date().getFullYear();
+    try {
+      const yearId = await getVacationYearId(employeeId, year);
+      if (!yearId) {
+        setBalance(null);
+        return;
+      }
+      setBalance(buildVacationBalance(year, await getVacationLedger(yearId)));
+    } catch {
+      // Das Urlaubskonto ist eine Zusatzinformation — schlägt es fehl, bleibt
+      // der Abwesenheits-Screen vollständig nutzbar (Antrag/Historie).
+      setBalance(null);
+    }
+  }, [employeeId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return balance;
+}

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -376,6 +376,17 @@ export default function EmployeeDetailScreen() {
               icon="calendar-outline"
             />
           </TouchableOpacity>
+          <View style={styles.rowDivider} />
+          <TouchableOpacity
+            onPress={() => router.push(`/employees/${employee.id}/vacation`)}
+            accessibilityRole="button"
+          >
+            <InfoRow
+              label="Urlaubskonto"
+              value="Saldo & Verlauf"
+              icon="sunny-outline"
+            />
+          </TouchableOpacity>
         </Card>
 
         {/* ── Aktueller Job ── */}

--- a/features/vacation/AdminVacationAccountScreen.tsx
+++ b/features/vacation/AdminVacationAccountScreen.tsx
@@ -1,0 +1,414 @@
+// features/vacation/AdminVacationAccountScreen.tsx
+// Urlaubskonto eines Mitarbeiters: Saldo, Verlauf, Initialisierung, Korrektur.
+//
+// Der Saldo wird NIE gespeichert, sondern immer aus den Buchungszeilen
+// summiert — die Aufstellung oben und der Verlauf unten sind damit
+// zwangsläufig konsistent ("warum 28,5?" ist zeilenweise beantwortbar).
+//
+// Drei klar getrennte Zustände statt einer erfundenen 0:
+//   Urlaubskonto aus        -> gar keine Zahlen
+//   Jahr nicht angelegt     -> Einrichtungshinweis + Aktion
+//   Jahr angelegt           -> Saldo + Verlauf
+
+import { AppHeader, ErrorBanner } from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import {
+  getEmploymentConfig,
+  getCompanyVacationDefaults,
+} from "@/services/employees/employmentConfig.service";
+import {
+  addVacationAdjustment,
+  getVacationLedger,
+  getVacationYearId,
+  initializeVacationYear,
+} from "@/services/vacation/vacationLedger.service";
+import type { AppTheme } from "@/constants/theme";
+import type { VacationBalance } from "@/types/vacationLedger";
+import { LEDGER_ENTRY_LABELS } from "@/types/vacationLedger";
+import {
+  buildVacationBalance,
+  formatDays,
+  formatLedgerAmount,
+} from "@/utils/vacationBalance";
+import { resolveEffectiveVacationConfig } from "@/utils/vacationConfig";
+import { alertDialog } from "@/utils/dialogs";
+import { toUserMessage } from "@/utils/userMessages";
+import { formatForDisplay } from "@/utils/date";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "disabled" }
+  | { kind: "not_initialized"; canInitialize: boolean; reason?: string }
+  | { kind: "ready"; balance: VacationBalance };
+
+export default function AdminVacationAccountScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const year = new Date().getFullYear();
+
+  const [state, setState] = useState<State>({ kind: "loading" });
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [adjustAmount, setAdjustAmount] = useState("");
+  const [adjustNote, setAdjustNote] = useState("");
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setState({ kind: "loading" });
+    setError(null);
+    try {
+      const [config, defaults] = await Promise.all([
+        getEmploymentConfig(id),
+        getCompanyVacationDefaults(),
+      ]);
+      const effective = resolveEffectiveVacationConfig(config, defaults);
+
+      if (effective.status === "disabled") {
+        setState({ kind: "disabled" });
+        return;
+      }
+
+      const yearId = await getVacationYearId(id, year);
+      if (!yearId) {
+        // Ohne vollständige Konfiguration kann der Jahresanspruch nicht
+        // gebucht werden — das wird benannt, nicht mit 0 überdeckt.
+        setState({
+          kind: "not_initialized",
+          canInitialize: effective.status === "configured",
+          reason:
+            effective.status === "incomplete"
+              ? "Die Urlaubs-Konfiguration ist unvollständig (Jahresanspruch fehlt)."
+              : undefined,
+        });
+        return;
+      }
+
+      const entries = await getVacationLedger(yearId);
+      setState({ kind: "ready", balance: buildVacationBalance(year, entries) });
+    } catch (err) {
+      setError(toUserMessage(err));
+      setState({ kind: "disabled" });
+    }
+  }, [id, year]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleInitialize = async () => {
+    if (!id) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await initializeVacationYear(id, year);
+      await load();
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleAdjust = async () => {
+    if (!id) return;
+    const parsed = Number(adjustAmount.trim().replace(",", "."));
+    if (!Number.isFinite(parsed) || parsed === 0) {
+      setError("Bitte einen Korrekturwert ungleich 0 angeben.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await addVacationAdjustment(id, year, parsed, adjustNote);
+      setAdjustOpen(false);
+      setAdjustAmount("");
+      setAdjustNote("");
+      await load();
+      alertDialog("Gebucht", "Die Korrektur wurde im Verlauf festgehalten.");
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <AppHeader title={`Urlaubskonto ${year}`} onBack={() => router.back()} />
+      <ScrollView contentContainerStyle={styles.content}>
+        {error ? <ErrorBanner message={error} /> : null}
+
+        {state.kind === "loading" ? (
+          <ActivityIndicator color={theme.colors.primary} style={styles.loader} />
+        ) : null}
+
+        {state.kind === "disabled" ? (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Urlaubskonto nicht aktiv</Text>
+            <Text style={styles.hint}>
+              Für diesen Mitarbeiter wird kein Urlaubskonto geführt. Urlaubsanträge
+              funktionieren unabhängig davon weiterhin.
+            </Text>
+          </View>
+        ) : null}
+
+        {state.kind === "not_initialized" ? (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Noch nicht eingerichtet</Text>
+            <Text style={styles.hint}>
+              {state.reason ??
+                `Für ${year} wurde noch kein Jahresanspruch gebucht. Erst danach entsteht ein Saldo.`}
+            </Text>
+            {state.canInitialize ? (
+              <TouchableOpacity
+                style={[styles.primaryBtn, busy && styles.btnDisabled]}
+                onPress={handleInitialize}
+                disabled={busy}
+              >
+                <Text style={styles.primaryBtnText}>
+                  {busy ? "..." : `Jahresanspruch für ${year} anlegen`}
+                </Text>
+              </TouchableOpacity>
+            ) : null}
+          </View>
+        ) : null}
+
+        {state.kind === "ready" ? (
+          <>
+            <View style={styles.card}>
+              <Row label="Jahresanspruch" value={formatDays(state.balance.annualEntitlement)} />
+              {state.balance.carryOver !== 0 ? (
+                <Row label="Übertrag" value={formatDays(state.balance.carryOver)} />
+              ) : null}
+              <Row label="Verbraucht" value={formatDays(state.balance.usedDays)} />
+              <Row label="Korrekturen" value={formatLedgerAmount(state.balance.adjustments)} />
+              <View style={styles.divider} />
+              <Row label="Resturlaub" value={formatDays(state.balance.remaining)} strong />
+            </View>
+
+            <Text style={styles.sectionTitle}>Verlauf</Text>
+            <View style={styles.card}>
+              {state.balance.entries.map((entry) => (
+                <View key={entry.id} style={styles.entryRow}>
+                  <Text
+                    style={[
+                      styles.entryAmount,
+                      entry.amountDays < 0 ? styles.negative : styles.positive,
+                    ]}
+                  >
+                    {formatLedgerAmount(entry.amountDays)}
+                  </Text>
+                  <View style={styles.entryBody}>
+                    <Text style={styles.entryLabel}>
+                      {LEDGER_ENTRY_LABELS[entry.entryType]}
+                    </Text>
+                    {entry.note ? <Text style={styles.entryNote}>{entry.note}</Text> : null}
+                    <Text style={styles.entryDate}>{formatForDisplay(entry.createdAt)}</Text>
+                  </View>
+                </View>
+              ))}
+            </View>
+
+            <TouchableOpacity
+              style={[styles.secondaryBtn, busy && styles.btnDisabled]}
+              onPress={() => setAdjustOpen(true)}
+              disabled={busy}
+            >
+              <Text style={styles.secondaryBtnText}>Manuelle Korrektur</Text>
+            </TouchableOpacity>
+            <Text style={styles.hint}>
+              Buchungen werden nie gelöscht oder geändert. Eine falsche Korrektur
+              wird durch eine weitere Gegenbuchung berichtigt.
+            </Text>
+          </>
+        ) : null}
+      </ScrollView>
+
+      <Modal visible={adjustOpen} transparent animationType="fade">
+        <View style={styles.backdrop}>
+          <View style={styles.sheet}>
+            <Text style={styles.cardTitle}>Manuelle Korrektur</Text>
+            <Text style={styles.hint}>
+              Positiver Wert schreibt gut, negativer zieht ab. Eine Begründung ist
+              Pflicht — sie erscheint dauerhaft im Verlauf.
+            </Text>
+            <TextInput
+              style={styles.input}
+              keyboardType="decimal-pad"
+              placeholder="z. B. 2 oder -0,5"
+              placeholderTextColor={theme.colors.onSurfaceVariant}
+              value={adjustAmount}
+              onChangeText={setAdjustAmount}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="Begründung"
+              placeholderTextColor={theme.colors.onSurfaceVariant}
+              value={adjustNote}
+              onChangeText={setAdjustNote}
+            />
+            <View style={styles.actions}>
+              <TouchableOpacity style={styles.cancelBtn} onPress={() => setAdjustOpen(false)}>
+                <Text style={styles.secondaryBtnText}>Abbrechen</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.primaryBtn, styles.flex, busy && styles.btnDisabled]}
+                onPress={handleAdjust}
+                disabled={busy}
+              >
+                <Text style={styles.primaryBtnText}>Buchen</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+
+  function Row({
+    label,
+    value,
+    strong,
+  }: {
+    label: string;
+    value: string;
+    strong?: boolean;
+  }) {
+    return (
+      <View style={styles.row}>
+        <Text style={[styles.rowLabel, strong && styles.rowStrong]}>{label}</Text>
+        <Text style={[styles.rowValue, strong && styles.rowStrong]}>{value}</Text>
+      </View>
+    );
+  }
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    content: { padding: theme.spacing.lg, gap: theme.spacing.sm },
+    loader: { marginTop: theme.spacing.xl },
+    flex: { flex: 1 },
+    card: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      gap: theme.spacing.xs,
+    },
+    cardTitle: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    sectionTitle: {
+      fontSize: theme.typography.size.lg,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+      marginTop: theme.spacing.lg,
+    },
+    hint: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.xs,
+    },
+    row: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 2 },
+    rowLabel: { fontSize: theme.typography.size.sm, color: theme.colors.onSurfaceVariant },
+    rowValue: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    rowStrong: {
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.onSurface,
+      fontSize: theme.typography.size.md,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: theme.colors.outlineVariant,
+      marginVertical: theme.spacing.xs,
+    },
+    entryRow: {
+      flexDirection: "row",
+      gap: theme.spacing.md,
+      paddingVertical: theme.spacing.xs,
+    },
+    entryAmount: {
+      minWidth: 56,
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.semibold,
+    },
+    positive: { color: theme.colors.statusCompleted },
+    negative: { color: theme.colors.error },
+    entryBody: { flex: 1 },
+    entryLabel: { fontSize: theme.typography.size.sm, color: theme.colors.onSurface },
+    entryNote: { fontSize: theme.typography.size.xs, color: theme.colors.onSurfaceVariant },
+    entryDate: { fontSize: theme.typography.size.xs, color: theme.colors.onSurfaceVariant },
+    primaryBtn: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      marginTop: theme.spacing.sm,
+    },
+    primaryBtnText: {
+      color: theme.colors.onPrimary,
+      fontWeight: theme.typography.weight.semibold,
+      fontSize: theme.typography.size.sm,
+    },
+    secondaryBtn: {
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      marginTop: theme.spacing.md,
+    },
+    secondaryBtnText: { color: theme.colors.onSurface, fontSize: theme.typography.size.sm },
+    btnDisabled: { opacity: 0.6 },
+    backdrop: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.5)",
+      justifyContent: "center",
+      padding: theme.spacing.lg,
+    },
+    sheet: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.lg,
+      padding: theme.spacing.lg,
+      gap: theme.spacing.sm,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+      color: theme.colors.onSurface,
+      fontSize: theme.typography.size.md,
+    },
+    actions: { flexDirection: "row", gap: theme.spacing.sm, marginTop: theme.spacing.sm },
+    cancelBtn: {
+      flex: 1,
+      paddingVertical: theme.spacing.md,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      alignItems: "center",
+      marginTop: theme.spacing.sm,
+    },
+  });
+}

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -256,6 +256,16 @@ create table if not exists public.job_photos (
 -- Migrationen unter supabase/migrations/. Der FK ist hier bewusst
 -- vollständig dokumentiert statt weggelassen — das Nachtragen von
 -- job_assignments selbst gehört in eine eigene Aufräum-Änderung.
+-- Urlaubskonto (20260824000000). Der Saldo ist NIE gespeichert, sondern immer
+-- SUM(vacation_ledger.amount_days) — es gibt bewusst KEINE remaining_days-Spalte.
+-- vacation_years ist ein reiner Jahres-Container; der Jahresanspruch steht als
+-- annual_entitlement-Zeile im Ledger, damit es nur EINE Quelle je Betrag gibt.
+-- Beide Tabellen: RLS an, nur SELECT-Policies (Mitarbeiter eigene Zeilen, Admin
+-- firmenweit) — jede Buchung laeuft ueber SECURITY DEFINER-RPCs, Append-only
+-- ist dadurch strukturell erzwungen.
+-- HINWEIS: Definitionen liegen in der Migration; hier bewusst nur als
+-- Referenz-Kommentar (gleiche Drift-Anmerkung wie bei job_assignments).
+
 create table if not exists public.employee_time_adjustments (
   id uuid primary key default gen_random_uuid(),
   assignment_id uuid not null references public.job_assignments(id) on delete cascade,

--- a/services/absences/adminAbsences.service.ts
+++ b/services/absences/adminAbsences.service.ts
@@ -303,15 +303,30 @@ export async function getCurrentCompanyAbsences(
 }
 
 /** Admin genehmigt/lehnt eine Urlaubsanfrage der eigenen Firma ab. */
+/**
+ * Urlaub genehmigen/ablehnen.
+ *
+ * `deductions` ist die vom Admin BESTÄTIGTE Abzugsmenge je Kalenderjahr
+ * (z. B. `{ "2026": 3 }`, bei Jahresübergang `{ "2026": 2, "2027": 3 }`).
+ * Sie wird NICHT berechnet: aus Referenz-Arbeitstagen/Woche lässt sich nicht
+ * ableiten, welche konkreten Tage Anspruch verbrauchen, und die Einsatzplanung
+ * ist nachträglich änderbar (siehe Migration 20260824000000).
+ *
+ * Pflicht, sobald für den Mitarbeiter ein Urlaubskonto geführt wird — die RPC
+ * lehnt eine Genehmigung ohne bestätigten Abzug ab. Ohne Urlaubskonto bleibt
+ * der Ablauf unverändert und der Wert wird ignoriert.
+ */
 export async function reviewVacation(
   absenceId: string,
   decision: "approved" | "rejected",
   adminNote?: string,
+  deductions?: Record<string, number> | null,
 ): Promise<Absence> {
   const { data, error } = await supabase.rpc("admin_review_vacation", {
     absence_id_input: absenceId,
     decision_input: decision,
     admin_note_input: adminNote?.trim() || null,
+    p_deductions: deductions ?? null,
   });
 
   if (error) {

--- a/services/vacation/vacationLedger.service.ts
+++ b/services/vacation/vacationLedger.service.ts
@@ -1,0 +1,139 @@
+// services/vacation/vacationLedger.service.ts
+// ─────────────────────────────────────────────────────────────────
+// Urlaubskonto: Lesen des Ledgers + die drei buchenden Admin-Aktionen.
+//
+// SCHREIBEN ausschließlich über SECURITY DEFINER-RPCs — auf vacation_years
+// und vacation_ledger existiert bewusst KEINE insert/update/delete-Policy.
+// Append-only ist damit strukturell erzwungen, nicht bloß per UI versteckt.
+// ─────────────────────────────────────────────────────────────────
+
+import { supabase } from "@/lib/supabase";
+import type {
+  VacationLedgerEntry,
+  VacationLedgerEntryType,
+} from "@/types/vacationLedger";
+
+type LedgerRow = {
+  id: string;
+  entry_type: VacationLedgerEntryType;
+  amount_days: number | string;
+  absence_id: string | null;
+  created_by: string | null;
+  note: string | null;
+  created_at: string;
+};
+
+// PostgREST liefert numeric als String — ohne Umwandlung würde die
+// Saldo-Summe zur String-Verkettung.
+function toNumber(value: number | string): number {
+  return typeof value === "string" ? Number(value) : value;
+}
+
+function mapEntry(row: LedgerRow): VacationLedgerEntry {
+  return {
+    id: row.id,
+    entryType: row.entry_type,
+    amountDays: toNumber(row.amount_days),
+    absenceId: row.absence_id,
+    createdBy: row.created_by,
+    note: row.note,
+    createdAt: row.created_at,
+  };
+}
+
+/** Urlaubsjahr-ID, falls bereits initialisiert (sonst null). */
+export async function getVacationYearId(
+  employeeId: string,
+  year: number,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("vacation_years")
+    .select("id")
+    .eq("employee_id", employeeId)
+    .eq("year", year)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data as { id: string } | null)?.id ?? null;
+}
+
+/** Alle Buchungszeilen eines Urlaubsjahres (chronologisch). */
+export async function getVacationLedger(
+  vacationYearId: string,
+): Promise<VacationLedgerEntry[]> {
+  const { data, error } = await supabase
+    .from("vacation_ledger")
+    .select("id, entry_type, amount_days, absence_id, created_by, note, created_at")
+    .eq("vacation_year_id", vacationYearId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return ((data ?? []) as unknown as LedgerRow[]).map(mapEntry);
+}
+
+/**
+ * Urlaubsjahr anlegen und den Jahresanspruch buchen (Admin).
+ *
+ * Idempotent: ein zweiter Aufruf erzeugt weder ein zweites Jahr noch eine
+ * zweite Anspruchszeile. Der Betrag wird serverseitig aus der Konfiguration
+ * aufgelöst — der Client kann keine Menge vorgeben.
+ */
+export async function initializeVacationYear(
+  employeeId: string,
+  year: number,
+): Promise<string> {
+  const { data, error } = await supabase.rpc("admin_initialize_vacation_year", {
+    p_employee_id: employeeId,
+    p_year: year,
+  });
+
+  if (error) throw error;
+  return data as string;
+}
+
+/** Manuelle Korrektur mit Pflicht-Begründung (Admin). */
+export async function addVacationAdjustment(
+  employeeId: string,
+  year: number,
+  amountDays: number,
+  note: string,
+): Promise<void> {
+  const trimmed = note.trim();
+  if (!trimmed) {
+    throw new Error("Bitte eine Begründung für die Korrektur angeben.");
+  }
+  if (!Number.isFinite(amountDays) || amountDays === 0) {
+    throw new Error("Bitte einen Korrekturwert ungleich 0 angeben.");
+  }
+
+  const { error } = await supabase.rpc("admin_add_vacation_adjustment", {
+    p_employee_id: employeeId,
+    p_year: year,
+    p_amount_days: amountDays,
+    p_note: trimmed,
+  });
+
+  if (error) throw error;
+}
+
+/**
+ * Wird für diesen Mitarbeiter ein Urlaubskonto geführt?
+ *
+ * Entscheidet, ob bei der Genehmigung eine Abzugsbestätigung verlangt wird.
+ * Bewusst eine eigene, schmale Abfrage statt eines Flags im Absence-Objekt:
+ * die Einstellung gehört zum Mitarbeiter, nicht zum Antrag, und kann sich
+ * zwischen Antrag und Genehmigung ändern.
+ */
+export async function isVacationAccountingEnabled(
+  employeeId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("vacation_management_enabled")
+    .eq("id", employeeId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data as { vacation_management_enabled: boolean } | null)
+    ?.vacation_management_enabled === true;
+}

--- a/supabase/migrations/20260824000000_vacation_ledger_foundation.sql
+++ b/supabase/migrations/20260824000000_vacation_ledger_foundation.sql
@@ -1,0 +1,592 @@
+-- =========================================================
+-- Urlaubskonto: Jahres-Container + Ledger + erklärbarer Saldo
+-- =========================================================
+-- ABZUGS-MODELL — BEWUSSTE ENTSCHEIDUNG GEGEN AUTOMATIK:
+--   Es gibt heute KEINE deterministische Grundlage, um zu berechnen, welche
+--   konkreten Tage eines Urlaubs Anspruch verbrauchen:
+--     * vacation_reference_days_per_week ist eine ANZAHL (z. B. 3), nicht die
+--       konkreten Wochentage. Bei Urlaub 10.–14.08. ist damit unbekannt,
+--       WELCHE 3 Tage gearbeitet worden wären.
+--     * Eine Formel wie kalendertage * referenztage / 7 ergibt 5 * 3/7 =
+--       2,14 Tage — ein Bruchwert ohne rechtliche Grundlage, den niemand
+--       einem Mitarbeiter erklären kann.
+--     * Job-Occurrences taugen NICHT als Quelle: sie sind nach der
+--       Genehmigung weiterhin änderbar (Admin legt Jobs an/verschiebt sie)
+--       und werden nur ~3 Monate im Voraus materialisiert (hartes Maximum
+--       730 Tage). Ein für nächstes Jahr genehmigter Urlaub ergäbe 0 Tage,
+--       und spätere Planänderungen würden verbrauchten Urlaub RÜCKWIRKEND
+--       verändern.
+--   DESHALB: der Admin bestätigt den Abzug bei der Genehmigung explizit. Der
+--   bestätigte Wert wird als unveränderlicher Schnappschuss festgeschrieben
+--   (employee_absences.vacation_deducted_days_snapshot + Ledger-Zeile).
+--   NICHTS rechnet ihn je neu — spätere Planänderungen können die Historie
+--   damit strukturell nicht mehr anfassen.
+--
+-- SALDO: ausschließlich SUM(vacation_ledger.amount_days). Es gibt bewusst
+--   KEINE veränderliche remaining_days-Spalte. Jede Zahl im UI ist damit
+--   zeilenweise belegbar ("warum 28,0?").
+--
+-- JAHRESGRENZE: Abzüge werden IMMER als Zuordnung Jahr -> Tage übergeben
+--   (jsonb). Ein Urlaub über den Jahreswechsel muss deshalb explizit
+--   aufgeteilt werden; es ist strukturell unmöglich, versehentlich alle Tage
+--   ins Startjahr zu buchen.
+--
+-- KRANKHEIT: eine Krankmeldung verändert das Urlaubskonto NICHT. Es gibt in
+--   dieser Migration keinen Pfad, der aus 'reported' eine Gutschrift erzeugt.
+--   Eine spätere, ärztlich bestätigte AU wird das über eine eigene
+--   Kompensationszeile lösen — hier ausdrücklich NICHT enthalten.
+
+-- ---------------------------------------------------------
+-- 1. Ereignisarten
+-- ---------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'vacation_ledger_entry_type') then
+    create type public.vacation_ledger_entry_type as enum (
+      'annual_entitlement',    -- Jahresanspruch (positiv), genau 1x je Jahr
+      'approved_vacation',     -- genehmigter Urlaub (negativ)
+      'vacation_cancellation', -- Storno eines genehmigten Urlaubs (positiv, kompensierend)
+      'manual_adjustment',     -- Admin-Korrektur (vorzeichenbehaftet)
+      'carry_over',            -- RESERVIERT: Übertrag — keine Logik in diesem PR
+      'au_restoration'         -- RESERVIERT: Gutschrift nach bestätigter AU — keine Logik
+    );
+  end if;
+end $$;
+
+comment on type public.vacation_ledger_entry_type is
+'Ereignisarten des Urlaubskontos. carry_over und au_restoration sind bewusst '
+'nur als Werte reserviert — es gibt in diesem Stand KEINE Geschäftslogik '
+'dafür (kein automatischer Übertrag, keine Rückgabe bei Krankheit).';
+
+-- ---------------------------------------------------------
+-- 2. Jahres-Container
+-- ---------------------------------------------------------
+-- BEWUSST OHNE entitlement_days: der Betrag steht ausschließlich als
+-- annual_entitlement-Zeile im Ledger. Zwei Orte für dieselbe Zahl wären genau
+-- die veränderliche Zweitquelle, die dieses Design vermeiden soll.
+create table if not exists public.vacation_years (
+  id uuid primary key default gen_random_uuid(),
+  company_id uuid not null references public.companies(id) on delete cascade,
+  employee_id uuid not null references public.profiles(id) on delete cascade,
+  year int not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint uq_vacation_years_employee_year unique (employee_id, year),
+  constraint chk_vacation_years_year check (year between 2000 and 2100)
+);
+
+comment on table public.vacation_years is
+'Ein Urlaubsjahr-Konto je Mitarbeiter und Kalenderjahr. Reiner Container — '
+'die Beträge liegen im Ledger. Historische Jahre bleiben dadurch stabil.';
+
+create index if not exists idx_vacation_years_company on public.vacation_years(company_id);
+create index if not exists idx_vacation_years_employee on public.vacation_years(employee_id, year);
+
+-- ---------------------------------------------------------
+-- 3. Ledger (append-only)
+-- ---------------------------------------------------------
+create table if not exists public.vacation_ledger (
+  id uuid primary key default gen_random_uuid(),
+  company_id uuid not null references public.companies(id) on delete cascade,
+  employee_id uuid not null references public.profiles(id) on delete cascade,
+  vacation_year_id uuid not null references public.vacation_years(id) on delete cascade,
+  entry_type public.vacation_ledger_entry_type not null,
+  amount_days numeric(6,2) not null,
+  absence_id uuid references public.employee_absences(id) on delete set null,
+  created_by uuid references public.profiles(id) on delete set null,
+  note text,
+  created_at timestamptz not null default now(),
+  -- Vorzeichen je Art erzwingen: ein "genehmigter Urlaub" mit positivem
+  -- Betrag waere ein stiller Buchungsfehler.
+  constraint chk_vacation_ledger_sign check (
+    (entry_type = 'annual_entitlement'    and amount_days >= 0)
+    or (entry_type = 'approved_vacation'     and amount_days <= 0)
+    or (entry_type = 'vacation_cancellation' and amount_days >= 0)
+    or (entry_type = 'carry_over'            and amount_days >= 0)
+    or (entry_type = 'au_restoration'        and amount_days >= 0)
+    or (entry_type = 'manual_adjustment')
+  ),
+  -- Korrekturen muessen begruendet sein (Nachvollziehbarkeit).
+  constraint chk_vacation_ledger_manual_note check (
+    entry_type <> 'manual_adjustment'
+    or (note is not null and length(btrim(note)) > 0)
+  )
+);
+
+comment on table public.vacation_ledger is
+'Append-only Buchungszeilen des Urlaubskontos. Resturlaub = SUM(amount_days). '
+'Zeilen werden NIE geaendert oder geloescht — Korrekturen entstehen '
+'ausschliesslich als neue, kompensierende Zeilen.';
+
+create index if not exists idx_vacation_ledger_year on public.vacation_ledger(vacation_year_id);
+create index if not exists idx_vacation_ledger_employee on public.vacation_ledger(employee_id, created_at);
+create index if not exists idx_vacation_ledger_company on public.vacation_ledger(company_id);
+create index if not exists idx_vacation_ledger_absence on public.vacation_ledger(absence_id) where absence_id is not null;
+
+-- Genau EINE Jahresanspruch-Zeile je Jahr (Idempotenz bei Retry).
+create unique index if not exists uq_vacation_ledger_annual
+  on public.vacation_ledger(vacation_year_id)
+  where entry_type = 'annual_entitlement';
+
+-- Genau EIN Abzug je Abwesenheit UND Jahr (Jahresuebergang => zwei Zeilen,
+-- aber pro Jahr nur eine). Verhindert Doppelabzug bei Retry.
+create unique index if not exists uq_vacation_ledger_absence_deduction
+  on public.vacation_ledger(absence_id, vacation_year_id)
+  where entry_type = 'approved_vacation';
+
+-- Genau EINE Storno-Gutschrift je Abwesenheit und Jahr.
+create unique index if not exists uq_vacation_ledger_absence_cancellation
+  on public.vacation_ledger(absence_id, vacation_year_id)
+  where entry_type = 'vacation_cancellation';
+
+-- ---------------------------------------------------------
+-- 4. Unveraenderlicher Schnappschuss an der Abwesenheit
+-- ---------------------------------------------------------
+alter table public.employee_absences
+  add column if not exists vacation_deducted_days_snapshot numeric(6,2);
+
+comment on column public.employee_absences.vacation_deducted_days_snapshot is
+'Vom Admin bei der Genehmigung BESTAETIGTE Abzugsmenge in Tagen (Summe ueber '
+'alle betroffenen Jahre). Historischer Schnappschuss — wird nie neu berechnet, '
+'auch nicht wenn sich die Einsatzplanung spaeter aendert. NULL, wenn fuer '
+'diesen Mitarbeiter kein Urlaubskonto gefuehrt wird.';
+
+-- ---------------------------------------------------------
+-- 5. RLS — Lesen nach Rolle, Schreiben ausschliesslich per RPC
+-- ---------------------------------------------------------
+alter table public.vacation_years  enable row level security;
+alter table public.vacation_ledger enable row level security;
+revoke all on public.vacation_years  from anon, authenticated;
+revoke all on public.vacation_ledger from anon, authenticated;
+grant select on public.vacation_years  to authenticated;
+grant select on public.vacation_ledger to authenticated;
+
+drop policy if exists "employee read own vacation years" on public.vacation_years;
+create policy "employee read own vacation years"
+on public.vacation_years for select to authenticated
+using (employee_id = auth.uid() and company_id = public.current_user_company_id());
+
+drop policy if exists "admin read company vacation years" on public.vacation_years;
+create policy "admin read company vacation years"
+on public.vacation_years for select to authenticated
+using (public.current_user_role() = 'admin' and company_id = public.current_user_company_id());
+
+drop policy if exists "employee read own vacation ledger" on public.vacation_ledger;
+create policy "employee read own vacation ledger"
+on public.vacation_ledger for select to authenticated
+using (employee_id = auth.uid() and company_id = public.current_user_company_id());
+
+drop policy if exists "admin read company vacation ledger" on public.vacation_ledger;
+create policy "admin read company vacation ledger"
+on public.vacation_ledger for select to authenticated
+using (public.current_user_role() = 'admin' and company_id = public.current_user_company_id());
+
+-- ABSICHTLICH KEINE insert/update/delete-Policy auf beiden Tabellen:
+-- jede Buchung laeuft ueber die SECURITY DEFINER-RPCs unten. Damit kann
+-- weder ein Mitarbeiter noch ein Admin am Client eine Zeile frei schreiben,
+-- aendern oder loeschen (append-only ist strukturell erzwungen).
+
+
+-- ---------------------------------------------------------
+-- 6. RPC: Urlaubsjahr anlegen (explizite Admin-Aktion, idempotent)
+-- ---------------------------------------------------------
+-- BEWUSST KEINE Automatik: waere die Initialisierung ein Nebeneffekt (z. B.
+-- beim Aktivieren des Urlaubskontos), wuerde eine spaetere Aenderung des
+-- Jahresanspruchs mehrdeutig — hat sie die Historie zu aendern oder nicht?
+-- Mit einer expliziten Aktion ist die Antwort eindeutig: die bestehende Zeile
+-- bleibt, eine Anpassung ist eine SICHTBARE Korrektur (siehe RPC unten).
+--
+-- Idempotent auf zwei Ebenen: on conflict beim Jahres-Container UND der
+-- partielle Unique-Index auf der annual_entitlement-Zeile.
+create or replace function public.admin_initialize_vacation_year(
+  p_employee_id uuid,
+  p_year int
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company     uuid;
+  v_enabled     boolean;
+  v_entitlement numeric(5,2);
+  v_year_id     uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can initialize a vacation year' using errcode = '42501';
+  end if;
+
+  if p_year is null or p_year < 2000 or p_year > 2100 then
+    raise exception 'Invalid year' using errcode = '22023';
+  end if;
+
+  -- Mitarbeiter MUSS zur Firma des Admins gehoeren (Firmenscope).
+  -- Effektiver Anspruch: Override, sonst Firmen-Default — exakt dieselbe
+  -- Regel wie utils/vacationConfig.ts, hier serverseitig aufgeloest, damit
+  -- kein Client einen Betrag vorgeben kann.
+  select p.company_id, p.vacation_management_enabled,
+         coalesce(p.vacation_annual_entitlement_days, c.default_vacation_annual_entitlement_days)
+    into v_company, v_enabled, v_entitlement
+  from public.profiles p
+  join public.companies c on c.id = p.company_id
+  where p.id = p_employee_id
+    and p.company_id = public.current_user_company_id();
+
+  if not found then
+    raise exception 'Employee not found in your company' using errcode = '42501';
+  end if;
+
+  if v_enabled is not true then
+    raise exception 'Vacation management is disabled for this employee' using errcode = '42501';
+  end if;
+
+  -- KEIN stiller 0-Wert: fehlt der Anspruch komplett, ist das ein
+  -- Konfigurationsfehler und muss sichtbar scheitern.
+  if v_entitlement is null then
+    raise exception 'No annual entitlement configured (neither employee override nor company default)'
+      using errcode = '23514';
+  end if;
+
+  insert into public.vacation_years (company_id, employee_id, year)
+  values (v_company, p_employee_id, p_year)
+  on conflict (employee_id, year) do nothing
+  returning id into v_year_id;
+
+  if v_year_id is null then
+    select id into v_year_id from public.vacation_years
+    where employee_id = p_employee_id and year = p_year;
+  end if;
+
+  -- Retry-sicher: die zweite Ausfuehrung prallt am partiellen Unique-Index ab.
+  insert into public.vacation_ledger (
+    company_id, employee_id, vacation_year_id, entry_type, amount_days, created_by, note
+  )
+  values (
+    v_company, p_employee_id, v_year_id, 'annual_entitlement', v_entitlement, auth.uid(),
+    'Jahresanspruch ' || p_year::text
+  )
+  on conflict (vacation_year_id) where entry_type = 'annual_entitlement' do nothing;
+
+  return v_year_id;
+end;
+$$;
+
+comment on function public.admin_initialize_vacation_year(uuid, int) is
+'Legt das Urlaubsjahr eines Mitarbeiters an und bucht den Jahresanspruch '
+'(Override oder Firmen-Default, serverseitig aufgeloest). Idempotent: ein '
+'zweiter Aufruf erzeugt weder ein zweites Jahr noch eine zweite '
+'Anspruchszeile. Aendert NIEMALS eine bereits gebuchte Zeile.';
+
+revoke all on function public.admin_initialize_vacation_year(uuid, int) from public, anon;
+grant execute on function public.admin_initialize_vacation_year(uuid, int) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 7. RPC: manuelle Korrektur
+-- ---------------------------------------------------------
+-- Kein Bearbeiten/Loeschen alter Zeilen — eine falsche Korrektur wird durch
+-- eine weitere, gegenlaeufige Korrektur geheilt. Begruendung ist Pflicht
+-- (CHECK auf der Tabelle, hier zusaetzlich frueh und verstaendlich gepruaeft).
+create or replace function public.admin_add_vacation_adjustment(
+  p_employee_id uuid,
+  p_year int,
+  p_amount_days numeric,
+  p_note text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company uuid;
+  v_year_id uuid;
+  v_entry   uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can adjust a vacation account' using errcode = '42501';
+  end if;
+
+  if p_amount_days is null or p_amount_days = 0 then
+    raise exception 'Adjustment amount must be a non-zero number' using errcode = '23514';
+  end if;
+
+  if p_note is null or length(btrim(p_note)) = 0 then
+    raise exception 'A reason is required for a manual adjustment' using errcode = '23514';
+  end if;
+
+  select vy.id, vy.company_id into v_year_id, v_company
+  from public.vacation_years vy
+  join public.profiles p on p.id = vy.employee_id
+  where vy.employee_id = p_employee_id
+    and vy.year = p_year
+    and p.company_id = public.current_user_company_id();
+
+  if not found then
+    raise exception 'Vacation year not initialized for this employee/year'
+      using errcode = '42501';
+  end if;
+
+  insert into public.vacation_ledger (
+    company_id, employee_id, vacation_year_id, entry_type, amount_days, created_by, note
+  )
+  values (v_company, p_employee_id, v_year_id, 'manual_adjustment', p_amount_days, auth.uid(), btrim(p_note))
+  returning id into v_entry;
+
+  return v_entry;
+end;
+$$;
+
+comment on function public.admin_add_vacation_adjustment(uuid, int, numeric, text) is
+'Bucht eine vorzeichenbehaftete Admin-Korrektur mit Pflicht-Begruendung. '
+'Bestehende Zeilen bleiben unangetastet; eine falsche Korrektur wird durch '
+'eine weitere Gegenbuchung korrigiert.';
+
+revoke all on function public.admin_add_vacation_adjustment(uuid, int, numeric, text) from public, anon;
+grant execute on function public.admin_add_vacation_adjustment(uuid, int, numeric, text) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 8. RPC: Genehmigung MIT bestaetigtem Abzug
+-- ---------------------------------------------------------
+-- p_deductions ist eine EXPLIZITE Zuordnung Jahr -> Tage, z. B.
+--   {"2026": 3}                 (einfacher Fall)
+--   {"2026": 2, "2027": 3}      (Urlaub ueber den Jahreswechsel)
+-- Der Admin bestaetigt die Menge; die App darf einen Vorschlag anzeigen,
+-- aber nichts stillschweigend annehmen (siehe Migrationskopf).
+--
+-- Wird das Urlaubskonto fuer den Mitarbeiter nicht gefuehrt, bleibt die
+-- Genehmigung exakt wie bisher (kein Ledger, kein Schnappschuss, p_deductions
+-- wird ignoriert) — der bestehende Ablauf darf durch die Buchhaltung nicht
+-- blockiert werden.
+--
+-- Alles in EINER Transaktion: Statuswechsel, Schnappschuss, Ledger-Zeilen und
+-- die (seit 20260821000000) bestehende Benachrichtigung.
+create or replace function public.admin_review_vacation(
+  absence_id_input uuid,
+  decision_input text,
+  admin_note_input text default null,
+  p_deductions jsonb default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_status     public.absence_status;
+  v_employee   uuid;
+  v_company_id uuid;
+  v_name       text;
+  v_start      date;
+  v_end        date;
+  v_enabled    boolean;
+  v_total      numeric(6,2) := 0;
+  v_key        text;
+  v_days       numeric;
+  v_year_id    uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can review vacation requests' using errcode = '42501';
+  end if;
+
+  if decision_input not in ('approved', 'rejected') then
+    raise exception 'decision must be ''approved'' or ''rejected''' using errcode = '22023';
+  end if;
+  v_status := decision_input::public.absence_status;
+
+  update public.employee_absences
+  set status = v_status,
+      admin_note = admin_note_input,
+      reviewed_by = auth.uid(),
+      reviewed_at = now(),
+      updated_at = now()
+  where id = absence_id_input
+    and company_id = public.current_user_company_id()
+    and type = 'vacation'
+    and status = 'requested'
+  returning employee_id, company_id, employee_name_snapshot, start_date, end_date
+    into v_employee, v_company_id, v_name, v_start, v_end;
+
+  if not found then
+    raise exception 'Vacation request not found, not in your company, or already reviewed'
+      using errcode = '42501';
+  end if;
+
+  -- ── Buchhaltung NUR bei Genehmigung und aktivem Urlaubskonto ──
+  if v_status = 'approved' and v_employee is not null then
+    select vacation_management_enabled into v_enabled
+    from public.profiles where id = v_employee;
+
+    if v_enabled is true then
+      if p_deductions is null or jsonb_typeof(p_deductions) <> 'object'
+         or p_deductions = '{}'::jsonb then
+        raise exception
+          'Vacation accounting is enabled for this employee: a confirmed deduction per year is required'
+          using errcode = '23514';
+      end if;
+
+      for v_key, v_days in select * from jsonb_each_text(p_deductions)
+      loop
+        if v_key !~ '^\d{4}$' then
+          raise exception 'Invalid year key in deductions: %', v_key using errcode = '22023';
+        end if;
+        if v_days is null or v_days < 0 then
+          raise exception 'Deduction for % must be >= 0', v_key using errcode = '23514';
+        end if;
+
+        -- Das Jahr MUSS vom Urlaubszeitraum beruehrt werden — verhindert,
+        -- dass Tage in ein voellig fremdes Jahr gebucht werden.
+        if v_key::int < extract(year from v_start)::int
+           or v_key::int > extract(year from v_end)::int then
+          raise exception 'Year % is outside the vacation range', v_key using errcode = '23514';
+        end if;
+
+        select id into v_year_id from public.vacation_years
+        where employee_id = v_employee and year = v_key::int;
+
+        if v_year_id is null then
+          raise exception 'Vacation year % is not initialized for this employee', v_key
+            using errcode = '42501';
+        end if;
+
+        if v_days > 0 then
+          insert into public.vacation_ledger (
+            company_id, employee_id, vacation_year_id, entry_type, amount_days,
+            absence_id, created_by, note
+          )
+          values (
+            v_company_id, v_employee, v_year_id, 'approved_vacation', -v_days,
+            absence_id_input, auth.uid(),
+            'Urlaub ' || to_char(v_start, 'DD.MM.YYYY') || '–' || to_char(v_end, 'DD.MM.YYYY')
+          )
+          on conflict (absence_id, vacation_year_id) where entry_type = 'approved_vacation'
+          do nothing;
+        end if;
+
+        v_total := v_total + v_days;
+      end loop;
+
+      -- Unveraenderlicher Schnappschuss der bestaetigten Gesamtmenge.
+      update public.employee_absences
+      set vacation_deducted_days_snapshot = v_total
+      where id = absence_id_input;
+    end if;
+  end if;
+
+  -- Benachrichtigung (unveraendert seit 20260821000000)
+  if v_employee is not null then
+    perform public.enqueue_absence_notification(
+      v_company_id, absence_id_input,
+      case when v_status = 'approved' then 'vacation_approved' else 'vacation_rejected' end,
+      v_employee, v_name, v_start, v_end, v_employee
+    );
+  end if;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.admin_review_vacation(uuid, text, text, jsonb) is
+'Admin genehmigt/lehnt eine Urlaubsanfrage ab (nur aus status=requested). Bei '
+'Genehmigung und aktivem Urlaubskonto ist p_deductions (Jahr -> Tage) PFLICHT '
+'— der Abzug wird vom Admin bestaetigt, nicht berechnet, und als '
+'unveraenderlicher Schnappschuss samt Ledger-Zeile(n) festgeschrieben. Ein '
+'Jahresuebergang muss explizit aufgeteilt werden. Ohne Urlaubskonto laeuft die '
+'Genehmigung unveraendert ohne Buchhaltung.';
+
+revoke all on function public.admin_review_vacation(uuid, text, text, jsonb) from public, anon;
+grant execute on function public.admin_review_vacation(uuid, text, text, jsonb) to authenticated;
+
+-- Alte 3-Argument-Signatur entfernen, damit kein Aufrufer versehentlich an
+-- der Buchhaltung vorbei genehmigt (PostgREST wuerde sonst nach Argumenten
+-- aufloesen und still die alte Variante treffen).
+drop function if exists public.admin_review_vacation(uuid, text, text);
+
+
+-- ---------------------------------------------------------
+-- 9. RPC: Storno eines genehmigten Urlaubs -> Gegenbuchung
+-- ---------------------------------------------------------
+-- Die alte Abzugszeile bleibt UNANGETASTET. Storniert der Mitarbeiter einen
+-- bereits genehmigten Urlaub, entsteht je betroffenem Jahr eine
+-- kompensierende Gutschrift in identischer Hoehe. Damit bleibt sowohl der
+-- urspruengliche Abzug als auch seine Aufhebung im Verlauf sichtbar.
+create or replace function public.cancel_own_vacation(
+  absence_id_input uuid
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_row record;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can cancel their own vacation' using errcode = '42501';
+  end if;
+
+  update public.employee_absences
+  set status = 'cancelled', updated_at = now()
+  where id = absence_id_input
+    and employee_id = auth.uid()
+    and type = 'vacation'
+    and status in ('requested', 'approved')
+    and start_date > current_date;
+
+  if not found then
+    raise exception 'Vacation not found, not yours, or no longer cancellable'
+      using errcode = '42501';
+  end if;
+
+  -- Gegenbuchung je bereits gebuchtem Abzug dieser Abwesenheit. Bei einem
+  -- lediglich beantragten (nie genehmigten) Urlaub existiert kein Abzug —
+  -- dann passiert hier nichts.
+  for v_row in
+    select vl.company_id, vl.employee_id, vl.vacation_year_id, vl.amount_days
+    from public.vacation_ledger vl
+    where vl.absence_id = absence_id_input
+      and vl.entry_type = 'approved_vacation'
+  loop
+    insert into public.vacation_ledger (
+      company_id, employee_id, vacation_year_id, entry_type, amount_days,
+      absence_id, created_by, note
+    )
+    values (
+      v_row.company_id, v_row.employee_id, v_row.vacation_year_id,
+      'vacation_cancellation', abs(v_row.amount_days),
+      absence_id_input, auth.uid(), 'Storno des genehmigten Urlaubs'
+    )
+    on conflict (absence_id, vacation_year_id) where entry_type = 'vacation_cancellation'
+    do nothing;
+  end loop;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.cancel_own_vacation(uuid) is
+'Mitarbeiter storniert eigenen, noch nicht begonnenen Urlaub (requested/'
+'approved, start_date > heute). Seit 20260824000000: war der Urlaub bereits '
+'genehmigt und gebucht, entsteht je Jahr eine kompensierende Gutschrift — die '
+'urspruengliche Abzugszeile bleibt zur Nachvollziehbarkeit erhalten.';
+
+revoke all on function public.cancel_own_vacation(uuid) from public, anon;
+grant execute on function public.cancel_own_vacation(uuid) to authenticated;

--- a/types/vacationLedger.ts
+++ b/types/vacationLedger.ts
@@ -1,0 +1,72 @@
+// types/vacationLedger.ts
+// ─────────────────────────────────────────────────────────────────
+// Urlaubskonto-Buchhaltung. Der Saldo ist NIE ein gespeicherter Wert,
+// sondern immer die Summe der Buchungszeilen — damit ist jede Zahl im UI
+// zeilenweise belegbar ("warum 28,5?").
+// ─────────────────────────────────────────────────────────────────
+
+export type VacationLedgerEntryType =
+  | "annual_entitlement"
+  | "approved_vacation"
+  | "vacation_cancellation"
+  | "manual_adjustment"
+  /** RESERVIERT — keine Logik in diesem Stand. */
+  | "carry_over"
+  /** RESERVIERT — keine Logik in diesem Stand (keine Rückgabe bei Krankheit). */
+  | "au_restoration";
+
+export const LEDGER_ENTRY_LABELS: Record<VacationLedgerEntryType, string> = {
+  annual_entitlement: "Jahresanspruch",
+  approved_vacation: "Genehmigter Urlaub",
+  vacation_cancellation: "Storno",
+  manual_adjustment: "Manuelle Korrektur",
+  carry_over: "Übertrag",
+  au_restoration: "Gutschrift (AU)",
+};
+
+export type VacationLedgerEntry = {
+  id: string;
+  entryType: VacationLedgerEntryType;
+  /** Vorzeichenbehaftet: Anspruch positiv, Abzug negativ. */
+  amountDays: number;
+  absenceId: string | null;
+  createdBy: string | null;
+  note: string | null;
+  createdAt: string;
+};
+
+export type VacationYear = {
+  id: string;
+  employeeId: string;
+  year: number;
+};
+
+/**
+ * Aufgeschlüsselter Saldo eines Urlaubsjahres.
+ *
+ * `pendingRequests` trägt bewusst NUR die Zeiträume, keine Tagessumme:
+ * wie viele Tage ein offener Antrag verbrauchen wird, steht erst fest, wenn
+ * der Admin den Abzug bei der Genehmigung bestätigt (siehe Migration
+ * 20260824000000). Eine geschätzte Zahl hier wäre erfunden.
+ */
+export type VacationBalance = {
+  year: number;
+  annualEntitlement: number;
+  carryOver: number;
+  usedDays: number;
+  adjustments: number;
+  remaining: number;
+  entries: VacationLedgerEntry[];
+};
+
+export type PendingVacationRequest = {
+  absenceId: string;
+  startDate: string;
+  endDate: string;
+};
+
+/** Zustand des Kontos für die Anzeige. */
+export type VacationAccountState =
+  | { status: "disabled" }
+  | { status: "not_initialized"; year: number }
+  | { status: "ready"; balance: VacationBalance };

--- a/utils/vacationBalance.ts
+++ b/utils/vacationBalance.ts
@@ -1,0 +1,92 @@
+// utils/vacationBalance.ts
+// ─────────────────────────────────────────────────────────────────
+// Aggregation der Urlaubs-Buchungszeilen zu einem erklärbaren Saldo.
+//
+// Reine Funktion ohne Supabase — gleiche Bauform wie utils/vacationConfig.ts
+// und utils/resolveEffectiveAbsenceDays.ts.
+//
+// GRUNDREGEL: Resturlaub = SUMME aller Zeilen. Es gibt keinen zweiten,
+// gespeicherten Saldo, der davon abweichen könnte. Die Einzelposten unten
+// sind nur eine Gruppierung derselben Zeilen für die Anzeige — deshalb
+// stimmt die Aufstellung per Konstruktion immer mit dem Ergebnis überein.
+//
+// NICHT Teil dieser Datei: geplante Minuten, Ist-Zeiten, Timesheet. Die
+// Einheit des Urlaubskontos ist TAGE (siehe types/vacationLedger.ts).
+// ─────────────────────────────────────────────────────────────────
+
+import type {
+  VacationBalance,
+  VacationLedgerEntry,
+} from "@/types/vacationLedger";
+
+function sumOf(
+  entries: VacationLedgerEntry[],
+  types: VacationLedgerEntry["entryType"][],
+): number {
+  return entries
+    .filter((entry) => types.includes(entry.entryType))
+    .reduce((total, entry) => total + entry.amountDays, 0);
+}
+
+// Gleitkomma-Summen können 27.999999999 erzeugen. Urlaub wird in halben
+// Tagen geführt, zwei Nachkommastellen sind daher verlustfrei.
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function buildVacationBalance(
+  year: number,
+  entries: VacationLedgerEntry[],
+): VacationBalance {
+  // "Verbraucht" ist der NETTO-Verbrauch: ein stornierter Urlaub hebt seinen
+  // eigenen Abzug wieder auf. Beide Zeilen bleiben im Verlauf sichtbar —
+  // nur die Kennzahl fasst sie zusammen, damit "Verbraucht" nicht dauerhaft
+  // Urlaub ausweist, der nie genommen wurde.
+  const used = -sumOf(entries, ["approved_vacation", "vacation_cancellation"]);
+
+  return {
+    year,
+    annualEntitlement: round(sumOf(entries, ["annual_entitlement"])),
+    carryOver: round(sumOf(entries, ["carry_over"])),
+    usedDays: round(used),
+    // au_restoration zählt als Korrektur mit — es existiert in diesem Stand
+    // keine Logik, die solche Zeilen erzeugt (reserviert für bestätigte AU).
+    adjustments: round(sumOf(entries, ["manual_adjustment", "au_restoration"])),
+    remaining: round(entries.reduce((total, entry) => total + entry.amountDays, 0)),
+    entries: [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+  };
+}
+
+/** Anzeigeform eines Betrags: "+30,0" / "−3,0". */
+export function formatLedgerAmount(amountDays: number): string {
+  const sign = amountDays < 0 ? "−" : "+";
+  const value = Math.abs(amountDays).toLocaleString("de-DE", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 2,
+  });
+  return `${sign}${value}`;
+}
+
+/** Anzeigeform einer Kennzahl (ohne erzwungenes Vorzeichen): "28,5". */
+export function formatDays(amountDays: number): string {
+  return amountDays.toLocaleString("de-DE", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 2,
+  });
+}
+
+/**
+ * Kalenderjahre, die ein Urlaubszeitraum berührt.
+ *
+ * Grundlage für die Abzugs-Bestätigung: erstreckt sich ein Urlaub über den
+ * Jahreswechsel, muss der Admin für JEDES Jahr eine Menge bestätigen — es
+ * ist bewusst unmöglich, versehentlich alles ins Startjahr zu buchen.
+ */
+export function yearsInRange(startDate: string, endDate: string): number[] {
+  const start = parseInt(startDate.slice(0, 4), 10);
+  const end = parseInt(endDate.slice(0, 4), 10);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return [];
+  const years: number[] = [];
+  for (let year = start; year <= end; year++) years.push(year);
+  return years;
+}


### PR DESCRIPTION
## Problem

Nach PR #100 existierte die Urlaubs-**Konfiguration**, aber keine Buchhaltung: kein Anspruch, kein Verbrauch, kein Resturlaub. Und die naheliegende Abkürzung — eine Spalte `remaining_vacation_days` — wäre genau die Falle: eine Zahl, die niemand erklären kann und die bei jedem Fehler still falsch bleibt.

## Abzugs-Modell: bewusst KEINE Automatik

Vor dem Bauen geprüft, ob sich der Abzug deterministisch berechnen lässt. **Nein:**

- `vacation_reference_days_per_week` ist eine **Anzahl** (z. B. 3), nicht die konkreten Wochentage. Bei Urlaub 10.–14.08. ist unbekannt, **welche** 3 Tage gearbeitet worden wären.
- Eine Formel wie `kalendertage × referenztage / 7` ergibt 5 × 3/7 = **2,14 Tage** — ein Bruchwert ohne rechtliche Grundlage, den niemand einem Mitarbeiter erklären kann.
- **Job-Occurrences taugen nicht als Quelle:** sie sind nach der Genehmigung weiter änderbar und werden nur ~3 Monate im Voraus materialisiert (hartes Maximum 730 Tage). Ein für nächstes Jahr genehmigter Urlaub ergäbe **0 Tage**, und spätere Planänderungen würden verbrauchten Urlaub **rückwirkend** verschieben.

**Deshalb:** der Admin bestätigt den Abzug bei der Genehmigung explizit. Der bestätigte Wert wird als unveränderlicher Schnappschuss festgeschrieben (`vacation_deducted_days_snapshot` + Ledger-Zeile) und **nie neu berechnet** — spätere Planänderungen können die Historie strukturell nicht mehr anfassen. Das ist einer stillschweigend falschen HR-Buchhaltung klar vorzuziehen.

## Datenmodell

`vacation_years` ist ein **reiner Container ohne `entitlement_days`** — der Betrag lebt ausschließlich als `annual_entitlement`-Zeile im Ledger, damit es je Betrag nur **eine** Quelle gibt. `vacation_ledger` ist append-only; **Resturlaub = SUM(amount_days)**.

Ereignisarten: `annual_entitlement` (+), `approved_vacation` (−), `vacation_cancellation` (+), `manual_adjustment` (±). `carry_over` und `au_restoration` sind **nur als Enum-Werte reserviert, ohne jede Logik**. CHECK-Constraints erzwingen das Vorzeichen je Art und eine Pflicht-Begründung bei Korrekturen.

## Buchung bei Genehmigung

`admin_review_vacation` bekommt `p_deductions jsonb` (Jahr → Tage) und schreibt Statuswechsel, Schnappschuss, Ledger-Zeilen **und** die Benachrichtigung in **einer** Transaktion. Bei aktivem Urlaubskonto ist der bestätigte Abzug Pflicht — die RPC lehnt eine Genehmigung ohne ihn ab. Ohne Urlaubskonto läuft die Genehmigung unverändert ohne Buchhaltung.

**Jahresgrenze:** die Zuordnung ist immer explizit (`{"2026": 2, "2027": 2}`). Es ist strukturell unmöglich, versehentlich alle Tage ins Startjahr zu buchen; Jahre außerhalb des Zeitraums werden abgelehnt.

**Idempotenz** auf DB-Ebene: ein Abzug je (Abwesenheit, Jahr), eine Anspruchszeile je Jahr, ein Jahr je (Mitarbeiter, Jahr). Ein Genehmigungs-Retry prallt zusätzlich schon am `status='requested'`-Übergang ab.

## Storno / Korrekturen

Es wird **nie** eine Zeile gelöscht oder geändert. Storniert ein Mitarbeiter einen bereits genehmigten Urlaub, entsteht je Jahr eine kompensierende Gutschrift in gleicher Höhe — Abzug *und* Aufhebung bleiben im Verlauf sichtbar. Eine falsche Korrektur wird durch eine weitere Gegenbuchung geheilt.

## Security

Alle Buchungen laufen über `SECURITY DEFINER`-RPCs mit gehärtetem `search_path`, Rollen- und Firmenprüfung. Auf beiden Tabellen gibt es **nur SELECT-Policies** (Mitarbeiter eigene Zeilen, Admin firmenweit) — append-only ist damit strukturell erzwungen, nicht per UI versteckt. Live belegt: Mitarbeiter-Korrektur abgelehnt, Mitarbeiter-Initialisierung abgelehnt, **direktes INSERT ins Ledger abgelehnt**, firmenfremder Admin abgelehnt (0 Zeilen).

## UI

**Admin:** eigener Urlaubskonto-Screen je Mitarbeiter mit Aufstellung (Anspruch/Verbraucht/Korrekturen/Resturlaub), vollständigem Verlauf und manueller Korrektur. Drei klar getrennte Zustände: Konto aus → gar keine Zahlen; Jahr nicht angelegt → Einrichtungshinweis + Aktion; angelegt → Saldo. **Nie ein erfundenes 0.**

**Mitarbeiter:** kompakte Karte im Abwesenheiten-Screen, die **nur** rendert, wenn Konto aktiv **und** Jahr initialisiert ist. Offene Anträge erscheinen als **Zeiträume ohne Tagessumme** — wie viele Tage sie verbrauchen, steht erst mit der Bestätigung des Admins fest. Rein lesend.

## Krankheit

Eine Krankmeldung verändert das Urlaubskonto **nicht**. Es existiert kein Pfad, der aus `reported` eine Gutschrift erzeugt (live verifiziert: Saldo unverändert, 0 Restaurations-Zeilen, Abzug weiterhin −3,0).

## Test-Evidenz (Staging)

**A–W alle PASS.** Höhepunkte: Konto aus → Initialisierung abgelehnt, nichts erfunden; Idempotenz (zweiter Aufruf → 1 Jahr, 1 Anspruchszeile); Firmen-Default 30 vs. Override 25, Historie 2026 unverändert; Genehmigung → genau 1 Zeile −3,00, Saldo 27,00; Retry blockiert; Ablehnung/offen → kein Abzug; Genehmigung **ohne** bestätigten Abzug abgelehnt; Korrekturen +2/−0,5 → 28,50 mit Autor/Grund/Zeitstempel; Begründungspflicht erzwungen; Jahresübergang → 2 Zeilen (−2,00 / −2,00), Schnappschuss 4,00, falsches Jahr abgelehnt; Storno → 2 Abzüge erhalten + 2 Gutschriften, Netto 0, Schnappschuss bleibt; Minijob/Aushilfe ohne Sonderbehandlung; Bestands-Urlaube **nicht** rückwirkend gebucht.

Plus **14/14** Aggregations-Assertions, inkl. des Beispiels aus der Aufgabe (30 + 2 − 5 + 1 = **28**) und Float-Sicherheit bei halben Tagen.

`npx tsc --noEmit` und `npm run lint` sauber. Staging auf Ausgangszustand zurückgesetzt, Production nachweislich unberührt (weiterhin `20260816000000`).

## Historische Daten

**Keine rückwirkende Rekonstruktion.** Die Buchhaltung beginnt mit der expliziten Initialisierung; ältere genehmigte Abwesenheiten bleiben Historie ohne Ledger-Zeile und ohne Schnappschuss. Wer einen Anfangsbestand braucht, bucht ihn als sichtbare manuelle Korrektur. Alles andere würde eine Vollständigkeit vortäuschen, die die Altdaten nicht haben.

## Ausdrückliche Nicht-Ziele

Keine AU-Bestätigung, keine Urlaubs-Rückgabe nach Krankheit, kein automatischer Übertrag, keine Anteilsberechnung bei Ein-/Austritt, keine Verfallsregeln (31.03.), kein Payroll-/DATEV-Export, kein Dokumenten-Upload.

## Deployment-Abhängigkeit

⚠️ Production steht weiterhin auf `20260816000000` und benötigt vor einem Release: `20260820000000`, `20260821000000`, `20260822000000`, `20260823000000`, diese `20260824000000`, einen Redeploy von `dispatch-notifications` und einen Push-Smoketest auf einem echten Gerät. Nichts davon wurde hier deployt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)