### PR TITLE
fix: harden employee invite lifecycle

### DIFF
--- a/app/(admin-tabs)/employees.tsx
+++ b/app/(admin-tabs)/employees.tsx
@@ -9,9 +9,8 @@ import { useJobs } from "@/context/JobContext";
 import { createEmployee } from "@/services/employees/createEmployee";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Alert,
   FlatList,
   KeyboardAvoidingView,
   Modal,
@@ -27,7 +26,12 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { AppTheme } from "@/constants/theme";
 import { getEmployeeStatus } from "@/utils/employeeStatus";
+import { isValidEmail, normalizeEmail } from "@/utils/email";
 import { toUserMessage } from "@/utils/userMessages";
+
+// Erfolgs-Banner blendet sich nach dieser Zeit selbst wieder aus — identisch
+// zum Muster in features/jobs/components/JobPhotos.tsx.
+const SUCCESS_DISPLAY_MS = 3000;
 
 function roleLabel(role?: string | null): string {
   if (role === "admin") return "Admin";
@@ -51,12 +55,26 @@ export default function EmployeesScreen() {
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [creating, setCreating] = useState(false);
+  const [modalError, setModalError] = useState("");
+
+  // Erfolgs-Feedback nach dem Einladen — Alert.alert ist auf Web ein No-Op
+  // (siehe ErrorBanner-Nutzung unten), daher ein eigenes, selbst
+  // ausblendendes Banner auf der Liste, analog zu JobPhotos.tsx.
+  const [successMessage, setSuccessMessage] = useState("");
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     refreshEmployees();
   }, [refreshEmployees]);
 
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current) clearTimeout(successTimerRef.current);
+    };
+  }, []);
+
   const handleOpenModal = () => {
+    setModalError("");
     setModalVisible(true);
   };
 
@@ -64,6 +82,7 @@ export default function EmployeesScreen() {
     setModalVisible(false);
     setFullName("");
     setEmail("");
+    setModalError("");
   };
 
   // ── Mitarbeiter einladen: legt das Konto unbestätigt an und verschickt eine
