### PR TITLE
Fix auth registration environment parity

### DIFF
--- a/supabase/migrations/20260826000000_backfill_on_auth_user_created_trigger.sql
+++ b/supabase/migrations/20260826000000_backfill_on_auth_user_created_trigger.sql
@@ -1,0 +1,45 @@
+-- =========================================================
+-- Backfill: on_auth_user_created trigger auf auth.users
+-- =========================================================
+-- Hintergrund: public.handle_new_user() existiert bereits seit der
+-- Baseline-Migration (20260713000000_remote_baseline.sql, ein Dump des
+-- *public*-Schemas). Der zugehoerige TRIGGER auf auth.users liegt jedoch im
+-- Supabase-verwalteten auth-Schema und wurde beim urspruenglichen
+-- Projekt-Setup nur manuell auf Production angelegt (siehe lib/schema.sql,
+-- das ihn bereits als Referenz dokumentiert) — nie als Migration erfasst.
+-- Frisch aus Migrationen provisionierte Umgebungen (Staging, lokale Dev-DB)
+-- haben deshalb die Funktion, aber nicht den Trigger: Admin-Registrierung
+-- legt zwar die Firma an, aber setup_company_for_admin()s abschliessendes
+-- UPDATE auf public.profiles betrifft 0 Zeilen (kein Fehler, da ungeprueft)
+-- — das Profil bleibt unverknuepft.
+--
+-- Idempotent: CREATE OR REPLACE + DROP TRIGGER IF EXISTS/CREATE TRIGGER,
+-- sicher erneut anwendbar auch dort, wo Funktion/Trigger schon existieren
+-- (Production). Dort ersetzt DROP+CREATE den bestehenden Trigger durch
+-- exakt dieselbe, bereits verifizierte Definition (kein 'New User'-
+-- Fallback-Unterschied zu lib/schema.sql) — verhaltenserhaltend, ohne
+-- Duplikat, auch wenn es technisch kein reiner No-op auf DB-Ebene ist.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, full_name)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'full_name', 'New User')
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row
+execute function public.handle_new_user();

--- a/utils/authErrorMessages.ts
+++ b/utils/authErrorMessages.ts
@@ -17,7 +17,31 @@ export const OFFLINE_ERROR_MESSAGE =
 export const SERVER_UNAVAILABLE_ERROR_MESSAGE =
   "Der Server ist momentan nicht erreichbar. Bitte versuche es später erneut.";
 
