### PR TITLE
feat: add AU confirmation and vacation restoration

### DIFF
--- a/app/absences/[id]/au.tsx
+++ b/app/absences/[id]/au.tsx
@@ -1,0 +1,3 @@
+import AdminAuReviewScreen from "@/features/absences/admin/AdminAuReviewScreen";
+
+export default AdminAuReviewScreen;

--- a/features/absences/admin/AdminAuReviewScreen.tsx
+++ b/features/absences/admin/AdminAuReviewScreen.tsx
@@ -1,0 +1,348 @@
+// features/absences/admin/AdminAuReviewScreen.tsx
+// AU-Prüfung einer Krankmeldung + Rückgabe abgezogener Urlaubstage.
+//
+// KERNREGEL im UI gespiegelt: die Rückgabe-Sektion erscheint ERST nach
+// bestätigter AU. Eine blosse Krankmeldung bietet sie gar nicht an.
+//
+// TEILÜBERSCHNEIDUNG WIRD NICHT GERATEN: der Abzug liegt als Jahres-Aggregat
+// vor, ohne Tagesbezug. Deckt die AU nur einen Teil des Urlaubs ab, bleibt
+// das Feld LEER und der Admin trägt die Menge ein. Nur bei vollständiger
+// Abdeckung ist der Wert eindeutig und wird vorbelegt.
+
+import { AppHeader, ErrorBanner } from "@/components/ui";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import {
+  getAbsenceEvidence,
+  getRestorationCandidates,
+  restoreVacationFromAu,
+  reviewAu,
+} from "@/services/absences/auEvidence.service";
+import type { AppTheme } from "@/constants/theme";
+import type {
+  AbsenceEvidence,
+  AuRestorationCandidate,
+  AuRestorationInput,
+} from "@/types/absenceEvidence";
+import { AU_NOT_REVIEWED_LABEL, AU_STATUS_LABELS } from "@/types/absenceEvidence";
+import { formatDays } from "@/utils/vacationBalance";
+import { formatForDisplay } from "@/utils/date";
+import { alertDialog } from "@/utils/dialogs";
+import { toUserMessage } from "@/utils/userMessages";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function AdminAuReviewScreen() {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [evidence, setEvidence] = useState<AbsenceEvidence | null>(null);
+  const [candidates, setCandidates] = useState<AuRestorationCandidate[]>([]);
+  const [amounts, setAmounts] = useState<Record<string, string>>({});
+
+  const keyOf = (c: AuRestorationCandidate) => `${c.vacationAbsenceId}:${c.year}`;
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const ev = await getAbsenceEvidence(id);
+      setEvidence(ev);
+
+      if (ev?.status === "confirmed") {
+        const list = await getRestorationCandidates(id);
+        setCandidates(list);
+        // Vorbelegung NUR bei eindeutiger Lage (volle Abdeckung).
+        const prefill: Record<string, string> = {};
+        for (const c of list) {
+          if (c.fullCoverage && c.restorableDays > 0) {
+            prefill[`${c.vacationAbsenceId}:${c.year}`] = String(c.restorableDays);
+          }
+        }
+        setAmounts(prefill);
+      } else {
+        setCandidates([]);
+        setAmounts({});
+      }
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleReview = async (decision: "confirmed" | "rejected") => {
+    if (!id) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await reviewAu(id, decision);
+      await load();
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!evidence) return;
+    const items: AuRestorationInput[] = [];
+    for (const c of candidates) {
+      const raw = (amounts[keyOf(c)] ?? "").trim().replace(",", ".");
+      if (!raw) continue;
+      const days = Number(raw);
+      if (!Number.isFinite(days) || days <= 0) {
+        setError(`Ungültiger Wert für ${formatForDisplay(c.vacationStart)}.`);
+        return;
+      }
+      if (days > c.restorableDays) {
+        setError(
+          `Für ${formatForDisplay(c.vacationStart)} sind höchstens ${formatDays(c.restorableDays)} Tage möglich.`,
+        );
+        return;
+      }
+      items.push({ vacation_absence_id: c.vacationAbsenceId, year: c.year, days });
+    }
+
+    if (items.length === 0) {
+      setError("Bitte mindestens einen Wert eintragen.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await restoreVacationFromAu(evidence.id, items);
+      alertDialog(
+        "Gebucht",
+        created > 0
+          ? "Die Urlaubstage wurden im Urlaubskonto gutgeschrieben."
+          : "Diese Rückgabe war bereits gebucht.",
+      );
+      await load();
+    } catch (err) {
+      setError(toUserMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusLabel = evidence
+    ? AU_STATUS_LABELS[evidence.status]
+    : AU_NOT_REVIEWED_LABEL;
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <AppHeader title="Arbeitsunfähigkeit" onBack={() => router.back()} />
+      <ScrollView contentContainerStyle={styles.content}>
+        {error ? <ErrorBanner message={error} /> : null}
+        {loading ? <ActivityIndicator color={theme.colors.primary} /> : null}
+
+        {!loading ? (
+          <>
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Status</Text>
+              <Text style={styles.status}>{statusLabel}</Text>
+              {evidence?.confirmedAt ? (
+                <Text style={styles.hint}>
+                  Entschieden am {formatForDisplay(evidence.confirmedAt)}
+                </Text>
+              ) : null}
+              <Text style={styles.hint}>
+                Eine Krankmeldung allein gibt keinen Urlaub zurück. Erst eine
+                bestätigte Arbeitsunfähigkeit berechtigt dazu.
+              </Text>
+
+              <View style={styles.actions}>
+                <TouchableOpacity
+                  style={[styles.confirmBtn, busy && styles.disabled]}
+                  onPress={() => handleReview("confirmed")}
+                  disabled={busy}
+                >
+                  <Text style={styles.confirmText}>AU bestätigen</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.rejectBtn, busy && styles.disabled]}
+                  onPress={() => handleReview("rejected")}
+                  disabled={busy}
+                >
+                  <Text style={styles.rejectText}>AU ablehnen</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {evidence?.status === "confirmed" ? (
+              candidates.length > 0 ? (
+                <>
+                  <Text style={styles.sectionTitle}>Urlaubstage zurückgeben</Text>
+                  {candidates.map((c) => (
+                    <View key={keyOf(c)} style={styles.card}>
+                      <Text style={styles.cardTitle}>
+                        Urlaub {formatForDisplay(c.vacationStart)}–
+                        {formatForDisplay(c.vacationEnd)}
+                        {candidates.some((o) => o.year !== c.year) ? ` · ${c.year}` : ""}
+                      </Text>
+                      <Text style={styles.hint}>
+                        Abgezogen: {formatDays(c.deductedDays)} Tage
+                        {c.alreadyRestored > 0
+                          ? ` · bereits zurückgegeben: ${formatDays(c.alreadyRestored)}`
+                          : ""}
+                      </Text>
+                      <Text style={styles.hint}>
+                        AU-Überschneidung: {formatForDisplay(c.overlapStart)}–
+                        {formatForDisplay(c.overlapEnd)}
+                      </Text>
+
+                      {c.restorableDays <= 0 ? (
+                        <Text style={styles.hint}>
+                          Bereits vollständig zurückgegeben.
+                        </Text>
+                      ) : (
+                        <>
+                          <Text style={styles.label}>
+                            Zurückgeben (max. {formatDays(c.restorableDays)})
+                          </Text>
+                          <TextInput
+                            style={styles.input}
+                            keyboardType="decimal-pad"
+                            value={amounts[keyOf(c)] ?? ""}
+                            onChangeText={(text) =>
+                              setAmounts((prev) => ({ ...prev, [keyOf(c)]: text }))
+                            }
+                            placeholder={c.fullCoverage ? "" : "Bitte eintragen"}
+                            placeholderTextColor={theme.colors.onSurfaceVariant}
+                          />
+                          {!c.fullCoverage ? (
+                            <Text style={styles.hint}>
+                              Die AU deckt den Urlaub nur teilweise ab — wie viele
+                              der abgezogenen Tage betroffen sind, lässt sich nicht
+                              berechnen. Bitte selbst festlegen.
+                            </Text>
+                          ) : null}
+                        </>
+                      )}
+                    </View>
+                  ))}
+
+                  <TouchableOpacity
+                    style={[styles.confirmBtn, busy && styles.disabled]}
+                    onPress={handleRestore}
+                    disabled={busy}
+                  >
+                    <Text style={styles.confirmText}>Urlaubstage zurückgeben</Text>
+                  </TouchableOpacity>
+                  <Text style={styles.hint}>
+                    Gutschriften werden nie gelöscht. Eine falsche Rückgabe wird
+                    über eine manuelle Korrektur im Urlaubskonto berichtigt.
+                  </Text>
+                </>
+              ) : (
+                <View style={styles.card}>
+                  <Text style={styles.hint}>
+                    Keine abgezogenen Urlaubstage überschneiden sich mit dieser
+                    Krankmeldung — es gibt nichts zurückzugeben.
+                  </Text>
+                </View>
+              )
+            ) : null}
+          </>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: AppTheme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    content: { padding: theme.spacing.lg, gap: theme.spacing.sm },
+    card: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      padding: theme.spacing.md,
+      gap: theme.spacing.xs,
+    },
+    cardTitle: {
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+    },
+    sectionTitle: {
+      fontSize: theme.typography.size.lg,
+      fontWeight: theme.typography.weight.semibold,
+      color: theme.colors.onSurface,
+      marginTop: theme.spacing.lg,
+    },
+    status: {
+      fontSize: theme.typography.size.lg,
+      fontWeight: theme.typography.weight.bold,
+      color: theme.colors.primary,
+    },
+    hint: {
+      fontSize: theme.typography.size.xs,
+      color: theme.colors.onSurfaceVariant,
+      lineHeight: theme.typography.lineHeight.xs,
+    },
+    label: {
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.onSurface,
+      marginTop: theme.spacing.xs,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+      color: theme.colors.onSurface,
+      fontSize: theme.typography.size.md,
+    },
+    actions: { flexDirection: "row", gap: theme.spacing.sm, marginTop: theme.spacing.sm },
+    confirmBtn: {
+      flex: 1,
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      marginTop: theme.spacing.sm,
+    },
+    confirmText: {
+      color: theme.colors.onPrimary,
+      fontWeight: theme.typography.weight.semibold,
+      fontSize: theme.typography.size.sm,
+    },
+    rejectBtn: {
+      flex: 1,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      borderRadius: theme.radius.md,
+      paddingVertical: theme.spacing.md,
+      alignItems: "center",
+      marginTop: theme.spacing.sm,
+    },
+    rejectText: { color: theme.colors.onSurface, fontSize: theme.typography.size.sm },
+    disabled: { opacity: 0.6 },
+  });
+}