@@ -72,21 +91,23 @@ export default function EmployeesScreen() {
   // den Einladungs-Link (siehe features/auth/AcceptInviteScreen.tsx).
   const handleCreateEmployee = async () => {
     const trimmedName = fullName.trim();
-    const trimmedEmail = email.trim().toLowerCase();
+    const trimmedEmail = normalizeEmail(email);
 
     if (creating) {
       return;
     }
 
     if (!trimmedName) {
-      Alert.alert("Fehler", "Bitte gib einen Namen ein.");
+      setModalError("Bitte gib einen Namen ein.");
       return;
     }
 
-    if (!trimmedEmail || !trimmedEmail.includes("@")) {
-      Alert.alert("Fehler", "Bitte gib eine gültige E-Mail-Adresse ein.");
+    if (!isValidEmail(trimmedEmail)) {
+      setModalError("Bitte gib eine gültige E-Mail-Adresse ein.");
       return;
     }
+
+    setModalError("");
 
     try {
       setCreating(true);
@@ -97,20 +118,23 @@ export default function EmployeesScreen() {
       });
 
       await refreshEmployees();
+      handleCloseModal();
 
-      Alert.alert(
-        "Einladung verschickt",
+      if (successTimerRef.current) clearTimeout(successTimerRef.current);
+      setSuccessMessage(
         `${trimmedName} erhält in Kürze eine E-Mail, um das eigene Passwort festzulegen.`,
       );
-
-      handleCloseModal();
+      successTimerRef.current = setTimeout(
+        () => setSuccessMessage(""),
+        SUCCESS_DISPLAY_MS,
+      );
     } catch (error) {
       const message = toUserMessage(
         error,
         "Einladung konnte nicht verschickt werden.",
       );
 
-      Alert.alert("Fehler", message);
+      setModalError(message);
     } finally {
       setCreating(false);
     }
@@ -172,6 +196,17 @@ export default function EmployeesScreen() {
                 statt als nackter roter Text (dieselbe Darstellung wie in den
                 Job-Screens). Text kam bisher zudem roh aus dem Backend. */}
             {error ? <ErrorBanner message={error} /> : null}
+
+            {successMessage ? (
+              <View style={styles.successBanner}>
+                <Ionicons
+                  name="checkmark-circle-outline"
+                  size={16}
+                  color={theme.colors.statusCompleted}
+                />
+                <Text style={styles.successText}>{successMessage}</Text>
+              </View>
+            ) : null}
           </View>
         }
         ListEmptyComponent={
@@ -256,6 +291,15 @@ export default function EmployeesScreen() {
             <Text style={styles.modalSubtitle}>
               Der Mitarbeiter erhält eine E-Mail und legt sein Passwort selbst fest.
             </Text>
+
+            {modalError ? (
+              <View style={styles.modalErrorWrap}>
+                <ErrorBanner
+                  message={modalError}
+                  onDismiss={() => setModalError("")}
+                />
+              </View>
+            ) : null}
 
             <View style={styles.formGroup}>
               <Text style={styles.label}>Name</Text>
@@ -390,7 +434,26 @@ function createStyles(theme: AppTheme) {
       color: theme.colors.onSurfaceVariant,
     },
 
-    // ── Error-Text
+    // ── Erfolgs-Banner (nach erfolgreicher Einladung)
+    successBanner: {
+      marginTop: theme.spacing.md,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.xs,
+      backgroundColor: theme.colors.statusCompletedBg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusCompletedBorder,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 8,
+    },
+    successText: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.statusCompleted,
+    },
 
     // ── Mitarbeiter-Karten in der Liste
     employeeCard: {
@@ -511,6 +574,9 @@ function createStyles(theme: AppTheme) {
       fontSize: theme.typography.size.sm,
       fontFamily: theme.typography.family.regular,
       color: theme.colors.onSurfaceVariant,
+    },
+    modalErrorWrap: {
+      marginTop: theme.spacing.md,
     },
 
     // ── Formular-Felder im Modal

--- a/features/auth/AcceptInviteScreen.tsx
+++ b/features/auth/AcceptInviteScreen.tsx
@@ -11,7 +11,7 @@ import { useAuthLinkSession } from "@/features/auth/useAuthLinkSession";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { supabase } from "@/lib/supabase";
 import { toFriendlyAuthErrorMessage } from "@/utils/authErrorMessages";
-import { validateNewPassword } from "@/utils/passwordValidation";
+import { MIN_PASSWORD_LENGTH, validateNewPassword } from "@/utils/passwordValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useMemo, useState } from "react";
@@ -47,6 +47,8 @@ export default function AcceptInviteScreen() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [formError, setFormError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  const passwordMeetsLength = newPassword.length >= MIN_PASSWORD_LENGTH;
 
   const handleSubmit = async () => {
     const validationError = validateNewPassword(newPassword, confirmPassword);
@@ -209,19 +211,36 @@ export default function AcceptInviteScreen() {
               />
             ) : null}
 
-            <PasswordInput
-              label="Passwort"
-              placeholder="Mindestens 10 Zeichen"
-              value={newPassword}
-              onChangeText={(text) => {
-                setNewPassword(text);
-                if (formError) setFormError("");
-              }}
-              autoCapitalize="none"
-              autoCorrect={false}
-              returnKeyType="next"
-              editable={!submitting}
-            />
+            <View style={styles.passwordField}>
+              <PasswordInput
+                label="Passwort"
+                placeholder="Mindestens 10 Zeichen"
+                value={newPassword}
+                onChangeText={(text) => {
+                  setNewPassword(text);
+                  if (formError) setFormError("");
+                }}
+                autoCapitalize="none"
+                autoCorrect={false}
+                returnKeyType="next"
+                editable={!submitting}
+              />
+              <View style={styles.passwordHintRow}>
+                <Ionicons
+                  name={passwordMeetsLength ? "checkmark-circle" : "ellipse-outline"}
+                  size={14}
+                  color={passwordMeetsLength ? theme.colors.statusCompleted : theme.colors.outline}
+                />
+                <Text
+                  style={[
+                    styles.passwordHintText,
+                    passwordMeetsLength && styles.passwordHintTextMet,
+                  ]}
+                >
+                  Mindestens {MIN_PASSWORD_LENGTH} Zeichen
+                </Text>
+              </View>
+            </View>
 
             <PasswordInput
               label="Passwort bestätigen"
@@ -308,6 +327,24 @@ function createStyles(theme: AppTheme) {
       padding: theme.spacing.xl,
       gap: theme.spacing.lg,
       ...theme.shadows.md,
+    },
+
+    // Passwort-Feld + Live-Anforderungshinweis
+    passwordField: { gap: 6 },
+    passwordHintRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingLeft: 2,
+    },
+    passwordHintText: {
+      fontSize: theme.typography.size.xs,
+      fontFamily: theme.typography.family.regular,
+      color: theme.colors.outline,
+    },
+    passwordHintTextMet: {
+      color: theme.colors.statusCompleted,
+      fontFamily: theme.typography.family.medium,
     },
 
     primaryBtn: {

--- a/features/employees/EmployeeDetailScreen.tsx
+++ b/features/employees/EmployeeDetailScreen.tsx
@@ -31,7 +31,7 @@ import { getJobStatusLabel } from "@/utils/jobStatus";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   ScrollView,
@@ -94,8 +94,19 @@ export default function EmployeeDetailScreen() {
 
   // Loading-State für Deaktivieren/Reaktivieren.
   const [updatingActive, setUpdatingActive] = useState(false);
-  // Loading-State für "Einladung erneut senden".
+  // Loading-/Feedback-State für "Einladung erneut senden". Eigenes
+  // Erfolgs-/Fehler-Feedback statt Alert.alert (auf Web ein No-Op) — analog
+  // zum Muster in app/(admin-tabs)/employees.tsx.
   const [resendingInvite, setResendingInvite] = useState(false);
+  const [resendError, setResendError] = useState("");
+  const [resendSuccess, setResendSuccess] = useState("");
+  const resendSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resendSuccessTimerRef.current) clearTimeout(resendSuccessTimerRef.current);
+    };
+  }, []);
 
   const employee = useMemo(
     () => employees.find((e) => e.id === id),
@@ -235,19 +246,23 @@ export default function EmployeeDetailScreen() {
   // resend-invite/index.ts).
   const handleResendInvite = async () => {
     if (!employee || resendingInvite) return;
+    setResendError("");
     try {
       setResendingInvite(true);
       await resendInvite(employee.id);
-      Alert.alert(
-        "Einladung verschickt",
-        `${employee.fullName} hat eine neue Einladungs-E-Mail erhalten.`,
+
+      if (resendSuccessTimerRef.current) clearTimeout(resendSuccessTimerRef.current);
+      setResendSuccess(`${employee.fullName} hat eine neue Einladungs-E-Mail erhalten.`);
+      resendSuccessTimerRef.current = setTimeout(
+        () => setResendSuccess(""),
+        3000,
       );
     } catch (err) {
       const message = toUserMessage(
         err,
         "Einladung konnte nicht erneut verschickt werden.",
       );
-      Alert.alert("Fehler", message);
+      setResendError(message);
     } finally {
       setResendingInvite(false);
     }
@@ -561,6 +576,19 @@ export default function EmployeeDetailScreen() {
 
         {/* ── Aktionen ── */}
         <View style={styles.actions}>
+          {resendError ? (
+            <ErrorBanner message={resendError} onDismiss={() => setResendError("")} />
+          ) : null}
+          {resendSuccess ? (
+            <View style={styles.resendSuccessBanner}>
+              <Ionicons
+                name="checkmark-circle-outline"
+                size={16}
+                color={theme.colors.statusCompleted}
+              />
+              <Text style={styles.resendSuccessText}>{resendSuccess}</Text>
+            </View>
+          ) : null}
           <Button
             label="Job zuweisen"
             icon="add"
@@ -698,6 +726,24 @@ function createStyles(theme: AppTheme) {
     actions: {
       gap: theme.spacing.sm,
       marginTop: theme.spacing.sm,
+    },
+    resendSuccessBanner: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.xs,
+      backgroundColor: theme.colors.statusCompletedBg,
+      borderWidth: 1,
+      borderColor: theme.colors.statusCompletedBorder,
+      borderRadius: theme.radius.md,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 8,
+    },
+    resendSuccessText: {
+      flex: 1,
+      fontSize: theme.typography.size.sm,
+      fontFamily: theme.typography.family.medium,
+      fontWeight: theme.typography.weight.medium,
+      color: theme.colors.statusCompleted,
     },
   });
 }

--- a/supabase/functions/create-employee/index.ts
+++ b/supabase/functions/create-employee/index.ts
@@ -21,6 +21,82 @@ type CreateEmployeeBody = {
 // nicht in Expo Go.
 const INVITE_REDIRECT_TO = "taskopsmanager://accept-invite";
 
+type AuthUserLookup = { id: string; email?: string };
+
+// Sucht einen Auth-Nutzer per exakter E-Mail, OHNE inviteUserByEmail
+// aufzurufen (kein Einladungs-Mail-Seiteneffekt) und OHNE einen unbeschränkten
+// listUsers()-Scan. GoTrue's Admin-REST-API unterstützt `filter` als
+// serverseitig ausgeführte, gebundene Suche — gegen Staging verifiziert:
+// leeres Array bei unbekannter E-Mail, Treffer bei bekannter. Das
+// installierte @supabase/supabase-js gibt diesen Parameter über
+// auth.admin.listUsers() NICHT durch (dessen Query-Objekt ist hart auf
+// page/perPage begrenzt, siehe GoTrueAdminApi.js) — daher roher fetch gegen
+// denselben Endpunkt, mit demselben service-role Key, den adminClient auch
+// sonst verwendet. `filter` matcht als Teilstring/ILIKE, nicht exakt (z.B.
+// "qa.admin" trifft auch "qa.admin.20260805@..."), deshalb wird hier IMMER
+// hart auf exakte Gleichheit nachgeprüft statt der erste Treffer ungeprüft
+// übernommen.
+async function findExistingAuthUserByEmail(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  email: string,
+): Promise<AuthUserLookup | null> {
+  const url = `${supabaseUrl}/auth/v1/admin/users?filter=${encodeURIComponent(email)}`;
+  const response = await fetch(url, {
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Auth-Lookup fehlgeschlagen (Status ${response.status}).`);
+  }
+
+  const body = (await response.json()) as { users?: AuthUserLookup[] };
+  const users = body.users ?? [];
+  return users.find((u) => u.email?.toLowerCase() === email) ?? null;
+}
+
+type ProfileConflictCheck = {
+  company_id: string | null;
+  invite_accepted_at: string | null;
+} | null;
+
+// Dieselbe Konflikt-Regel wird zweimal angewendet: VOR inviteUserByEmail
+// (verhindert im Normalfall den Einladungs-Mail-Seiteneffekt für abgelehnte
+// Anfragen) und NACH inviteUserByEmail (Race-Absicherung — zwei praktisch
+// gleichzeitige Requests für dieselbe, wirklich neue E-Mail können die
+// Vorab-Prüfung beide passieren, siehe Kommentar unten am zweiten
+// Aufrufort). Kein echtes Profil (null) oder ein Trigger-Stub
+// (company_id = null, siehe handle_new_user()) ist nie ein Konflikt — eine
+// Auth-Identität, die noch bei KEINER Firma Mitglied ist, darf frei
+// eingeladen werden.
+//
+// Architektur-Hinweis (nicht in B4 aufgelöst): "existiert dieselbe Person
+// schon woanders" und "gehört diese Mitgliedschaft schon einer anderen
+// Firma" sind hier bewusst DIESELBE Prüfung, weil `profiles.company_id`
+// eine EINZELNE Spalte ist — eine Auth-Identität hat maximal eine
+// Mitgliedschaft gleichzeitig abbildbar. Diese Funktion sperrt NICHT "eine
+// Person darf nur bei einer Firma je existieren" als Geschäftsregel; sie
+// verhindert nur, dass ein Invite die EINZIGE vorhandene Mitgliedschaftszeile
+// eines fremden/bereits akzeptierten Mitarbeiters überschreibt — bei einer
+// Spalte gibt es dafür keinen sicheren "daneben"-Fall, nur "überschreiben"
+// oder "ablehnen". Sollte Mehrfirmen-Beschäftigung künftig ein echtes
+// Produktfeature werden, braucht das eine eigene Datenmodell-Änderung (z.B.
+// eine company_memberships-Tabelle statt einer Spalte) — diese Funktion
+// müsste dann pro Mitgliedschaft statt pro Profil prüfen. Absichtlich nicht
+// in B4 vorweggenommen.
+function isConflictingProfile(
+  profile: ProfileConflictCheck,
+  adminCompanyId: string,
+): boolean {
+  if (!profile || profile.company_id === null) return false;
+  const sameCompany = profile.company_id === adminCompanyId;
+  const alreadyAccepted = !!profile.invite_accepted_at;
+  return !sameCompany || alreadyAccepted;
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -112,6 +188,56 @@ Deno.serve(async (req) => {
       );
     }
 
+    // ── Pre-Invite-Prüfung ──────────────────────────────────────────────
+    // Lehnt bekannte Konflikte AB, BEVOR inviteUserByEmail aufgerufen wird —
+    // eine Anfrage, die ohnehin abgelehnt wird, soll im Normalfall keine
+    // echte Einladungs-Mail an eine fremde/bereits aktive Adresse auslösen.
+    // Nur wenn KEIN Auth-Nutzer für diese E-Mail existiert ODER er zwar
+    // existiert, aber (noch) kein echtes Profil bei irgendeiner Firma hat
+    // (Trigger-Stub, company_id = null), läuft die Anfrage ungehindert
+    // weiter. Der Post-Invite-Guard unten bleibt zusätzlich bestehen — er
+    // sichert den seltenen Race-Fall ab (siehe dortiger Kommentar), auf den
+    // sich diese Vorab-Prüfung allein nicht verlassen kann.
+    let preInviteAuthUser: AuthUserLookup | null = null;
+    try {
+      preInviteAuthUser = await findExistingAuthUserByEmail(
+        supabaseUrl,
+        serviceRoleKey,
+        email,
+      );
+    } catch {
+      return Response.json(
+        { error: "E-Mail-Adresse konnte nicht geprüft werden." },
+        { status: 500, headers: corsHeaders },
+      );
+    }
+
+    if (preInviteAuthUser) {
+      const { data: preInviteProfile, error: preInviteProfileError } =
+        await adminClient
+          .from("profiles")
+          .select("company_id, invite_accepted_at")
+          .eq("id", preInviteAuthUser.id)
+          .maybeSingle();
+
+      if (preInviteProfileError) {
+        return Response.json(
+          { error: "Mitarbeiter-Profil konnte nicht geprüft werden." },
+          { status: 500, headers: corsHeaders },
+        );
+      }
+
+      if (isConflictingProfile(preInviteProfile, adminProfile.company_id)) {
+        return Response.json(
+          {
+            error: "Für diese E-Mail-Adresse existiert bereits ein Konto.",
+            code: "email_exists",
+          },
+          { status: 409, headers: corsHeaders },
+        );
+      }
+    }
+
     // Einladung statt admin-vergebenem Passwort: legt den Nutzer unbestätigt
     // an und verschickt Supabase's Invite-Mail mit einem einmalig gültigen
     // Link. Der Mitarbeiter setzt sein Passwort selbst (accept-invite-Screen,
@@ -137,6 +263,61 @@ Deno.serve(async (req) => {
 
     const employeeId = invitedUser.user.id;
     const invitedAt = new Date().toISOString();
+
+    // ── Post-Invite-Guard (Race-Absicherung) ─────────────────────────────
+    // Bleibt trotz der Vorab-Prüfung oben bestehen: zwei praktisch
+    // gleichzeitige create-employee-Aufrufe für dieselbe, wirklich neue
+    // E-Mail (z.B. von zwei verschiedenen Firmen-Admins) können BEIDE die
+    // Vorab-Prüfung mit "kein Konflikt" passieren, bevor einer von beiden
+    // inviteUserByEmail/den Upsert abgeschlossen hat — GoTrue liefert dann
+    // beiden dieselbe employeeId zurück (E-Mail ist eindeutig in
+    // auth.users). Dieser zweite, unabhängige Check nach dem tatsächlichen
+    // Ergebnis von inviteUserByEmail ist die einzige Stelle, die diesen
+    // Fall zuverlässig abfängt: wer zuerst upserted, "gewinnt" die
+    // Firmenzuordnung; der andere sieht hier einen echten Konflikt und wird
+    // abgelehnt, BEVOR sein eigener Upsert die Zeile erneut anfasst.
+    //
+    // inviteUserByEmail matcht per E-Mail und liefert bei einer bereits
+    // existierenden Auth-Identität (bestätigt ODER unbestätigt) dieselbe
+    // employeeId zurück — nicht zwingend einen neuen Nutzer. Ohne diese
+    // Prüfung würde der Upsert unten das zugehörige profiles-Zeile blind
+    // überschreiben: is_active könnte einen deaktivierten Mitarbeiter
+    // reaktivieren, company_id könnte ihn firmenübergreifend umhängen.
+    //
+    // Wichtig: der on_auth_user_created-Trigger (handle_new_user(), siehe
+    // 20260826000000_backfill_on_auth_user_created_trigger.sql) legt bei
+    // JEDEM neuen auth.users-Insert — auch dem, den inviteUserByEmail gerade
+    // für einen wirklich neuen Nutzer ausgelöst hat — sofort eine Stub-Zeile
+    // in profiles an (nur id + full_name, company_id bleibt null). Eine
+    // existierende profiles-Zeile ist daher kein zuverlässiges Signal für
+    // "schon eingeladen" — isConflictingProfile() behandelt einen Stub
+    // (company_id = null) korrekt wie "kein Profil".
+    const { data: existingProfile, error: existingProfileError } =
+      await adminClient
+        .from("profiles")
+        .select("company_id, invite_accepted_at")
+        .eq("id", employeeId)
+        .maybeSingle();
+
+    if (existingProfileError) {
+      return Response.json(
+        { error: "Mitarbeiter-Profil konnte nicht geprüft werden." },
+        { status: 500, headers: corsHeaders },
+      );
+    }
+
+    if (isConflictingProfile(existingProfile, adminProfile.company_id)) {
+      return Response.json(
+        {
+          error: "Für diese E-Mail-Adresse existiert bereits ein Konto.",
+          code: "email_exists",
+        },
+        { status: 409, headers: corsHeaders },
+      );
+    }
+    // Kein Konflikt: entweder ein wirklich neuer Nutzer, ein Stub ohne
+    // Firma, oder eine offene Einladung DERSELBEN Firma (Upsert unten
+    // verhält sich dann wie ein erneutes Senden).
 
     const { error: upsertProfileError } = await adminClient
       .from("profiles")

--- a/utils/authErrorMessages.ts
+++ b/utils/authErrorMessages.ts
@@ -162,8 +162,16 @@ export async function toFriendlyEdgeFunctionErrorMessage(
     try {
       const body = await (error.context as Response).json();
       const bodyMessage = typeof body?.error === "string" ? body.error : "";
-      if (bodyMessage) {
-        return toFriendlyAuthErrorMessage(bodyMessage, fallback);
+      const bodyCode = typeof body?.code === "string" ? body.code : "";
+      if (bodyMessage || bodyCode) {
+        // Ein `code`-Feld (siehe z.B. create-employee: "email_exists") ist
+        // robuster als der Text — Edge Functions formulieren ihre Meldung
+        // bereits selbst auf Deutsch, aber der Code erlaubt trotzdem den
+        // stabilen KNOWN_ERROR_CODES-Treffer statt Text-Musterabgleich.
+        return toFriendlyAuthErrorMessage(
+          { message: bodyMessage, code: bodyCode },
+          fallback,
+        );
       }
     } catch {
       // Body nicht lesbar (kein/kaputtes JSON) → unten generisch zuordnen.


### PR DESCRIPTION
## Summary
- Added a server-side pre-invite conflict check to `create-employee`: normalized email is looked up via GoTrue's Admin REST `filter=` search (bounded, server-only, exact-match verified against the results) *before* `inviteUserByEmail` is called.
- Prevents rejected invitations from triggering any invite-email side effect — verified live on Staging with byte-identical `auth.users` state (`invited_at`/`confirmation_sent_at`/`updated_at`/metadata) before and after every rejected attempt.
- Keeps the existing defensive post-invite guard, unchanged in behavior, as a race backstop for two near-simultaneous requests targeting the same brand-new email.
- Same-company pending invites still preserve the existing resend behavior (re-invite regenerates the link, no duplicate profile, company/role untouched).
- Existing accepted employees and foreign-company memberships can no longer be overwritten by a create-employee call — confirmed via live cross-company attack simulation (rejecting admin's payload never lands in the target's profile).
- Documents a current schema limitation in code: `profiles.company_id` is a single column, so one identity can only hold one membership row today. The reject condition is a consequence of that, not a "one company forever" business rule — real multi-company employment would need a future membership table, out of scope here.
- Also: live password-length hint on `AcceptInviteScreen` (parity with reset-password), `Alert.alert` replaced with in-form banners in the invite-creation/resend flows (web no-op fix), shared email normalization/validation reused from `utils/email.ts`, and `utils/authErrorMessages.ts` now reads a structured `code` field from Edge Function error bodies.
- Staging regression completed across both the original guard and the new pre-check: brand-new, same-company pending, same-company accepted, cross-company pending, and cross-company accepted — all passed, all disposable test data cleaned up afterward. Both Staging and Production `uri_allow_list` independently confirmed (read-only, Management API) to contain `taskopsmanager://accept-invite`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Staging: brand-new employee invite → correct company, pending, one profile row
- [x] Staging: same-company pending re-invite → resend behavior, no duplicate
- [x] Staging: same-company accepted re-invite → rejected, zero DB/auth mutation
- [x] Staging: cross-company pending invite attempt → rejected, target's company/name untouched
- [x] Staging: cross-company accepted invite attempt → rejected, zero mutation
- [x] Staging + Production `uri_allow_list` verified read-only via Management API
- [x] All disposable Staging test data (users, profiles, companies) cleaned up; baseline restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)