-// Bekannte technische GoTrue-/Supabase-Auth-Fehlertexte → deutsche
+// Stabile GoTrue-Fehlercodes (AuthApiError.code / REST-Body error_code) →
+// deutsche Nutzer-Meldung. Wird VOR den Text-Mustern unten geprüft — ein
+// Code ist robuster als ein Textmuster, weil Supabase die Wortwahl der
+// Meldung ändern kann, ohne den Code zu ändern. Werte siehe
+// @supabase/auth-js ErrorCode-Union (node_modules/@supabase/auth-js/dist/*/lib/error-codes.d.ts).
+const KNOWN_ERROR_CODES: Readonly<Record<string, string>> = {
+  invalid_credentials: "E-Mail oder Passwort ist falsch.",
+  email_not_confirmed: "Bitte bestätige zuerst deine E-Mail-Adresse.",
+  email_address_invalid: "Bitte gib eine gültige E-Mail-Adresse ein.",
+  email_address_not_authorized: "Bitte gib eine gültige E-Mail-Adresse ein.",
+  user_already_exists: "Für diese E-Mail-Adresse existiert bereits ein Konto.",
+  email_exists: "Für diese E-Mail-Adresse existiert bereits ein Konto.",
+  weak_password: "Das Passwort erfüllt nicht die Mindestanforderungen.",
+  over_email_send_rate_limit:
+    "Zu viele Versuche. Bitte warte kurz und versuche es erneut.",
+  over_request_rate_limit:
+    "Zu viele Versuche. Bitte warte kurz und versuche es erneut.",
+  refresh_token_not_found: "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+  session_expired: "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+  session_not_found: "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+};
+
+// Fallback für Fehler ohne erhaltenen Code (z.B. Edge-Function-Bodies, die
+// nur einen String liefern — siehe toFriendlyEdgeFunctionErrorMessage):
+// bekannte technische GoTrue-/Supabase-Auth-Fehlertexte → deutsche
 // Nutzer-Meldung. Reihenfolge relevant: spezifischere Muster zuerst.
 const KNOWN_ERROR_PATTERNS: readonly {
   pattern: RegExp;
@@ -32,7 +56,12 @@ const KNOWN_ERROR_PATTERNS: readonly {
     message: "Bitte bestätige zuerst deine E-Mail-Adresse.",
   },
   {
-    pattern: /unable to validate email address|invalid email/i,
+    // Deckt sowohl "Unable to validate email address" als auch GoTrues
+    // "Email address "x@y.z" is invalid" ab (unterschiedliche Wortstellung,
+    // beide bedeuten dasselbe email_address_invalid). Eng genug, um nicht
+    // versehentlich unabhängige Fehler zu treffen: verlangt "email" +
+    // "invalid" UND (address/adresse-Kontext) im selben Satz.
+    pattern: /unable to validate email address|invalid email|email address.{0,60}is invalid/i,
     message: "Bitte gib eine gültige E-Mail-Adresse ein.",
   },
   {
@@ -69,6 +98,15 @@ function extractMessage(err: unknown): string {
   return typeof maybeMessage === "string" ? maybeMessage : "";
 }
 
+// AuthApiError.code (supabase-js) bzw. REST-Body error_code (Edge Functions,
+// die den Fehler roh durchreichen) — siehe KNOWN_ERROR_CODES oben.
+function extractErrorCode(err: unknown): string {
+  if (!err || typeof err !== "object") return "";
+  const maybeCode =
+    (err as { code?: unknown }).code ?? (err as { error_code?: unknown }).error_code;
+  return typeof maybeCode === "string" ? maybeCode : "";
+}
+
 // Übersetzt einen beliebigen Fehler (Supabase AuthError, geworfene Errors,
 // rohe Strings) in eine nutzerfreundliche deutsche Meldung. `fallback`
 // erlaubt jedem Aufrufer einen zum Kontext passenden Default (z.B. "E-Mail
@@ -78,6 +116,9 @@ export function toFriendlyAuthErrorMessage(
   fallback: string = GENERIC_AUTH_ERROR_MESSAGE,
 ): string {
   if (isNetworkError(err)) return OFFLINE_ERROR_MESSAGE;
+
+  const code = extractErrorCode(err);
+  if (code && KNOWN_ERROR_CODES[code]) return KNOWN_ERROR_CODES[code];
 
   const message = extractMessage(err);
   if (!message) return fallback;


### PR DESCRIPTION
## Summary

### Database parity
- Production has always had the `on_auth_user_created AFTER INSERT ON auth.users` trigger, applied manually at some point (consistent with this repo's documented "apply `lib/schema.sql` changes manually" workflow) — but no versioned migration ever created it.
- Staging, provisioned purely from migrations, had `handle_new_user()` (from the baseline migration) but was missing the trigger — so `setup_company_for_admin`'s closing `UPDATE public.profiles` silently affected 0 rows (no row-count check), and Admin self-registration never linked a profile.
- New migration `20260826000000_backfill_on_auth_user_created_trigger.sql` captures the required trigger in version control: idempotent `CREATE OR REPLACE FUNCTION` (using Production's exact verified body) + `DROP TRIGGER IF EXISTS`/`CREATE TRIGGER`.
- Already deployed and verified on **Staging only** — confirmed via `pg_trigger` and a functional smoke test. Literal Admin Registration now works end-to-end on Staging.
- Applying this migration to Production later is **behavior-preserving and idempotent in effect**: `DROP`+`CREATE` replaces the existing trigger with the exact same definition it already runs — not a duplicate, not a data change, not literally a no-op at the SQL level but a no-op in observable behavior.

### Auth error handling
- `utils/authErrorMessages.ts` gained a stable-error-code-first mapping layer (`AuthApiError.code` / REST body `error_code`, checked before the existing message-regex fallback) — more robust since Supabase can reword messages without changing the code.
- GoTrue's `Email address "..." is invalid` (`error_code: email_address_invalid`) can no longer leak as raw English — maps to `Bitte gib eine gültige E-Mail-Adresse ein.`
- All existing mappings remain intact: invalid credentials, duplicate account, weak password, network failure, generic fallback.

## Verification
- Literal Staging Admin Registration with exactly 10 characters succeeded through the real `RegisterScreen` UI — no substitutions: `signUp()` returned an active session immediately, the trigger auto-created the profile, `setup_company_for_admin` created the company, `profiles.role='admin'`/`company_id` verified correct via direct DB query, and the app routed automatically to a fresh Admin Dashboard.
- 9-character password correctly client-blocked, zero `auth.users` rows created.
- Logout + fresh re-login with the exact registration password verified — same dashboard, same company, same admin identity.
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- All disposable Staging test data created during verification was deleted and cascade-confirmed; the pre-existing QA fixture was left untouched.

## Deployment note

> Production still has `password_min_length = 6`. Do not raise it to 10 until this PR is merged and the versioned migration is safely applied through the normal Production deployment path.

Also note: Staging `uri_allow_list` still differs from Production (empty vs. the two `taskopsmanager://` deep links). This does not block this PR or the password-policy rollout, but it should be aligned before the next Forgot Password / Invite deep-link QA phase.

## Test plan
- [ ] Apply migration `20260826000000` to Production via the normal deployment path
- [ ] Confirm Production's `on_auth_user_created` trigger still matches after the migration (should be identical — same function body, same trigger definition)
- [ ] Raise Production `password_min_length` to 10 (separate, deliberate step — not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)