### PR TITLE
Polish forgot and reset password flow

### DIFF
--- a/features/auth/ForgotPasswordScreen.tsx
+++ b/features/auth/ForgotPasswordScreen.tsx
@@ -6,7 +6,7 @@ import { ErrorBanner, Input } from "@/components/ui";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
-import { normalizeEmail } from "@/utils/email";
+import { isValidEmail, normalizeEmail } from "@/utils/email";
 import { Ionicons } from "@expo/vector-icons";
 import * as Linking from "expo-linking";
 import { router } from "expo-router";
@@ -41,6 +41,10 @@ export default function ForgotPasswordScreen() {
 
     if (!email.trim()) {
       setEmailError("E-Mail ist erforderlich.");
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setEmailError("Bitte gib eine gültige E-Mail-Adresse ein.");
       return;
     }
 

--- a/features/auth/ResetPasswordScreen.tsx
+++ b/features/auth/ResetPasswordScreen.tsx
@@ -10,7 +10,7 @@ import { useAuthLinkSession } from "@/features/auth/useAuthLinkSession";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
-import { validateNewPassword } from "@/utils/passwordValidation";
+import { MIN_PASSWORD_LENGTH, validateNewPassword } from "@/utils/passwordValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useMemo, useState } from "react";
@@ -46,6 +46,8 @@ export default function ResetPasswordScreen() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [formError, setFormError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  const passwordMeetsLength = newPassword.length >= MIN_PASSWORD_LENGTH;
 
   const handleSubmit = async () => {
     const validationError = validateNewPassword(newPassword, confirmPassword);
@@ -199,19 +201,36 @@ export default function ResetPasswordScreen() {
               <ErrorBanner message={formError} onDismiss={() => setFormError("")} />
             ) : null}
 
-            <PasswordInput
-              label="Neues Passwort"
-              placeholder="Mindestens 10 Zeichen"
-              value={newPassword}
-              onChangeText={(text) => {
-                setNewPassword(text);
-                if (formError) setFormError("");
-              }}
-              autoCapitalize="none"
-              autoCorrect={false}
-              returnKeyType="next"
-              editable={!submitting}
-            />
+            <View style={styles.passwordField}>
+              <PasswordInput
+                label="Neues Passwort"
+                placeholder="Mindestens 10 Zeichen"
+                value={newPassword}
+                onChangeText={(text) => {
+                  setNewPassword(text);
+                  if (formError) setFormError("");
+                }}
+                autoCapitalize="none"
+                autoCorrect={false}
+                returnKeyType="next"
+                editable={!submitting}
+              />
+              <View style={styles.passwordHintRow}>
+                <Ionicons
+                  name={passwordMeetsLength ? "checkmark-circle" : "ellipse-outline"}
+                  size={14}
+                  color={passwordMeetsLength ? theme.colors.statusCompleted : theme.colors.outline}
+                />
+                <Text
+                  style={[
+                    styles.passwordHintText,
+                    passwordMeetsLength && styles.passwordHintTextMet,
+                  ]}
+                >
+                  Mindestens {MIN_PASSWORD_LENGTH} Zeichen
+                </Text>
+              </View>
+            </View>
 
             <PasswordInput
               label="Passwort bestätigen"
@@ -292,6 +311,24 @@ function createStyles(theme: AppTheme) {
       padding: theme.spacing.xl,
       gap: theme.spacing.lg,
       ...theme.shadows.md,
+    },
+
+    // Passwort-Feld + Live-Anforderungshinweis
+    passwordField: { gap: 6 },
+    passwordHintRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingLeft: 2,
+    },
+    passwordHintText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.outline,
+    },
+    passwordHintTextMet: {
+      color: theme.colors.statusCompleted,
+      fontFamily: theme.typography.family.medium,
     },
 
     primaryBtn: {

--- a/utils/passwordValidation.ts
+++ b/utils/passwordValidation.ts
@@ -7,6 +7,17 @@
 
 export const MIN_PASSWORD_LENGTH = 10;
 
+// Supabase Auth hasht Passwörter mit bcrypt, das nur die ersten 72 BYTES
+// (nicht Zeichen) verwendet — bei Überschreitung antwortet GoTrue nicht mit
+// einer sauberen Validierungsmeldung, sondern mit einem rohen, instabilen
+// 500 "unexpected_failure" (verifiziert direkt gegen Staging). Da dieses
+// 72-Byte-Limit eine feste, dokumentierte Eigenschaft von bcrypt selbst ist
+// (nicht etwas, das sich mit der Supabase-Version ändert), lohnt sich eine
+// clientseitige Schranke, statt sich auf die Fehlerzuordnung eines instabilen
+// 500ers zu verlassen. Byte- statt zeichenbasiert geprüft, da Unicode-Zeichen
+// (Emoji, Umlaute außerhalb Latin-1 etc.) mehr als 1 Byte belegen können.
+export const MAX_PASSWORD_BYTES = 72;
+
 export const PASSWORD_MISMATCH_MESSAGE = "Die Passwörter stimmen nicht überein.";
 
 export type PasswordValidationResult = {
@@ -15,7 +26,24 @@ export type PasswordValidationResult = {
   errors: string[];
 };
 
-/** Prüft ein neues Passwort gegen die Mindestlänge. Liefert Details für UI-Feedback statt nur einem Boolean. */
+// UTF-8-Byte-Länge ohne TextEncoder (dessen Verfügbarkeit auf allen
+// RN/Hermes-Zielplattformen nicht gesichert ist) — behandelt Surrogatpaare
+// (z.B. Emoji) korrekt über codePointAt.
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i++) {
+    const codePoint = value.codePointAt(i);
+    if (codePoint === undefined) continue;
+    if (codePoint > 0xffff) i++; // Surrogatpaar: zweite UTF-16-Einheit überspringen
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
+}
+
+/** Prüft ein neues Passwort gegen Mindest- und Höchstlänge. Liefert Details für UI-Feedback statt nur einem Boolean. */
 export function validatePassword(password: string): PasswordValidationResult {
   const errors: string[] = [];
 
@@ -23,6 +51,8 @@ export function validatePassword(password: string): PasswordValidationResult {
     errors.push("Bitte ein Passwort eingeben.");
   } else if (password.length < MIN_PASSWORD_LENGTH) {
     errors.push(`Das Passwort muss mindestens ${MIN_PASSWORD_LENGTH} Zeichen lang sein.`);
+  } else if (utf8ByteLength(password) > MAX_PASSWORD_BYTES) {
+    errors.push("Das Passwort ist zu lang.");
   }
 
   return { valid: errors.length === 0, errors };


### PR DESCRIPTION
## Summary

### Forgot Password
- Added shared `isValidEmail()` client-side format validation (previously only checked non-empty) — a typo'd email now shows "Bitte gib eine gültige E-Mail-Adresse ein." before any request is sent.
- Privacy-preserving behavior retained: the success message never reveals whether an account exists, and this was verified live (repeated requests to a non-existent address returned the identical message and never created a user).

### Reset Password
- Added a live "Mindestens 10 Zeichen" requirement indicator, matching the existing pattern already used on `RegisterScreen` (unmet → neutral, met → green checkmark).
- Shared password-validation behavior retained — mismatch and minimum-length checks continue to route entirely through `utils/passwordValidation.ts`, no screen-local duplication.

### Password safety
- `utils/passwordValidation.ts` gains a shared, UTF-8-byte-aware upper bound (`MAX_PASSWORD_BYTES = 72`) — bcrypt's documented password-hashing input limit, verified directly against Staging (72 bytes accepted, 73 returns a raw, unstable GoTrue `500 unexpected_failure`).
- Byte length is computed via `codePointAt` (no `TextEncoder` dependency, since its availability isn't guaranteed across all RN/Hermes targets), so emoji and other surrogate-pair characters are counted correctly rather than under-counted by a naive `.length` check.
- Because `validateNewPassword` calls `validatePassword` internally, this single implementation is shared by **Registration, Reset Password, Accept Invite, and Change Password** — no per-screen duplication.
- Passwords are never trimmed or otherwise mutated by validation; internal/leading/trailing whitespace is preserved exactly.

### Deep-link QA
During this phase, Staging's remote Auth configuration was aligned with Production: `uri_allow_list` raised from empty to `taskopsmanager://reset-password,taskopsmanager://accept-invite`, matching Production exactly. **This remote Staging setting is not part of this Git diff** — it was applied directly via the Supabase Management API, verified to be the only changed config key (full field-by-field diff), and Production was never touched. A real Staging recovery-link redirect was independently re-verified afterward to correctly return `taskopsmanager://reset-password#access_token=...` (previously fell back to `localhost:3000`), and redemption through the real app was confirmed reaching the Reset Password screen.

## Verification
- Malformed Forgot Password email blocked client-side — verified.
- Privacy-preserving success state verified (non-existent address, identical response).
- Real Staging recovery-link redirect and redemption verified through the actual app.
- 9-character password rejected — verified.
- 73-byte password rejected client-side with "Das Passwort ist zu lang." — verified.
- Mismatched confirmation rejected — verified.
- Unicode password with internal spaces (diacritics, exact preservation via eye-toggle) accepted, persisted, and confirmed via login — verified.
- Successful reset → forced sign-out → fresh login with the new password — verified end-to-end.
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.

**No Production configuration or Production data was changed during Phase B3.**

## Test plan
- [ ] Forgot Password with a malformed email shows an inline error, no request sent
- [ ] Forgot Password with a valid email shows the privacy-preserving success screen
- [ ] Reset Password live length indicator turns green at exactly 10 characters
- [ ] Reset Password rejects an intentionally very long (73+ byte) password with a friendly message
- [ ] Successful password reset signs the user out and requires fresh login

🤖 Generated with [Claude Code](https://claude.com/claude-code)