### PR TITLE
Polish login and registration UX

### DIFF
--- a/components/ui/index.tsx
+++ b/components/ui/index.tsx
@@ -265,6 +265,8 @@ export function PasswordInput({ label, error, style, ...props }: PasswordInputPr
           onPress={() => setVisible((v) => !v)}
           style={styles.eyeBtn}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel={visible ? "Passwort verbergen" : "Passwort anzeigen"}
         >
           <Ionicons
             name={visible ? "eye-off-outline" : "eye-outline"}
@@ -327,10 +329,16 @@ function createInputStyles(theme: AppTheme) {
       paddingRight: 48,
     },
     eyeBtn: {
+      // Breite an theme.spacing.tapTarget angelehnt (44pt WCAG-Mindestmaß) —
+      // Icon bleibt optisch unverändert (18px, zentriert), nur die tatsächliche
+      // Tippfläche wächst. top:0/bottom:0 übernehmen bereits die volle
+      // Zeilenhöhe (= Eingabefeldhöhe), hier fehlte bisher nur die Breite.
       position: "absolute",
-      right: 14,
+      right: 0,
       top: 0,
       bottom: 0,
+      width: 44,
+      alignItems: "center",
       justifyContent: "center",
     },
   });

--- a/features/auth/LoginScreen.tsx
+++ b/features/auth/LoginScreen.tsx
@@ -1,13 +1,12 @@
 // features/auth/LoginScreen.tsx
-// Redesign: useAppTheme(), Inter-Font, PasswordInput, ErrorBanner.
-// Auth-Logik bleibt unverändert.
+// Login-Formular (E-Mail/Passwort) via supabase.auth.signInWithPassword.
 
 import { ErrorBanner, PasswordInput, Input } from "@/components/ui";
 import { AuthBrand } from "@/features/auth/components/AuthBrand";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
