### PR TITLE
fix: prepare push notification infrastructure

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,6 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "permissions": ["android.permission.RECORD_AUDIO"],
       "package": "com.ferash.taskopsmanager",
       "googleServicesFile": "./google-services.json"
     },

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -98,6 +98,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const autoRetryCountRef = useRef(0);
   const MAX_AUTO_RETRIES = 3;
 
+  // Verhindert überlappende syncPushToken()-Läufe, falls die App mehrfach
+  // schnell hintereinander in den Vordergrund wechselt (z. B. schneller
+  // App-Switch) — kein neuer Zustand, nur ein In-Flight-Schutz.
+  const syncingPushTokenRef = useRef(false);
+
   // Merker, ob aktuell ein VOLLSTÄNDIGES Profil gesetzt ist.
   // Grundlage für die Overwrite-Schutzregel in setProfileSafe.
   const hasCompleteProfileRef = useRef(false);
@@ -324,6 +329,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [loadAndApplyProfile]);
 
   const syncPushToken = useCallback(async () => {
+    // In-Flight-Schutz: verhindert überlappende Läufe, wenn z. B. ein
+    // schneller App-Foreground-Wechsel mehrfach hintereinander feuert. Kein
+    // neuer Speicherzustand — update_my_push_token ist ohnehin idempotent
+    // (setzt nur die eigene Zeile), das hier spart nur unnötige Doppelaufrufe.
+    if (syncingPushTokenRef.current) {
+      return;
+    }
+    syncingPushTokenRef.current = true;
+
     try {
       const expoPushToken = await registerForPushNotifications();
 
@@ -358,6 +372,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (!isNetworkError(error)) {
         console.error("Failed to register for push notifications:", error);
       }
+    } finally {
+      syncingPushTokenRef.current = false;
     }
   }, []);
 
@@ -576,6 +592,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // (über refreshProfile). Das funktioniert auch dann, wenn Realtime nicht
   // konfiguriert ist oder die Verbindung im Hintergrund abgerissen ist — der
   // Nutzer wird spätestens beim nächsten Antippen der App gesperrt.
+  //
+  // Derselbe Foreground-Wechsel synchronisiert zusätzlich den Push-Token
+  // (C2.1): bisher lief syncPushToken() nur beim Kaltstart und bei
+  // Auth-State-Änderungen — ein Nutzer, der die Benachrichtigungs-Berechtigung
+  // erst NACH dem ersten Start (über die iOS-/Android-Einstellungen) erteilt
+  // und danach nur in die bereits laufende App zurückwechselt, bekam sonst
+  // keinen Token, bis die nächste Anmeldung/Session-Erneuerung lief.
+  // syncPushToken ist selbst web-sicher (registerForPushNotifications gibt
+  // dort sofort null zurück) und serverseitig idempotent (update_my_push_token
+  // setzt nur die eigene Zeile) — hier bewusst KEIN separater Listener,
+  // sondern derselbe Handler wie oben, um keine zweite AppState-Subscription
+  // zu erzeugen.
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextState) => {
       if (nextState === "active" && session) {
@@ -583,11 +611,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // Fehler landen über profileError in der UI; hier bewusst schlucken,
           // damit ein Foreground-Wechsel nie zu einer unbehandelten Rejection wird.
         });
+        syncPushToken().catch(() => {
+          // syncPushToken fängt eigene Fehler bereits intern ab (siehe oben) —
+          // dieser catch ist nur ein zusätzliches Sicherheitsnetz gegen eine
+          // unbehandelte Rejection bei einem Foreground-Wechsel.
+        });
       }
     });
 
     return () => subscription.remove();
-  }, [session, refreshProfile]);
+  }, [session, refreshProfile, syncPushToken]);
 
   const signOut = useCallback(async () => {
     // Push-Token IMMER zuerst best effort löschen — auch wenn signOut() selbst


### PR DESCRIPTION
## Summary
- Fixed Staging's `notification-dispatch-sweeper` cron job — it was hardcoded to call Production's `dispatch-notifications` URL instead of its own. Verification uncovered two deeper gaps behind the same symptom: `dispatch-notifications` had never been deployed to Staging at all, and Staging had neither a `DISPATCH_SWEEPER_SECRET` function secret nor a matching Vault entry. All three fixed together (Staging-only, live environment changes — no migration, no code change to the function itself): deployed the existing unmodified function, provisioned a fresh Staging-only sweeper secret, corrected the cron URL. Verified end-to-end via the real HTTP response at each step: `401` (wrong secret, hitting prod) → `404` (right project, function missing) → `200 {"mode":"server",...}` once all three pieces were in place.
- Added foreground push-token resync: `syncPushToken()` previously only ran on cold start and auth-state changes, so a user who granted notification permission late (via OS Settings, after initially denying) wouldn't get a token registered until their next login or session refresh. Now also runs on the existing `AppState → "active"` handler (no new listener — added to the same subscription that already refreshes the profile on foreground), guarded by an in-flight ref to avoid overlapping calls on rapid app-switching. Web stays protected via the existing `Platform.OS === "web"` guard inside `registerForPushNotifications`; `update_my_push_token` was already idempotent, so no duplicate-token risk.
- Removed the unused `android.permission.RECORD_AUDIO` from `app.json` — audited first: no audio-recording code, no `expo-av`/`expo-audio`, no dependency requires it anywhere in the app; the only prior reference to it in the whole repo was the permission declaration itself.

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Production untouched — re-verified after all changes: Production's cron command still points to its own URL (byte-identical to before), `dispatch-notifications` on Production still at its pre-existing version, no deploy from this branch ever targeted Production
- [x] Diff scope confirmed: exactly `app.json` and `context/AuthContext.tsx` — no notification backend files, no migrations, no native project files, no dependency changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)