### PR TITLE
fix: polish vacation balance and AU date display

### DIFF
--- a/features/absences/admin/AdminAuReviewScreen.tsx
+++ b/features/absences/admin/AdminAuReviewScreen.tsx
@@ -25,7 +25,7 @@ import type {
 } from "@/types/absenceEvidence";
 import { AU_NOT_REVIEWED_LABEL, AU_STATUS_LABELS } from "@/types/absenceEvidence";
 import { formatDays } from "@/utils/vacationBalance";
-import { formatForDisplay } from "@/utils/date";
+import { formatDateOnlyDE, formatForDisplay } from "@/utils/date";
 import { alertDialog } from "@/utils/dialogs";
 import { toUserMessage } from "@/utils/userMessages";
 import { router, useLocalSearchParams } from "expo-router";
@@ -111,12 +111,12 @@ export default function AdminAuReviewScreen() {
       if (!raw) continue;
       const days = Number(raw);
       if (!Number.isFinite(days) || days <= 0) {
-        setError(`Ungültiger Wert für ${formatForDisplay(c.vacationStart)}.`);
+        setError(`Ungültiger Wert für ${formatDateOnlyDE(c.vacationStart)}.`);
         return;
       }
       if (days > c.restorableDays) {
         setError(
-          `Für ${formatForDisplay(c.vacationStart)} sind höchstens ${formatDays(c.restorableDays)} Tage möglich.`,
+          `Für ${formatDateOnlyDE(c.vacationStart)} sind höchstens ${formatDays(c.restorableDays)} Tage möglich.`,
         );
         return;
       }
@@ -197,8 +197,8 @@ export default function AdminAuReviewScreen() {
                   {candidates.map((c) => (
                     <View key={keyOf(c)} style={styles.card}>
                       <Text style={styles.cardTitle}>
-                        Urlaub {formatForDisplay(c.vacationStart)}–
-                        {formatForDisplay(c.vacationEnd)}
+                        Urlaub {formatDateOnlyDE(c.vacationStart)}–
+                        {formatDateOnlyDE(c.vacationEnd)}
                         {candidates.some((o) => o.year !== c.year) ? ` · ${c.year}` : ""}
                       </Text>
                       <Text style={styles.hint}>
@@ -208,8 +208,8 @@ export default function AdminAuReviewScreen() {
                           : ""}
                       </Text>
                       <Text style={styles.hint}>
-                        AU-Überschneidung: {formatForDisplay(c.overlapStart)}–
-                        {formatForDisplay(c.overlapEnd)}
+                        AU-Überschneidung: {formatDateOnlyDE(c.overlapStart)}–
+                        {formatDateOnlyDE(c.overlapEnd)}
                       </Text>
 
                       {c.restorableDays <= 0 ? (

--- a/features/absences/components/VacationBalanceCard.tsx
+++ b/features/absences/components/VacationBalanceCard.tsx
@@ -15,7 +15,7 @@ import type { AppTheme } from "@/constants/theme";
 import type { Absence } from "@/types/absence";
 import type { VacationBalance } from "@/types/vacationLedger";
 import { formatDays } from "@/utils/vacationBalance";
-import { formatForDisplay } from "@/utils/date";
+import { formatDateOnlyDE } from "@/utils/date";
 import React, { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
@@ -62,8 +62,8 @@ export function VacationBalanceCard({ balance, pending }: Props) {
           <Text style={styles.label}>Offene Anträge</Text>
           {pending.map((absence) => (
             <Text key={absence.id} style={styles.pendingLine}>
-              {formatForDisplay(absence.startDate)}
-              {absence.endDate ? ` – ${formatForDisplay(absence.endDate)}` : ""}
+              {formatDateOnlyDE(absence.startDate)}
+              {absence.endDate ? ` – ${formatDateOnlyDE(absence.endDate)}` : ""}
             </Text>
           ))}
           <Text style={styles.footnote}>

--- a/utils/vacationBalance.ts
+++ b/utils/vacationBalance.ts
@@ -67,9 +67,17 @@ export function formatLedgerAmount(amountDays: number): string {
   return `${sign}${value}`;
 }
 
-/** Anzeigeform einer Kennzahl (ohne erzwungenes Vorzeichen): "28,5". */
+/**
+ * Anzeigeform einer Kennzahl (ohne erzwungenes Vorzeichen): "28,5".
+ *
+ * `+ 0` normalisiert eine negative Null (-0) auf +0, BEVOR toLocaleString sie
+ * sieht — sonst zeigt z. B. ein exakt ausgeglichenes "Verbraucht" (Abzug und
+ * Storno heben sich auf, buildVacationBalance liefert -0) fälschlich "-0,0"
+ * an. In JS gilt -0 + 0 === 0 (Object.is(-0 + 0, 0) → true), das ist reine
+ * Zahlendarstellung und ändert keinen echten negativen Wert.
+ */
 export function formatDays(amountDays: number): string {
-  return amountDays.toLocaleString("de-DE", {
+  return (amountDays + 0).toLocaleString("de-DE", {
     minimumFractionDigits: 1,
     maximumFractionDigits: 2,
   });


### PR DESCRIPTION
## Problem

Two cosmetic issues found during Staging smoke testing of PR #102's screens (no functional bug, no accounting error):

1. **`Verbraucht: -0,0`** on the Urlaubskonto screen when a vacation deduction and its cancellation exactly offset (`-3 + 3`).
2. **`16.11.2026 01:00`** on the AU screen for date-only vacation/overlap ranges — a fake time and a timezone-shift risk.

## Root causes

**`-0,0`:** [`formatDays`](utils/vacationBalance.ts) formatted the raw number directly. `-3 + 3` in JS/the ledger sum can legitimately produce `-0`, and `toLocaleString` renders its sign. `formatLedgerAmount` was unaffected — it derives the sign from a separate comparison (`amountDays < 0`, which is `false` for `-0`) rather than from the formatted number.

**Fake time:** the AU screen passed date-only `"YYYY-MM-DD"` values (from `AuRestorationCandidate.vacationStart/End/overlapStart/End`) through `formatForDisplay`, a datetime formatter that always appends `HH:mm`. An unused, already-correct helper — `formatDateOnlyDE` (pure string-slicing, no `Date()` parsing, no timezone shift) — already existed for exactly this case.

## Fixes

- `formatDays`: `(amountDays + 0).toLocaleString(...)` — normalizes `-0` to `+0` before formatting (`-0 + 0 === 0` in JS). Presentation-only; the underlying ledger sum is untouched.
- `AdminAuReviewScreen.tsx` / `VacationBalanceCard.tsx`: date-only fields now use `formatDateOnlyDE`. Real timestamps (`confirmedAt`, ledger `createdAt`, `invitedAt`) are untouched — they still use `formatForDisplay` and still show time.

## Verification

- `npx tsc --noEmit` / `npm run lint`: clean.
- 12/12 assertions on `formatDays`/`formatLedgerAmount` against the required matrix (`0`, `-0`, `0.0`, `-0.0`, positive fractional, negative fractional) — real negative values still render correctly, nothing is hidden.
- 5/5 assertions on `formatDateOnlyDE` vs `formatForDisplay` — date-only strips time, real timestamps keep it.
- **Live on Staging:** a fully offset ledger (`-3` deduction + `+3` cancellation) now shows `Verbraucht 0,0` (not `-0,0`); the AU screen shows `Urlaub 01.12.2026–05.12.2026` / `AU-Überschneidung: 02.12.2026–03.12.2026` (no time), while `Entschieden am 22.08.2026 00:38` correctly keeps its time.
- No schema change, no migration, no accounting logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)