-import { normalizeEmail } from "@/utils/email";
+import { isValidEmail, normalizeEmail } from "@/utils/email";
 import { router } from "expo-router";
 import React, { useMemo, useRef, useState } from "react";
 import {
@@ -56,6 +55,9 @@ export default function LoginScreen() {
 
     if (!email.trim()) {
       setEmailError("E-Mail ist erforderlich.");
+      valid = false;
+    } else if (!isValidEmail(email)) {
+      setEmailError("Bitte gib eine gültige E-Mail-Adresse ein.");
       valid = false;
     }
     if (!password) {
@@ -173,6 +175,9 @@ export default function LoginScreen() {
               onPress={handleLogin}
               disabled={loading}
               activeOpacity={0.82}
+              accessibilityRole="button"
+              accessibilityLabel="Anmelden"
+              accessibilityState={{ disabled: loading, busy: loading }}
             >
               <Text style={styles.loginBtnText}>
                 {loading ? "Anmelden..." : "Anmelden"}

--- a/features/auth/RegisterScreen.tsx
+++ b/features/auth/RegisterScreen.tsx
@@ -1,12 +1,13 @@
 // features/auth/RegisterScreen.tsx
-// Redesign: useAppTheme(), Inter-Font, PasswordInput, Passwort-Bestätigung.
-// registerAdmin()-Logik bleibt vollständig unverändert.
+// Admin-Registrierung: Konto + Firma in einem Formular
+// (registerAdmin ruft im Anschluss setupCompanyForAdmin auf).
 
 import { ErrorBanner, Input, PasswordInput } from "@/components/ui";
 import { AuthBrand } from "@/features/auth/components/AuthBrand";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAuth } from "@/context/AuthContext";
 import { registerAdmin } from "@/services/auth/registerAdmin";
+import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useMemo, useRef, useState } from "react";
 import {
@@ -23,7 +24,12 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
-import { validatePassword } from "@/utils/passwordValidation";
+import { isValidEmail } from "@/utils/email";
+import {
+  MIN_PASSWORD_LENGTH,
+  PASSWORD_MISMATCH_MESSAGE,
+  validatePassword,
+} from "@/utils/passwordValidation";
 
 export default function RegisterScreen() {
   const theme      = useAppTheme();
@@ -46,6 +52,8 @@ export default function RegisterScreen() {
   const [formError,         setFormError]         = useState("");
 
   const [loading, setLoading] = useState(false);
+
+  const passwordMeetsLength = password.length >= MIN_PASSWORD_LENGTH;
 
   // Animation
   const fadeAnim  = useRef(new Animated.Value(0)).current;
@@ -78,6 +86,9 @@ export default function RegisterScreen() {
     if (!email.trim()) {
       setEmailError("E-Mail ist erforderlich.");
       valid = false;
+    } else if (!isValidEmail(email)) {
+      setEmailError("Bitte gib eine gültige E-Mail-Adresse ein.");
+      valid = false;
     }
     const passwordCheck = validatePassword(password);
     if (!passwordCheck.valid) {
@@ -85,7 +96,7 @@ export default function RegisterScreen() {
       valid = false;
     }
     if (password && passwordConf && password !== passwordConf) {
-      setPasswordConfError("Passwörter stimmen nicht überein.");
+      setPasswordConfError(PASSWORD_MISMATCH_MESSAGE);
       valid = false;
     }
     if (password && !passwordConf) {
@@ -201,16 +212,33 @@ export default function RegisterScreen() {
             <View style={styles.section}>
               <Text style={styles.sectionLabel}>PASSWORT</Text>
               <View style={styles.fields}>
-                <PasswordInput
-                  label="Passwort"
-                  placeholder="Mindestens 10 Zeichen"
-                  value={password}
-                  onChangeText={(t) => { setPassword(t); setPasswordError(""); clearError(); }}
-                  error={passwordError}
-                  autoComplete="password-new"
-                  returnKeyType="next"
-                  editable={!loading}
-                />
+                <View style={styles.passwordField}>
+                  <PasswordInput
+                    label="Passwort"
+                    placeholder="Mindestens 10 Zeichen"
+                    value={password}
+                    onChangeText={(t) => { setPassword(t); setPasswordError(""); clearError(); }}
+                    error={passwordError}
+                    autoComplete="password-new"
+                    returnKeyType="next"
+                    editable={!loading}
+                  />
+                  <View style={styles.passwordHintRow}>
+                    <Ionicons
+                      name={passwordMeetsLength ? "checkmark-circle" : "ellipse-outline"}
+                      size={14}
+                      color={passwordMeetsLength ? theme.colors.statusCompleted : theme.colors.outline}
+                    />
+                    <Text
+                      style={[
+                        styles.passwordHintText,
+                        passwordMeetsLength && styles.passwordHintTextMet,
+                      ]}
+                    >
+                      Mindestens {MIN_PASSWORD_LENGTH} Zeichen
+                    </Text>
+                  </View>
+                </View>
                 <PasswordInput
                   label="Passwort bestätigen"
                   placeholder="Passwort wiederholen"
@@ -238,6 +266,9 @@ export default function RegisterScreen() {
               onPress={handleRegister}
               disabled={loading}
               activeOpacity={0.82}
+              accessibilityRole="button"
+              accessibilityLabel="Firma erstellen"
+              accessibilityState={{ disabled: loading, busy: loading }}
             >
               <Text style={styles.registerBtnText}>
                 {loading ? "Konto wird erstellt..." : "Firma erstellen"}
@@ -310,6 +341,24 @@ function createStyles(theme: AppTheme) {
       letterSpacing: theme.typography.letterSpacing.widest,
     },
     fields: { gap: theme.spacing.md },
+
+    // Passwort-Feld + Live-Anforderungshinweis
+    passwordField: { gap: 6 },
+    passwordHintRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingLeft: 2,
+    },
+    passwordHintText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.outline,
+    },
+    passwordHintTextMet: {
+      color: theme.colors.statusCompleted,
+      fontFamily: theme.typography.family.medium,
+    },
 
     // Hinweis-Box
     infoBox: {

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -1,10 +1,20 @@
 // utils/email.ts
-// Gemeinsame E-Mail-Normalisierung für alle Auth-Formulare (Login,
-// Registrierung, Passwort vergessen). Verhindert, dass unterschiedliche
+// Gemeinsame E-Mail-Normalisierung und Format-Prüfung für alle Auth-Formulare
+// (Login, Registrierung, Passwort vergessen). Verhindert, dass unterschiedliche
 // Groß-/Kleinschreibung oder Leerzeichen zu abweichenden Supabase-Auth-
 // Nutzern führen. Ändert niemals das Passwort.
 
 /** Trimmt Whitespace und normalisiert die Groß-/Kleinschreibung für Supabase Auth. */
 export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
+}
+
+// Bewusst ein einfaches, permissives Muster (kein RFC-5322-Vollvalidator) —
+// Ziel ist, offensichtliche Tippfehler ("foo@bar") früh im Formular statt
+// erst als generischer "E-Mail oder Passwort ist falsch."-Fehler zu fangen.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Grobe Format-Prüfung für Client-seitiges UI-Feedback (nicht die einzige Absicherung — Supabase validiert serverseitig). */
+export function isValidEmail(email: string): boolean {
+  return EMAIL_PATTERN.test(email.trim());
 }

--- a/utils/passwordValidation.ts
+++ b/utils/passwordValidation.ts
@@ -7,6 +7,8 @@
 
 export const MIN_PASSWORD_LENGTH = 10;
 
+export const PASSWORD_MISMATCH_MESSAGE = "Die Passwörter stimmen nicht überein.";
+
 export type PasswordValidationResult = {
   valid: boolean;
   /** Deutsche Fehlermeldungen, leer wenn `valid`. Für UI-Feedback nutzbar. */
@@ -33,6 +35,6 @@ export function validateNewPassword(
 ): string | null {
   const { valid, errors } = validatePassword(password);
   if (!valid) return errors[0];
-  if (password !== confirmPassword) return "Die Passwörter stimmen nicht überein.";
+  if (password !== confirmPassword) return PASSWORD_MISMATCH_MESSAGE;
   return null;
 }


### PR DESCRIPTION
## Summary

- **Login email-format validation** — malformed emails now show "Bitte gib eine gültige E-Mail-Adresse ein." before submit, instead of surfacing as a confusing wrong-password error from Supabase.
- **Registration email-format validation** — same shared check applied to Register.
- **Live "Mindestens 10 Zeichen" password feedback** on Register — a hint under the password field updates in real time as the user types, switching from a neutral/incomplete state to a green checkmark once the minimum length (from the shared B1 validator) is met.
- **Shared password-mismatch message** — Register previously hand-wrote its own "Passwörter stimmen nicht überein." string; it now reuses the same `PASSWORD_MISMATCH_MESSAGE` constant as the rest of the app.
- **Improved `PasswordInput` eye-toggle touch target** — the shared show/hide button (used by Login, Register, Reset, Accept-Invite, Change-Password) had an effective touch target of only ~34pt despite already being ~47pt tall. Widened to ~44×47pt without any visible layout change (icon position shifts by <1pt).
- **`PasswordInput` accessibility labels** — the eye-toggle now exposes `accessibilityRole="button"` and a dynamic German label ("Passwort anzeigen" / "Passwort verbergen").
- **Focused Auth cleanup** — removed stale changelog-style header comments on `LoginScreen.tsx`/`RegisterScreen.tsx` ("Redesign: ...", "bleibt unverändert") that no longer described current behavior.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` (`expo lint`) — clean.
- `isValidEmail()` was audited/stress-tested against 18 cases (7 valid real-world addresses, 11 invalid patterns covering missing `@`, missing domain/suffix, double `@`, and whitespace in invalid positions) — all passed; kept as-is (already appropriately permissive, not overly strict).
- Manual/browser verification performed against the already-running local dev server: Login and Register email-format validation, live password-length hint, password-mismatch message, eye-toggle on both screens (including both password fields on Register independently), and confirmation the revealed password value is never mutated/trimmed.
- **Successful Admin registration was intentionally not executed** — the local dev environment's `.env` is connected to the production Supabase project, and completing registration would have created a real account/company row in production. This path's underlying logic (`registerAdmin`, `setupCompanyForAdmin`) is unchanged from the already-merged B1 PR.
- Diff audited: exactly 5 files, all Auth-related. No dependency/lockfile changes, no iOS/Android native changes, no migrations, no notification/job/timer/absence changes, no leftover 6-character-policy references, no password/token logging.

## Deployment note

Remote Supabase password minimum remains 6 in both Staging and Production. After this PR is merged, Staging should be changed to 10 first and real Auth regression should be performed there before changing Production.

## Test plan
- [ ] Login with an existing account still works
- [ ] Login shows a friendly error for a malformed email
- [ ] Register shows the live password-length hint transitioning to "met" at 10 characters
- [ ] Register shows the mismatch message when confirmation doesn't match
- [ ] Eye-toggle reveals/hides the exact typed password (no mutation) on Login and both Register password fields
- [ ] Successful Admin registration + company setup (against Staging, not Production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)