### PR TITLE
fix: allow negative values in vacation correction input on iOS

### DIFF
--- a/features/vacation/AdminVacationAccountScreen.tsx
+++ b/features/vacation/AdminVacationAccountScreen.tsx
@@ -249,7 +249,7 @@ export default function AdminVacationAccountScreen() {
             </Text>
             <TextInput
               style={styles.input}
-              keyboardType="decimal-pad"
+              keyboardType="numbers-and-punctuation"
               placeholder="z. B. 2 oder -0,5"
               placeholderTextColor={theme.colors.onSurfaceVariant}
               value={adjustAmount}


### PR DESCRIPTION
## Summary
- C1 regression fix: the manual vacation correction input (`AdminVacationAccountScreen`, "Manuelle Korrektur") used `keyboardType="decimal-pad"`, which has no minus key on iOS — negative corrections like `-0,5` were untypeable even though the UI text explicitly says "negativer zieht ab.".
- Changed to `keyboardType="numbers-and-punctuation"`, the iOS-supported keyboard that includes `-`, `+`, and `.`/`,`.
- No other changes: parsing/validation (`handleAdjust`) already correctly accepts `2`, `-0,5`, `+2,5` and rejects invalid text — it was only ever blocked by the keyboard. Vacation calculation logic, DB schema, correction rules, and audit/history are untouched.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Diff confirmed to touch exactly one line in one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)