--- a/features/absences/admin/components/AdminAbsenceRow.tsx
+++ b/features/absences/admin/components/AdminAbsenceRow.tsx
@@ -10,6 +10,7 @@
 
 import { Card } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
+import { router } from "expo-router";
 import { isVacationAccountingEnabled } from "@/services/vacation/vacationLedger.service";
 import { VacationDeductionSheet } from "./VacationDeductionSheet";
 import type { AppTheme } from "@/constants/theme";
@@ -44,6 +45,11 @@ export function AdminAbsenceRow({
   const [deductionSheetOpen, setDeductionSheetOpen] = useState(false);
 
   const isVacation = absence.type === "vacation";
+  // AU-Pruefung gibt es nur fuer aktive Krankmeldungen. Der Einstieg liegt
+  // bewusst auf einem eigenen Screen: Bestaetigung UND moegliche
+  // Urlaubs-Rueckgabe sind ein eigener Vorgang, kein Listen-Button.
+  const isActiveSickness =
+    absence.type === "sickness" && absence.status === "reported";
   const isPendingVacation = isVacation && absence.status === "requested";
   const reviewerNote =
     absence.status === "rejected" || absence.status === "approved"
@@ -164,7 +170,18 @@ export function AdminAbsenceRow({
           handleConfirmReject(note);
         }}
       />
-          <VacationDeductionSheet
+          {isActiveSickness ? (
+        <TouchableOpacity
+          style={styles.auLink}
+          onPress={() =>
+            router.push({ pathname: "/absences/[id]/au", params: { id: absence.id } })
+          }
+          accessibilityRole="button"
+        >
+          <Text style={styles.auLinkText}>Arbeitsunfähigkeit prüfen</Text>
+        </TouchableOpacity>
+      ) : null}
+      <VacationDeductionSheet
         visible={deductionSheetOpen}
         employeeName={absence.employeeName}
         rangeLabel={formatAbsenceDateRange(absence)}
@@ -269,6 +286,16 @@ function createStyles(theme: AppTheme) {
     },
     actionBtnDisabled: {
       opacity: 0.5,
+    },
+    auLink: {
+      marginTop: 8,
+      paddingVertical: 8,
+      alignItems: "center",
+    },
+    auLinkText: {
+      color: theme.colors.primary,
+      fontSize: theme.typography.size.sm,
+      fontWeight: theme.typography.weight.semibold,
     },
     approveBtn: {
       backgroundColor: theme.colors.statusCompletedBg,

--- a/services/absences/auEvidence.service.ts
+++ b/services/absences/auEvidence.service.ts
@@ -1,0 +1,135 @@
+// services/absences/auEvidence.service.ts
+// ─────────────────────────────────────────────────────────────────
+// AU-Bestätigung und Urlaubs-Rückgabe (nur Admin).
+//
+// Alle schreibenden Aktionen laufen über SECURITY DEFINER-RPCs — auf
+// absence_evidence gibt es bewusst keine insert/update/delete-Policy, ein
+// Mitarbeiter kann seine eigene AU also strukturell nicht bestätigen.
+// ─────────────────────────────────────────────────────────────────
+
+import { supabase } from "@/lib/supabase";
+import type {
+  AbsenceEvidence,
+  AuEvidenceStatus,
+  AuRestorationCandidate,
+  AuRestorationInput,
+} from "@/types/absenceEvidence";
+
+type EvidenceRow = {
+  id: string;
+  absence_id: string;
+  status: AuEvidenceStatus;
+  confirmed_by: string | null;
+  confirmed_at: string | null;
+  note: string | null;
+};
+
+type CandidateRow = {
+  vacation_absence_id: string;
+  vacation_start: string;
+  vacation_end: string;
+  year: number;
+  deducted_days: number | string;
+  already_restored: number | string;
+  restorable_days: number | string;
+  overlap_start: string;
+  overlap_end: string;
+  full_coverage: boolean;
+};
+
+// PostgREST liefert numeric als String.
+const num = (v: number | string) => (typeof v === "string" ? Number(v) : v);
+
+/** Nachweis zu einer Krankmeldung, falls vorhanden. */
+export async function getAbsenceEvidence(
+  absenceId: string,
+): Promise<AbsenceEvidence | null> {
+  const { data, error } = await supabase
+    .from("absence_evidence")
+    .select("id, absence_id, status, confirmed_by, confirmed_at, note")
+    .eq("absence_id", absenceId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  const row = data as unknown as EvidenceRow;
+  return {
+    id: row.id,
+    absenceId: row.absence_id,
+    status: row.status,
+    confirmedBy: row.confirmed_by,
+    confirmedAt: row.confirmed_at,
+    note: row.note,
+  };
+}
+
+/** AU bestätigen oder ablehnen (Admin). Idempotent. */
+export async function reviewAu(
+  absenceId: string,
+  decision: "confirmed" | "rejected",
+  note?: string,
+): Promise<string> {
+  const { data, error } = await supabase.rpc("admin_review_au", {
+    p_absence_id: absenceId,
+    p_decision: decision,
+    p_note: note?.trim() || null,
+  });
+
+  if (error) throw error;
+  return data as string;
+}
+
+/**
+ * Rückgabefähige Posten zu einer Krankmeldung.
+ *
+ * Grundlage sind ausschliesslich TATSÄCHLICH GEBUCHTE Abzüge im Ledger —
+ * nie ein blosser Urlaubszeitraum und nie die Einsatzplanung.
+ */
+export async function getRestorationCandidates(
+  absenceId: string,
+): Promise<AuRestorationCandidate[]> {
+  const { data, error } = await supabase.rpc("get_au_restoration_candidates", {
+    p_absence_id: absenceId,
+  });
+
+  if (error) throw error;
+
+  return ((data ?? []) as CandidateRow[]).map((row) => ({
+    vacationAbsenceId: row.vacation_absence_id,
+    vacationStart: row.vacation_start,
+    vacationEnd: row.vacation_end,
+    year: row.year,
+    deductedDays: num(row.deducted_days),
+    alreadyRestored: num(row.already_restored),
+    restorableDays: num(row.restorable_days),
+    overlapStart: row.overlap_start,
+    overlapEnd: row.overlap_end,
+    fullCoverage: row.full_coverage,
+  }));
+}
+
+/**
+ * Urlaubstage aufgrund bestätigter AU zurückgeben.
+ *
+ * Die Menge je Urlaub und Jahr kommt vom Admin — bei Teilüberschneidung ist
+ * sie nicht berechenbar. Serverseitig gilt eine harte Obergrenze: die Summe
+ * aller Rückgaben je (Urlaub, Jahr) kann den ursprünglichen Abzug nie
+ * übersteigen, auch nicht über mehrere Krankmeldungen hinweg.
+ */
+export async function restoreVacationFromAu(
+  evidenceId: string,
+  restorations: AuRestorationInput[],
+): Promise<number> {
+  if (restorations.length === 0) {
+    throw new Error("Bitte mindestens einen Posten angeben.");
+  }
+
+  const { data, error } = await supabase.rpc("admin_restore_vacation_from_au", {
+    p_evidence_id: evidenceId,
+    p_restorations: restorations,
+  });
+
+  if (error) throw error;
+  return (data as number) ?? 0;
+}

--- a/supabase/migrations/20260825000000_au_confirmation_restoration.sql
+++ b/supabase/migrations/20260825000000_au_confirmation_restoration.sql
@@ -1,0 +1,582 @@
+-- =========================================================
+-- AU-Bestätigung + Urlaubs-Rückgabe
+-- =========================================================
+-- KERNREGEL (unverhandelbar): eine blosse Krankmeldung gibt NIEMALS Urlaub
+--   zurueck. Eine Gutschrift entsteht ausschliesslich nach einer separaten,
+--   ausdruecklich vom Admin BESTAETIGTEN Arbeitsunfaehigkeit. Die bestehende
+--   Anzeige-Prioritaet 'Krankheit > Urlaub' (resolveEffectiveAbsenceDays)
+--   bleibt reine Darstellungs-/Berechnungslogik und erzeugt selbst keine
+--   Buchung.
+--
+-- MODELL: eigene Entitaet absence_evidence statt Felder auf
+--   employee_absences. Gruende:
+--     * employee_absences.status ist per CHECK an den Typ gekoppelt
+--       (vacation: requested/approved/rejected/cancelled, sickness:
+--       reported/cancelled). AU-Zustaende dort einzuhaengen wuerde entweder
+--       den Status ueberladen oder Spalten erzeugen, die fuer Urlaubszeilen
+--       bedeutungslos sind.
+--     * Die AU-Pruefung ist ein EIGENER Vorgang mit eigenem Akteur, eigenen
+--       Zeitstempeln und eigenem Lebenszyklus.
+--     * document_path kann spaeter ergaenzt werden, ohne die
+--       Abwesenheitstabelle anzufassen.
+--
+-- RUECKGABE-MENGE — BEWUSST KEINE AUTOMATIK BEI TEILUEBERSCHNEIDUNG:
+--   Der Abzug liegt als AGGREGAT je (Urlaub, Jahr) im Ledger — es gibt KEINE
+--   Zuordnung Tag -> abgezogener Tag. Deckt eine AU nur einen Teil des
+--   Urlaubs ab (z. B. AU 12.–13.08. bei Urlaub 10.–14.08. mit 3 Tagen
+--   Abzug), ist schlicht unbekannt, wie viele der 3 Tage auf 12.–13. fallen.
+--   Eine Verhaeltnisrechnung (ueberschneidung/kalendertage * abzug) waere
+--   geraten. Deshalb bestaetigt der Admin die Menge je Urlaub und Jahr
+--   explizit; nur bei VOLLSTAENDIGER Abdeckung schlaegt die App den vollen
+--   Abzug vor (dort ist die Menge eindeutig).
+--
+-- DOPPELTE RUECKGABE ist auf DB-Ebene ausgeschlossen:
+--   (a) Unique-Index je (Nachweis, Urlaub, Jahr)
+--   (b) serverseitige Obergrenze: Summe aller Rueckgaben je (Urlaub, Jahr)
+--       darf den urspruenglichen Abzug nie uebersteigen — auch nicht ueber
+--       ZWEI verschiedene Krankmeldungen hinweg.
+
+-- ---------------------------------------------------------
+-- 1. AU-Zustaende
+-- ---------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'au_evidence_status') then
+    create type public.au_evidence_status as enum ('pending', 'confirmed', 'rejected');
+  end if;
+end $$;
+
+comment on type public.au_evidence_status is
+'Zustand der AU-Pruefung. BEWUSST getrennt von employee_absences.status: die '
+'Krankmeldung bleibt reported/cancelled, die aerztliche Bestaetigung ist ein '
+'eigener Vorgang.';
+
+-- ---------------------------------------------------------
+-- 2. Nachweis-Entitaet
+-- ---------------------------------------------------------
+-- Genau EIN Nachweis je Krankmeldung (unique absence_id). Damit kann eine
+-- Krankmeldung nicht ueber zwei Nachweiszeilen doppelt zurueckgeben.
+create table if not exists public.absence_evidence (
+  id uuid primary key default gen_random_uuid(),
+  company_id uuid not null references public.companies(id) on delete cascade,
+  absence_id uuid not null references public.employee_absences(id) on delete cascade,
+  status public.au_evidence_status not null default 'pending',
+  submitted_at timestamptz not null default now(),
+  confirmed_by uuid references public.profiles(id) on delete set null,
+  confirmed_at timestamptz,
+  note text,
+  -- RESERVIERT: es gibt in diesem Stand keinen Upload-Pfad. Bewusst schon
+  -- vorhanden, damit ein spaeterer Datei-Upload die Tabelle nicht aendern muss.
+  document_path text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint uq_absence_evidence_absence unique (absence_id),
+  -- Ein entschiedener Nachweis traegt immer Akteur UND Zeitpunkt.
+  constraint chk_absence_evidence_decided check (
+    status = 'pending'
+    or (confirmed_by is not null and confirmed_at is not null)
+  )
+);
+
+comment on table public.absence_evidence is
+'AU-Nachweis zu EINER Krankmeldung. Nur ein bestaetigter Nachweis '
+'(status=confirmed) berechtigt zu einer Urlaubs-Rueckgabe — eine blosse '
+'Krankmeldung nie.';
+
+create index if not exists idx_absence_evidence_company on public.absence_evidence(company_id);
+create index if not exists idx_absence_evidence_absence on public.absence_evidence(absence_id);
+
+-- ---------------------------------------------------------
+-- 3. Ledger: Herkunft der Rueckgabe
+-- ---------------------------------------------------------
+-- absence_id zeigt bei einer Rueckgabe auf den URLAUB (wie bei
+-- approved_vacation/vacation_cancellation) — dadurch stehen Abzug und
+-- Rueckgabe derselben Abwesenheit zusammen. evidence_id haelt fest, WELCHE
+-- AU sie ausgeloest hat.
+alter table public.vacation_ledger
+  add column if not exists evidence_id uuid references public.absence_evidence(id) on delete set null;
+
+comment on column public.vacation_ledger.evidence_id is
+'Nur bei entry_type=''au_restoration'': der bestaetigte AU-Nachweis, der die '
+'Gutschrift begruendet. absence_id zeigt weiterhin auf den URLAUB, dessen '
+'Abzug teilweise oder ganz zurueckgegeben wird.';
+
+-- Eine Rueckgabe je (Nachweis, Urlaub, Jahr) — Retry-sicher.
+create unique index if not exists uq_vacation_ledger_au_restoration
+  on public.vacation_ledger(evidence_id, absence_id, vacation_year_id)
+  where entry_type = 'au_restoration';
+
+create index if not exists idx_vacation_ledger_evidence
+  on public.vacation_ledger(evidence_id) where evidence_id is not null;
+
+-- ---------------------------------------------------------
+-- 4. RLS — lesen nach Rolle, schreiben nur ueber RPC
+-- ---------------------------------------------------------
+alter table public.absence_evidence enable row level security;
+revoke all on public.absence_evidence from anon, authenticated;
+grant select on public.absence_evidence to authenticated;
+
+drop policy if exists "employee read own absence evidence" on public.absence_evidence;
+create policy "employee read own absence evidence"
+on public.absence_evidence for select to authenticated
+using (
+  company_id = public.current_user_company_id()
+  and exists (
+    select 1 from public.employee_absences ea
+    where ea.id = absence_evidence.absence_id
+      and ea.employee_id = auth.uid()
+  )
+);
+
+drop policy if exists "admin read company absence evidence" on public.absence_evidence;
+create policy "admin read company absence evidence"
+on public.absence_evidence for select to authenticated
+using (
+  public.current_user_role() = 'admin'
+  and company_id = public.current_user_company_id()
+);
+
+-- ABSICHTLICH keine insert/update/delete-Policy: jede Aenderung laeuft ueber
+-- die SECURITY DEFINER-RPCs unten. Ein Mitarbeiter kann seine eigene AU
+-- damit strukturell nicht bestaetigen.
+
+
+-- ---------------------------------------------------------
+-- 5. RPC: AU bestaetigen / ablehnen
+-- ---------------------------------------------------------
+-- Idempotent: ein erneutes Bestaetigen aendert nichts und erzeugt insbesondere
+-- keine zweite Nachweiszeile (unique absence_id + Zustandspruefung).
+-- Eine STORNIERTE Krankmeldung ist nicht pruefbar.
+create or replace function public.admin_review_au(
+  p_absence_id uuid,
+  p_decision text,
+  p_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company uuid;
+  v_status  public.absence_status;
+  v_type    public.absence_type;
+  v_new     public.au_evidence_status;
+  v_id      uuid;
+  v_current public.au_evidence_status;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can review an AU' using errcode = '42501';
+  end if;
+
+  if p_decision not in ('confirmed', 'rejected') then
+    raise exception 'decision must be ''confirmed'' or ''rejected''' using errcode = '22023';
+  end if;
+  v_new := p_decision::public.au_evidence_status;
+
+  -- Firmenscope + Typ/Status der Krankmeldung pruefen; Zeile sperren, damit
+  -- zwei gleichzeitige Bestaetigungen serialisiert werden.
+  select ea.company_id, ea.status, ea.type
+    into v_company, v_status, v_type
+  from public.employee_absences ea
+  where ea.id = p_absence_id
+    and ea.company_id = public.current_user_company_id()
+  for update;
+
+  if not found then
+    raise exception 'Absence not found or not in your company' using errcode = '42501';
+  end if;
+
+  if v_type <> 'sickness' then
+    raise exception 'Only sickness absences can carry an AU' using errcode = '23514';
+  end if;
+
+  if v_status = 'cancelled' then
+    raise exception 'A cancelled sickness report cannot be reviewed' using errcode = '23514';
+  end if;
+
+  select id, status into v_id, v_current
+  from public.absence_evidence where absence_id = p_absence_id for update;
+
+  if v_id is null then
+    insert into public.absence_evidence (
+      company_id, absence_id, status, confirmed_by, confirmed_at, note
+    )
+    values (v_company, p_absence_id, v_new, auth.uid(), now(), p_note)
+    returning id into v_id;
+    return v_id;
+  end if;
+
+  -- Bereits derselbe Zustand -> echter No-Op (Retry-sicher).
+  if v_current = v_new then
+    return v_id;
+  end if;
+
+  -- Eine bereits bestaetigte AU, auf der Rueckgaben gebucht sind, darf nicht
+  -- einfach umgeschaltet werden — sonst haetten gebuchte Gutschriften
+  -- ploetzlich keine Grundlage mehr. Korrektur laeuft dann bewusst ueber eine
+  -- sichtbare manuelle Anpassung im Urlaubskonto.
+  if v_current = 'confirmed' and exists (
+    select 1 from public.vacation_ledger
+    where evidence_id = v_id and entry_type = 'au_restoration'
+  ) then
+    raise exception
+      'This AU already has posted vacation restorations and can no longer be changed; correct the vacation account instead'
+      using errcode = '42501';
+  end if;
+
+  update public.absence_evidence
+  set status = v_new, confirmed_by = auth.uid(), confirmed_at = now(),
+      note = coalesce(p_note, note), updated_at = now()
+  where id = v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function public.admin_review_au(uuid, text, text) is
+'Admin bestaetigt/lehnt die Arbeitsunfaehigkeit zu einer Krankmeldung ab. '
+'Idempotent; eine stornierte Krankmeldung ist nicht pruefbar; eine bereits '
+'bestaetigte AU mit gebuchten Rueckgaben ist gesperrt.';
+
+revoke all on function public.admin_review_au(uuid, text, text) from public, anon;
+grant execute on function public.admin_review_au(uuid, text, text) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 6. RPC: Rueckgabe-Kandidaten zu einer bestaetigten AU
+-- ---------------------------------------------------------
+-- Liefert je betroffenem (Urlaub, Jahr): den urspruenglichen Abzug, die
+-- bereits zurueckgegebene Menge, den Rest und die Ueberschneidungstage.
+-- full_coverage sagt, ob die AU den GESAMTEN Urlaub abdeckt — nur dann ist
+-- die Rueckgabemenge eindeutig und die App darf sie vorbelegen.
+--
+-- Grundlage sind ausschliesslich TATSAECHLICH GEBUCHTE Abzuege im Ledger,
+-- nie ein blosser Urlaubszeitraum und nie Einsatzplanung.
+create or replace function public.get_au_restoration_candidates(
+  p_absence_id uuid
+)
+returns table (
+  vacation_absence_id uuid,
+  vacation_start date,
+  vacation_end date,
+  year int,
+  deducted_days numeric,
+  already_restored numeric,
+  restorable_days numeric,
+  overlap_start date,
+  overlap_end date,
+  full_coverage boolean
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company uuid;
+  v_start   date;
+  v_end     date;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can inspect restoration candidates' using errcode = '42501';
+  end if;
+
+  select ea.company_id, ea.start_date, coalesce(ea.end_date, 'infinity'::date)
+    into v_company, v_start, v_end
+  from public.employee_absences ea
+  where ea.id = p_absence_id
+    and ea.company_id = public.current_user_company_id()
+    and ea.type = 'sickness'
+    and ea.status = 'reported';
+
+  if not found then
+    raise exception 'Sickness report not found or not in your company' using errcode = '42501';
+  end if;
+
+  return query
+  select
+    va.id,
+    va.start_date,
+    va.end_date,
+    vy.year,
+    abs(vl.amount_days)::numeric,
+    coalesce(restored.total, 0)::numeric,
+    (abs(vl.amount_days) - coalesce(restored.total, 0))::numeric,
+    greatest(va.start_date, v_start),
+    least(va.end_date, v_end),
+    (v_start <= va.start_date and v_end >= va.end_date)
+  from public.vacation_ledger vl
+  join public.employee_absences va on va.id = vl.absence_id
+  join public.vacation_years vy on vy.id = vl.vacation_year_id
+  left join lateral (
+    select sum(r.amount_days) total
+    from public.vacation_ledger r
+    where r.absence_id = vl.absence_id
+      and r.vacation_year_id = vl.vacation_year_id
+      and r.entry_type = 'au_restoration'
+  ) restored on true
+  where vl.entry_type = 'approved_vacation'
+    and vl.company_id = v_company
+    and va.type = 'vacation'
+    and va.status = 'approved'
+    -- echte Ueberschneidung der Zeitraeume
+    and va.start_date <= v_end
+    and va.end_date   >= v_start
+    -- der Urlaub muss demselben Mitarbeiter gehoeren wie die Krankmeldung
+    and va.employee_id = (select employee_id from public.employee_absences where id = p_absence_id)
+  order by va.start_date, vy.year;
+end;
+$$;
+
+comment on function public.get_au_restoration_candidates(uuid) is
+'Listet je (genehmigtem Urlaub, Jahr) den gebuchten Abzug, bereits '
+'zurueckgegebene Tage, den verbleibenden Rest und die Ueberschneidung mit der '
+'Krankmeldung. full_coverage=true nur bei vollstaendiger Abdeckung — nur dann '
+'ist die Rueckgabemenge eindeutig.';
+
+revoke all on function public.get_au_restoration_candidates(uuid) from public, anon;
+grant execute on function public.get_au_restoration_candidates(uuid) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 7. RPC: Urlaubstage aufgrund bestaetigter AU zurueckgeben
+-- ---------------------------------------------------------
+-- p_restorations ist ein ARRAY expliziter Posten, je Urlaub UND Jahr:
+--   [{"vacation_absence_id":"…","year":2026,"days":1.0}, …]
+-- Getrennte Posten je Urlaub sind Absicht (Nachvollziehbarkeit): eine
+-- Krankmeldung kann mehrere Urlaube beruehren, und jede Gutschrift bleibt
+-- ihrem Abzug zuordenbar statt in einer undurchsichtigen Sammelbuchung.
+--
+-- OBERGRENZE: je (Urlaub, Jahr) darf die Summe ALLER Rueckgaben — auch ueber
+-- verschiedene Krankmeldungen hinweg — den urspruenglichen Abzug nie
+-- uebersteigen. Serverseitig geprueft, mit Sperre auf den Abzugszeilen.
+create or replace function public.admin_restore_vacation_from_au(
+  p_evidence_id uuid,
+  p_restorations jsonb
+)
+returns int
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company    uuid;
+  v_ev_status  public.au_evidence_status;
+  v_sick_id     uuid;
+  v_sick_start  date;
+  v_sick_end    date;
+  -- eigene Variable: die Krankmeldung traegt absence_status, NICHT
+  -- au_evidence_status — die beiden Enums duerfen sich nicht vermischen.
+  v_sick_status public.absence_status;
+  v_employee   uuid;
+  item         jsonb;
+  v_vac_id     uuid;
+  v_year       int;
+  v_days       numeric;
+  v_year_id    uuid;
+  v_deducted   numeric;
+  v_restored   numeric;
+  v_count      int := 0;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can restore vacation days' using errcode = '42501';
+  end if;
+
+  select ae.company_id, ae.status, ae.absence_id
+    into v_company, v_ev_status, v_sick_id
+  from public.absence_evidence ae
+  where ae.id = p_evidence_id
+    and ae.company_id = public.current_user_company_id()
+  for update;
+
+  if not found then
+    raise exception 'Evidence not found or not in your company' using errcode = '42501';
+  end if;
+
+  -- KERNREGEL: ohne bestaetigte AU gibt es keine Gutschrift.
+  if v_ev_status is distinct from 'confirmed' then
+    raise exception 'Vacation can only be restored for a CONFIRMED AU' using errcode = '42501';
+  end if;
+
+  select ea.start_date, coalesce(ea.end_date, 'infinity'::date), ea.employee_id, ea.status
+    into v_sick_start, v_sick_end, v_employee, v_sick_status
+  from public.employee_absences ea where ea.id = v_sick_id;
+
+  if v_sick_status = 'cancelled' then
+    raise exception 'The sickness report was cancelled' using errcode = '23514';
+  end if;
+
+  if p_restorations is null or jsonb_typeof(p_restorations) <> 'array'
+     or jsonb_array_length(p_restorations) = 0 then
+    raise exception 'At least one restoration item is required' using errcode = '23514';
+  end if;
+
+  for item in select * from jsonb_array_elements(p_restorations)
+  loop
+    v_vac_id := (item ->> 'vacation_absence_id')::uuid;
+    v_year   := (item ->> 'year')::int;
+    v_days   := (item ->> 'days')::numeric;
+
+    if v_vac_id is null or v_year is null or v_days is null then
+      raise exception 'Each item needs vacation_absence_id, year and days' using errcode = '23514';
+    end if;
+
+    if v_days <= 0 then
+      raise exception 'Restoration days must be greater than 0' using errcode = '23514';
+    end if;
+
+    select id into v_year_id from public.vacation_years
+    where employee_id = v_employee and year = v_year;
+
+    if v_year_id is null then
+      raise exception 'Vacation year % is not initialized', v_year using errcode = '42501';
+    end if;
+
+    -- Abzugszeile SPERREN: verhindert, dass zwei gleichzeitige Rueckgaben die
+    -- Obergrenze gemeinsam ueberschreiten.
+    select abs(amount_days) into v_deducted
+    from public.vacation_ledger
+    where absence_id = v_vac_id
+      and vacation_year_id = v_year_id
+      and entry_type = 'approved_vacation'
+      and company_id = v_company
+    for update;
+
+    if v_deducted is null then
+      raise exception 'No approved vacation deduction found for this vacation/year'
+        using errcode = '42501';
+    end if;
+
+    -- Der Urlaub MUSS sich wirklich mit der Krankmeldung ueberschneiden.
+    if not exists (
+      select 1 from public.employee_absences va
+      where va.id = v_vac_id
+        and va.employee_id = v_employee
+        and va.type = 'vacation'
+        and va.status = 'approved'
+        and va.start_date <= v_sick_end
+        and va.end_date   >= v_sick_start
+    ) then
+      raise exception 'Vacation does not overlap the sickness period' using errcode = '23514';
+    end if;
+
+    -- Summe ALLER bisherigen Rueckgaben fuer diesen (Urlaub, Jahr) —
+    -- unabhaengig davon, aus welcher Krankmeldung sie stammen.
+    select coalesce(sum(amount_days), 0) into v_restored
+    from public.vacation_ledger
+    where absence_id = v_vac_id
+      and vacation_year_id = v_year_id
+      and entry_type = 'au_restoration';
+
+    if v_restored + v_days > v_deducted then
+      raise exception
+        'Restoration exceeds the original deduction (deducted %, already restored %, requested %)',
+        v_deducted, v_restored, v_days
+        using errcode = '23514';
+    end if;
+
+    insert into public.vacation_ledger (
+      company_id, employee_id, vacation_year_id, entry_type, amount_days,
+      absence_id, evidence_id, created_by, note
+    )
+    values (
+      v_company, v_employee, v_year_id, 'au_restoration', v_days,
+      v_vac_id, p_evidence_id, auth.uid(),
+      'AU-Wiederherstellung (Krankmeldung ab ' || to_char(v_sick_start, 'DD.MM.YYYY') || ')'
+    )
+    on conflict (evidence_id, absence_id, vacation_year_id)
+      where entry_type = 'au_restoration'
+    do nothing;
+
+    if found then
+      v_count := v_count + 1;
+    end if;
+  end loop;
+
+  return v_count;
+end;
+$$;
+
+comment on function public.admin_restore_vacation_from_au(uuid, jsonb) is
+'Bucht Urlaubs-Gutschriften aufgrund einer BESTAETIGTEN AU. Menge je Urlaub '
+'und Jahr wird vom Admin bestaetigt (bei Teilueberschneidung nicht berechenbar). '
+'Serverseitige Obergrenze: die Summe aller Rueckgaben je (Urlaub, Jahr) kann '
+'den urspruenglichen Abzug nie uebersteigen, auch nicht ueber mehrere '
+'Krankmeldungen hinweg. Retry erzeugt keine zweite Gutschrift.';
+
+revoke all on function public.admin_restore_vacation_from_au(uuid, jsonb) from public, anon;
+grant execute on function public.admin_restore_vacation_from_au(uuid, jsonb) to authenticated;
+
+
+-- ---------------------------------------------------------
+-- 8. Storno einer Krankmeldung mit gebuchter Rueckgabe blockieren
+-- ---------------------------------------------------------
+-- Sonst stuende eine Gutschrift auf einer Krankmeldung, die es offiziell
+-- nicht mehr gibt. Historie wird NICHT still geloescht — die Korrektur laeuft
+-- bewusst ueber eine sichtbare manuelle Anpassung im Urlaubskonto.
+create or replace function public.cancel_own_sickness(
+  absence_id_input uuid
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'employee' then
+    raise exception 'Only employees can cancel their own sickness report'
+      using errcode = '42501';
+  end if;
+
+  if exists (
+    select 1
+    from public.absence_evidence ae
+    join public.vacation_ledger vl on vl.evidence_id = ae.id
+    where ae.absence_id = absence_id_input
+      and vl.entry_type = 'au_restoration'
+  ) then
+    raise exception
+      'This sickness report already led to restored vacation days and can no longer be cancelled; please contact your admin'
+      using errcode = '42501';
+  end if;
+
+  update public.employee_absences
+  set status = 'cancelled', updated_at = now()
+  where id = absence_id_input
+    and employee_id = auth.uid()
+    and type = 'sickness'
+    and status = 'reported';
+
+  if not found then
+    raise exception 'Sickness report not found, not yours, or already closed'
+      using errcode = '42501';
+  end if;
+
+  return query select * from public.employee_absences where id = absence_id_input;
+end;
+$$;
+
+comment on function public.cancel_own_sickness(uuid) is
+'Mitarbeiter storniert eigene aktive Krankmeldung. Seit 20260825000000 '
+'gesperrt, sobald daraus bereits Urlaubstage zurueckgegeben wurden — die '
+'Gutschrift bliebe sonst ohne Grundlage. Korrektur dann ueber eine sichtbare '
+'manuelle Anpassung im Urlaubskonto.';
+
+revoke all on function public.cancel_own_sickness(uuid) from public, anon;
+grant execute on function public.cancel_own_sickness(uuid) to authenticated;

--- a/types/absenceEvidence.ts
+++ b/types/absenceEvidence.ts
@@ -1,0 +1,60 @@
+// types/absenceEvidence.ts
+// ─────────────────────────────────────────────────────────────────
+// AU-Nachweis zu einer Krankmeldung.
+//
+// BEWUSST getrennt von Absence.status: die Krankmeldung bleibt
+// reported/cancelled, die ärztliche Bestätigung ist ein eigener Vorgang mit
+// eigenem Akteur und Zeitpunkt.
+//
+// KERNREGEL: nur `confirmed` berechtigt zu einer Urlaubs-Rückgabe. Eine
+// blosse Krankmeldung nie.
+// ─────────────────────────────────────────────────────────────────
+
+export type AuEvidenceStatus = "pending" | "confirmed" | "rejected";
+
+export const AU_STATUS_LABELS: Record<AuEvidenceStatus, string> = {
+  pending: "AU offen",
+  confirmed: "AU bestätigt",
+  rejected: "AU abgelehnt",
+};
+
+/** Kein Nachweis vorhanden = noch gar nicht geprüft. */
+export const AU_NOT_REVIEWED_LABEL = "Nicht geprüft";
+
+export type AbsenceEvidence = {
+  id: string;
+  absenceId: string;
+  status: AuEvidenceStatus;
+  confirmedBy: string | null;
+  confirmedAt: string | null;
+  note: string | null;
+};
+
+/**
+ * Ein rückgabefähiger Posten: ein genehmigter Urlaub in einem Urlaubsjahr,
+ * dessen Abzug sich mit der bestätigten AU überschneidet.
+ *
+ * `fullCoverage` sagt, ob die AU den GESAMTEN Urlaub abdeckt. Nur dann ist
+ * die Rückgabemenge eindeutig und darf vorbelegt werden — bei einer
+ * Teilüberschneidung ist unbekannt, wie viele der abgezogenen Tage in den
+ * AU-Zeitraum fallen (der Abzug ist ein Jahres-Aggregat ohne Tagesbezug).
+ */
+export type AuRestorationCandidate = {
+  vacationAbsenceId: string;
+  vacationStart: string;
+  vacationEnd: string;
+  year: number;
+  deductedDays: number;
+  alreadyRestored: number;
+  restorableDays: number;
+  overlapStart: string;
+  overlapEnd: string;
+  fullCoverage: boolean;
+};
+
+/** Ein vom Admin bestätigter Rückgabe-Posten. */
+export type AuRestorationInput = {
+  vacation_absence_id: string;
+  year: number;
+  days: number;
+};

--- a/types/vacationLedger.ts
+++ b/types/vacationLedger.ts
@@ -21,7 +21,7 @@ export const LEDGER_ENTRY_LABELS: Record<VacationLedgerEntryType, string> = {
   vacation_cancellation: "Storno",
   manual_adjustment: "Manuelle Korrektur",
   carry_over: "Übertrag",
-  au_restoration: "Gutschrift (AU)",
+  au_restoration: "AU-Wiederherstellung",
 };
 
 export type VacationLedgerEntry = {


### PR DESCRIPTION
## Problem

Bisher konnte eine Krankheit während des Urlaubs die bereits abgezogenen Urlaubstage nicht zurückgeben. Die naheliegende Abkürzung — eine Krankmeldung automatisch gutschreiben — wäre fachlich falsch: eine Meldung ist kein ärztlicher Nachweis.

## Kernregel

**Eine Krankmeldung allein gibt niemals Urlaub zurück.** Eine Gutschrift entsteht ausschliesslich nach einer separaten, ausdrücklich vom Admin **bestätigten** Arbeitsunfähigkeit. Die bestehende Priorität `Krankheit > Urlaub` bleibt reine Anzeige-/Berechnungslogik und erzeugt selbst keine Buchung — live verifiziert (Test A und T).

## AU-Modell

**Eigene Entität `absence_evidence`** (`pending | confirmed | rejected`) statt Felder auf `employee_absences`. Begründung:
- `employee_absences.status` ist per CHECK an den Typ gekoppelt (vacation: requested/approved/rejected/cancelled, sickness: reported/cancelled). AU-Zustände dort einzuhängen würde entweder den Status überladen oder Spalten erzeugen, die für Urlaubszeilen bedeutungslos sind.
- Die AU-Prüfung ist ein **eigener Vorgang** mit eigenem Akteur, eigenen Zeitstempeln und eigenem Lebenszyklus.
- `document_path` ist reserviert; **kein Upload** in diesem Stand.

Genau ein Nachweis je Krankmeldung (`unique absence_id`) — dadurch kann eine Krankmeldung nicht über zwei Nachweiszeilen doppelt zurückgeben.

## Rückgabe-Modell: Admin-bestätigt, nicht berechnet

Der Abzug liegt als **Aggregat je (Urlaub, Jahr)** im Ledger — es gibt **keine** Zuordnung Tag → abgezogener Tag.

- **Volle Abdeckung** (AU umfasst den ganzen Urlaub): die Menge ist eindeutig, das Feld wird **vorbelegt**.
- **Teilüberschneidung** (z. B. AU 12.–13.08. bei Urlaub 10.–14.08. mit 3 Tagen Abzug): es ist schlicht unbekannt, wie viele der 3 Tage betroffen sind. Eine Verhältnisrechnung `überschneidung/kalendertage × abzug` wäre **geraten** — das Feld bleibt **leer** und der Admin legt die Menge fest.

`get_au_restoration_candidates` liefert dafür je Posten: gebuchten Abzug, bereits zurückgegebene Tage, offenen Rest, Überschneidungszeitraum und `full_coverage`. Grundlage sind **ausschliesslich tatsächlich gebuchte Abzüge im Ledger** — nie ein blosser Urlaubszeitraum, nie Einsatzplanung, nie Timesheet-Minuten.

## Doppelte Rückgabe

Zwei unabhängige Ebenen:
1. **Unique-Index** je (Nachweis, Urlaub, Jahr) → Retry erzeugt keine zweite Gutschrift.
2. **Serverseitige Obergrenze:** die Summe **aller** Rückgaben je (Urlaub, Jahr) — auch über **verschiedene Krankmeldungen** hinweg — kann den ursprünglichen Abzug nie übersteigen. Geprüft mit `FOR UPDATE` auf der Abzugszeile, damit zwei gleichzeitige Rückgaben die Grenze nicht gemeinsam reissen.

Mehrere Urlaube einer Krankmeldung bleiben **getrennte, zuordenbare** Gutschriften (`absence_id` = Urlaub, `evidence_id` = auslösende AU) statt einer undurchsichtigen Sammelbuchung.

## Storno / Korrektur

Eine Krankmeldung, aus der bereits Urlaub zurückgegeben wurde, ist **nicht mehr stornierbar**; eine bestätigte AU mit Buchungen ist **nicht mehr umschaltbar**. Sonst stünde eine Gutschrift ohne Grundlage. Historie wird **nie** gelöscht — die Korrektur läuft bewusst über eine sichtbare manuelle Anpassung im Urlaubskonto.

## Security

Alle Aktionen über `SECURITY DEFINER`-RPCs mit gehärtetem `search_path`, Rollen- und Firmenprüfung, Zeilensperren. `absence_evidence` hat **nur SELECT-Policies** (Mitarbeiter eigene Zeilen, Admin firmenweit) — ein Mitarbeiter kann seine eigene AU strukturell nicht bestätigen. Live belegt: Mitarbeiter-Bestätigung abgelehnt, firmenfremder Admin abgelehnt.

## UI

**Admin:** eigener AU-Screen je Krankmeldung — Status (`Nicht geprüft`/`AU bestätigt`/`AU abgelehnt`), `AU bestätigen`/`AU ablehnen`, und **erst nach Bestätigung** die Rückgabe-Sektion mit Abzug, Überschneidung und Restmenge je Urlaub/Jahr. Bei Teilüberschneidung steht explizit dort, dass die Menge nicht berechenbar ist.

**Mitarbeiter:** keine AU-Aktion (nur Admin). Die Gutschrift erscheint im Urlaubskonto-Verlauf als `+1,0 AU-Wiederherstellung` — genau das im Auftrag beschriebene Muster, ohne zweiten Saldo-Screen.

## Notifications

**Keine hinzugefügt.** Geprüft: ein `au_confirmed`-Event wäre über die generische Outbox technisch klein (~20 Zeilen). Bewusst nicht aufgenommen, um den Fokus dieses PRs auf die buchhalterische Integrität zu halten und keine erneute Migration + QA-Runde für einen optionalen Zusatz auszulösen. Sauberer Folge-PR. Bestehende Benachrichtigungen unverändert (Test V).

## Test-Evidenz (Staging)

**A–W alle PASS.** Höhepunkte: gemeldete Krankheit → 0 Gutschriften, kein Nachweis automatisch erzeugt; abgelehnte AU → keine Rückgabe möglich; Teilüberschneidung → `full_coverage=false`, Überschneidung `02.06.–03.06.`; einmal zurückgeben → 1 Zeile +1,00, Saldo 25,00 → 26,00; Retry → 0 neue Zeilen; Über-Rückgabe abgelehnt; **zweite Krankmeldung auf denselben Urlaub** → kumulative Grenze greift (1 + 2 = 3 = Abzug, danach alles Weitere abgelehnt), 2 zuordenbare Nachweise; volle Abdeckung → Restmenge = Abzug; **Jahresübergang** → 2 Kandidatenzeilen, Gutschriften 1,00/1,00 je Jahr; Storno vor Bestätigung erlaubt, stornierte Krankmeldung nicht prüfbar; Storno nach Rückgabe blockiert, Historie intakt, bestätigte AU gesperrt.

Regression: Urlaubsgenehmigung (−2,00), Storno-Kompensation, manuelle Korrektur (+1,50), Timesheet, Benachrichtigungen, Jahresanspruch unverändert (30,00).

`npx tsc --noEmit` und `npm run lint` sauber. Staging bereinigt (gemeinsame Fixtures erhalten), Production nachweislich unberührt (weiterhin `20260816000000`).

## Historische Daten

**Kein Backfill.** Alte Krankmeldungen bekommen weder Nachweis noch rückwirkende Gutschrift. Historische Korrekturen laufen manuell über das Urlaubskonto — kein nachträgliches Raten.

## Ausdrückliche Nicht-Ziele

Kein automatischer Übertrag, keine Anteilsberechnung, keine Verfallsregeln (31.03.), keine eAU-/Kassen-Integration, kein OCR, kein Dokumenten-Upload, keine Lohn-Integration.

## Deployment-Abhängigkeit

⚠️ Production steht weiterhin auf `20260816000000` und benötigt vor einem Release: `20260820000000`, `20260821000000`, `20260822000000`, `20260823000000`, `20260824000000`, diese `20260825000000`, einen Redeploy von `dispatch-notifications` und einen Push-Smoketest auf einem echten Gerät.

🤖 Generated with [Claude Code](https://claude.com/claude-code)