### PR TITLE
fix(vacation): route admin-created vacation through accounting approval

### DIFF
--- a/features/absences/admin/AdminCreateAbsenceScreen.tsx
+++ b/features/absences/admin/AdminCreateAbsenceScreen.tsx
@@ -77,7 +77,7 @@ export default function AdminCreateAbsenceScreen({
     setError("");
     setSubmitting(true);
     try {
-      await adminCreateAbsence({
+      const created = await adminCreateAbsence({
         employeeId: employeeId!,
         type,
         startDate: formatDateISO(startDate!)!,
@@ -85,10 +85,18 @@ export default function AdminCreateAbsenceScreen({
         note: note.trim() || undefined,
       });
 
+      // Wortlaut richtet sich nach dem TATSÄCHLICH zurückgegebenen Status,
+      // nicht nach einer hier erneut geprüften Konto-Annahme: für einen
+      // Mitarbeiter mit geführtem Urlaubskonto liefert admin_create_absence
+      // seit 20260826000002 status='requested' statt 'approved' — die
+      // Genehmigung samt Abzugsbestätigung läuft dann über die bestehende
+      // Urlaubsanträge-Ansicht (admin_review_vacation), nicht hier.
       await alertDialog(
         "Abwesenheit erfasst",
         type === "vacation"
-          ? "Der Urlaub wurde als genehmigt erfasst."
+          ? created.status === "approved"
+            ? "Der Urlaub wurde als genehmigt erfasst."
+            : "Der Urlaub wurde erfasst. Für diesen Mitarbeiter wird ein Urlaubskonto geführt — die Genehmigung samt Abzugsbestätigung erfolgt über die Urlaubsanträge-Liste."
           : "Die Krankmeldung wurde erfasst.",
       );
       router.back();

--- a/supabase/migrations/20260826000002_admin_create_absence_respects_vacation_ledger.sql
+++ b/supabase/migrations/20260826000002_admin_create_absence_respects_vacation_ledger.sql
@@ -1,0 +1,219 @@
+-- =========================================================
+-- MIGRATION: admin_create_absence respektiert das Urlaubskonto
+-- =========================================================
+-- BEFUND (QA vor Beta, verifiziert auf Staging)
+--   admin_create_absence(type='vacation') hat Urlaub bisher IMMER direkt bei
+--   status='approved' angelegt — unabhaengig davon, ob fuer den Mitarbeiter
+--   ein Urlaubskonto gefuehrt wird (profiles.vacation_management_enabled).
+--   Damit entstand fuer Konto-Mitarbeiter:
+--     * ein als "genehmigt" gefuehrter Urlaub,
+--     * der in Stundenzettel/Uebersicht als wirksame Abwesenheit zaehlt
+--       (isOperationallyActiveAbsence prueft nur status='approved'),
+--     * OHNE jede vacation_ledger-Zeile und OHNE
+--       vacation_deducted_days_snapshot.
+--   Das Urlaubskonto-Design (20260824000000) geht davon aus, dass "approved"
+--   ausschliesslich ueber admin_review_vacation erreicht wird — genau dort
+--   sitzt die einzige Stelle, die den Abzug bestaetigt und festschreibt.
+--   admin_create_absence ist in KEINER der drei Ledger-Migrationen
+--   (20260823/24/25) auch nur erwaehnt; der zweite Weg zu "approved" wurde
+--   beim Entwurf des Kontos schlicht nicht mitgedacht.
+--
+--   Empirisch auf Staging reproduziert: 5-Tage-Urlaub ueber
+--   admin_create_absence fuer einen Konto-Mitarbeiter -> status=approved,
+--   vacation_deducted_days_snapshot=NULL, 0 Ledger-Zeilen, Saldo
+--   unveraendert, aber vom Stundenzettel als 5 wirksame Urlaubstage gezaehlt.
+--
+-- =========================================================
+-- FIX (kleinstmoeglich, keine Logik-Duplikation)
+-- =========================================================
+--   admin_create_absence liest zusaetzlich profiles.vacation_management_enabled
+--   des Ziel-Mitarbeiters — GENAU dieselbe Spalte, GENAU derselbe direkte
+--   Zugriff (kein Firmen-Default-Fallback), den admin_review_vacation bereits
+--   fuer dieselbe Entscheidung verwendet ("if v_enabled is true then ...").
+--   Beide RPCs stimmen dadurch strukturell IMMER ueberein, welches Regime
+--   fuer einen Mitarbeiter gilt.
+--
+--   Fuer type='vacation':
+--     * vacation_management_enabled = true  -> status='requested',
+--       reviewed_by/reviewed_at bleiben NULL (kein Genehmigungsschritt
+--       vorweggenommen). Der Admin genehmigt anschliessend ueber die
+--       BESTEHENDE admin_review_vacation()-UI (AdminAbsenceRow zeigt
+--       Genehmigen/Ablehnen fuer jede status='requested'-Zeile, unabhaengig
+--       davon, wer sie angelegt hat) — dort laeuft die Abzugsbestaetigung,
+--       die Ledger-Zeile und der Snapshot exakt wie fuer einen
+--       Mitarbeiter-Antrag.
+--     * vacation_management_enabled = false/NULL -> unveraendertes
+--       Verhalten (status='approved', reviewed_by/at = erfassender Admin).
+--
+--   Fuer type='sickness': VOLLSTAENDIG UNVERAENDERT (status='reported',
+--   reviewed_by/at bleiben NULL) — Krankheit beruehrt das Urlaubskonto nie,
+--   unabhaengig vom Erfassungsweg.
+--
+--   KEINE neue Ledger-Logik in dieser Funktion: admin_review_vacation bleibt
+--   die EINZIGE Stelle, die vacation_ledger-Zeilen und
+--   vacation_deducted_days_snapshot schreibt (siehe deren Kommentarblock,
+--   20260824000000). Diese Migration fasst admin_review_vacation nicht an.
+--
+--   UNVERAENDERT: Rollenpruefung, Firmenscope (inkl. is_active-loser
+--   Mitarbeitersuche fuer historische Nacherfassung), Ueberschneidungs-
+--   pruefung, Enddatum-Validierung, employee_name_snapshot, Benachrichtigung
+--   (keine — admin_create_absence hat nie enqueue_absence_notification
+--   aufgerufen; das aendert sich hier nicht), RLS-Modell (weiterhin
+--   ausschliesslich diese SECURITY-DEFINER-RPC als Schreibpfad).
+--
+-- IDEMPOTENZ
+--   CREATE OR REPLACE FUNCTION — vollstaendig wiederholbar.
+--
+-- ANWENDUNG
+--   Wie alle Schemaaenderungen hier MANUELL im Supabase SQL Editor
+--   ausfuehren (siehe CLAUDE.md).
+-- =========================================================
+
+create or replace function public.admin_create_absence(
+  employee_id_input uuid,
+  type_input public.absence_type,
+  start_date_input date,
+  end_date_input date default null,
+  note_input text default null
+)
+returns setof public.employee_absences
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_company_id        uuid;
+  v_full_name         text;
+  v_vacation_enabled  boolean;
+  v_status            public.absence_status;
+  v_new_id            uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if public.current_user_role() is distinct from 'admin' then
+    raise exception 'Only admins can manually record an absence'
+      using errcode = '42501';
+  end if;
+
+  v_company_id := public.current_user_company_id();
+  if v_company_id is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  -- Mitarbeiter muss in derselben Firma sein. BEWUSST OHNE is_active-
+  -- Bedingung: ein Admin muss eine historische Abwesenheit auch fuer einen
+  -- inzwischen deaktivierten Mitarbeiter nachtragen koennen (z. B.
+  -- Krankmeldung kurz vor Austritt), ohne dass ein Datensatz verloren geht.
+  -- Das entspricht dem Muster von admin_correct_assignment_time, das
+  -- ebenfalls keine is_active-Bedingung an der betroffenen Person kennt.
+  --
+  -- NEU: vacation_management_enabled wird hier zusaetzlich gelesen — exakt
+  -- derselbe direkte Spaltenzugriff wie in admin_review_vacation, damit
+  -- beide RPCs fuer denselben Mitarbeiter niemals unterschiedlich
+  -- entscheiden koennen.
+  select full_name, vacation_management_enabled
+    into v_full_name, v_vacation_enabled
+  from public.profiles
+  where id = employee_id_input
+    and company_id = v_company_id;
+
+  if not found then
+    raise exception 'Employee not found in your company'
+      using errcode = '42501';
+  end if;
+
+  if start_date_input is null then
+    raise exception 'start_date is required' using errcode = '23514';
+  end if;
+
+  if type_input = 'vacation' then
+    if end_date_input is null then
+      raise exception 'end_date is required for vacation'
+        using errcode = '23514';
+    end if;
+    if end_date_input < start_date_input then
+      raise exception 'end_date must not be before start_date'
+        using errcode = '23514';
+    end if;
+
+    if exists (
+      select 1 from public.employee_absences ea
+      where ea.employee_id = employee_id_input
+        and ea.type = 'vacation'
+        and ea.status in ('requested', 'approved')
+        and ea.start_date <= end_date_input
+        and ea.end_date   >= start_date_input
+    ) then
+      raise exception 'Overlaps an existing vacation request'
+        using errcode = '23514';
+    end if;
+
+    -- KERNAENDERUNG: fuer einen gefuehrten Urlaubskonto-Mitarbeiter NICHT
+    -- direkt genehmigen. admin_review_vacation bleibt das einzige Tor zu
+    -- 'approved' fuer diese Gruppe — dort wird der Abzug erzwungen bestaetigt
+    -- und als Ledger-Zeile + Snapshot festgeschrieben.
+    v_status := case when v_vacation_enabled is true then 'requested' else 'approved' end;
+  elsif type_input = 'sickness' then
+    if end_date_input is not null and end_date_input < start_date_input then
+      raise exception 'end_date must not be before start_date'
+        using errcode = '23514';
+    end if;
+
+    if exists (
+      select 1 from public.employee_absences ea
+      where ea.employee_id = employee_id_input
+        and ea.type = 'sickness'
+        and ea.status = 'reported'
+        and ea.start_date <= coalesce(end_date_input, 'infinity'::date)
+        and coalesce(ea.end_date, 'infinity'::date) >= start_date_input
+    ) then
+      raise exception 'Overlaps an existing active sickness report'
+        using errcode = '23514';
+    end if;
+
+    v_status := 'reported';
+  else
+    raise exception 'Unknown absence type' using errcode = '22023';
+  end if;
+
+  insert into public.employee_absences (
+    company_id, employee_id, employee_name_snapshot,
+    type, status, start_date, end_date, admin_note, created_by,
+    reviewed_by, reviewed_at
+  )
+  values (
+    v_company_id, employee_id_input, coalesce(nullif(btrim(v_full_name), ''), 'Unbekannt'),
+    type_input, v_status, start_date_input, end_date_input, note_input, auth.uid(),
+    -- reviewed_by/at werden NUR gesetzt, wenn diese Zeile bereits final
+    -- genehmigt ist (Urlaub ohne Konto). Ein 'requested'-Urlaub (Konto
+    -- aktiv) durchlaeuft die Genehmigung noch — reviewed_by/at bleiben dafuer
+    -- NULL, exakt wie bei einem Mitarbeiter-Antrag ueber
+    -- request_own_vacation(). Krankheit kennt ohnehin keinen
+    -- Genehmigungsschritt und bleibt bei NULL/NULL.
+    case when type_input = 'vacation' and v_status = 'approved' then auth.uid() else null end,
+    case when type_input = 'vacation' and v_status = 'approved' then now() else null end
+  )
+  returning id into v_new_id;
+
+  return query select * from public.employee_absences where id = v_new_id;
+end;
+$$;
+
+comment on function public.admin_create_absence(uuid, public.absence_type, date, date, text) is
+'Admin erfasst eine Abwesenheit manuell fuer einen Mitarbeiter der eigenen '
+'Firma (Telefon-Krankmeldung, ausserhalb der App vereinbarter Urlaub). '
+'Krankheit landet immer direkt bei status=reported (kein Genehmigungsschritt). '
+'Urlaub landet bei status=approved (reviewed_by/at = der erfassende Admin) '
+'NUR wenn fuer den Mitarbeiter KEIN Urlaubskonto gefuehrt wird '
+'(profiles.vacation_management_enabled=false/NULL) — sonst bei '
+'status=requested, ohne reviewed_by/at, damit die Genehmigung samt '
+'Abzugsbestaetigung ausschliesslich ueber admin_review_vacation laeuft '
+'(einzige Quelle fuer vacation_ledger-Zeilen und '
+'vacation_deducted_days_snapshot, siehe 20260824000000). '
+'created_by <> employee_id markiert die Zeile als manuell erfasst. Erlaubt '
+'auch fuer inzwischen deaktivierte Mitarbeiter (historische Nacherfassung).';
+
+revoke all on function public.admin_create_absence(uuid, public.absence_type, date, date, text) from public, anon;
+grant execute on function public.admin_create_absence(uuid, public.absence_type, date, date, text) to authenticated;

--- a/supabase/tests/admin_create_absence_vacation_ledger.test.sql
+++ b/supabase/tests/admin_create_absence_vacation_ledger.test.sql
@@ -1,0 +1,299 @@
+-- =========================================================
+-- TEST: admin_create_absence respektiert das Urlaubskonto
+-- (Migration 20260826000002_admin_create_absence_respects_vacation_ledger)
+-- =========================================================
+-- Deckt den auf Staging nachgewiesenen Pre-Beta-Blocker ab: admin_create_
+-- absence(type='vacation') landete bisher IMMER direkt bei status='approved'
+-- — auch fuer Mitarbeiter mit gefuehrtem Urlaubskonto (profiles.
+-- vacation_management_enabled=true) — ohne jede vacation_ledger-Zeile und
+-- ohne vacation_deducted_days_snapshot, obwohl die Zeile ab sofort ueberall
+-- als wirksamer Urlaub zaehlt (isOperationallyActiveAbsence prueft nur
+-- status='approved').
+--
+-- Alle Zugriffe laufen als echte Rollen (SET ROLE + request.jwt.claims),
+-- also ueber denselben Pfad wie die App ueber PostgREST.
+--
+-- HINWEIS ZU „VERWEIGERT"-PFADEN: der lokale Supabase-Container stuerzt bei
+-- FEHLENDEM PRIVILEG ab (siehe job_assignments_rls.test.sql). Alle
+-- Ablehnungen hier laufen ueber die RPC-eigene Rollen-/Firmenpruefung
+-- (raise exception, sauber abgefangen per BEGIN/EXCEPTION), nicht ueber ein
+-- fehlendes GRANT.
+--
+-- Laeuft transaktional (BEGIN … ROLLBACK): keine Rueckstaende, keine
+-- Produktionsdaten. Ausfuehren lokal:
+--   docker exec -i supabase_db_<projekt> psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f - < supabase/tests/admin_create_absence_vacation_ledger.test.sql
+-- =========================================================
+
+begin;
+
+-- ── Fixdaten ──
+-- Firma A = 51…1 | Firma B = 51…2
+-- Admin A  = 52…1
+-- X = 52…2  (Firma A, vacation_management_enabled=true, Konto 2026 mit 24 Tagen)
+-- Y = 52…3  (Firma A, vacation_management_enabled=false — Standardfall)
+-- Admin B  = 52…4 (Firma B, fuer Cross-Company-Faelle)
+do $$
+begin
+  insert into auth.users (instance_id,id,aud,role,email,raw_user_meta_data) values
+    ('00000000-0000-0000-0000-000000000000','52000000-0000-0000-0000-000000000001','authenticated','authenticated','z-adminA@example.test','{"full_name":"Admin A"}'),
+    ('00000000-0000-0000-0000-000000000000','52000000-0000-0000-0000-000000000002','authenticated','authenticated','z-x@example.test','{"full_name":"Xenia Konto"}'),
+    ('00000000-0000-0000-0000-000000000000','52000000-0000-0000-0000-000000000003','authenticated','authenticated','z-y@example.test','{"full_name":"Yannick Ohne Konto"}'),
+    ('00000000-0000-0000-0000-000000000000','52000000-0000-0000-0000-000000000004','authenticated','authenticated','z-adminB@example.test','{"full_name":"Admin B"}');
+end $$;
+
+-- Der auth-Trigger handle_new_user ist in der lokalen Baseline nicht
+-- enthalten — Profile werden deshalb explizit angelegt.
+insert into public.profiles (id, full_name) values
+  ('52000000-0000-0000-0000-000000000001','Admin A'),
+  ('52000000-0000-0000-0000-000000000002','Xenia Konto'),
+  ('52000000-0000-0000-0000-000000000003','Yannick Ohne Konto'),
+  ('52000000-0000-0000-0000-000000000004','Admin B')
+on conflict (id) do nothing;
+
+insert into public.companies (id,name,slug) values
+  ('51000000-0000-0000-0000-000000000001','Ledger Firma A','ledger-firma-a-test'),
+  ('51000000-0000-0000-0000-000000000002','Ledger Firma B','ledger-firma-b-test');
+
+update public.profiles set company_id='51000000-0000-0000-0000-000000000001', role='admin',    is_active=true
+  where id='52000000-0000-0000-0000-000000000001';
+update public.profiles set company_id='51000000-0000-0000-0000-000000000001', role='employee', is_active=true,
+  vacation_management_enabled=true, vacation_annual_entitlement_days=24
+  where id='52000000-0000-0000-0000-000000000002';
+update public.profiles set company_id='51000000-0000-0000-0000-000000000001', role='employee', is_active=true,
+  vacation_management_enabled=false
+  where id='52000000-0000-0000-0000-000000000003';
+update public.profiles set company_id='51000000-0000-0000-0000-000000000002', role='admin',    is_active=true
+  where id='52000000-0000-0000-0000-000000000004';
+
+create temporary table _r (case_no int, beschreibung text, erwartet text, ergebnis text) on commit drop;
+
+create or replace function pg_temp.act_as(uid uuid) returns void language plpgsql as $f$
+begin
+  perform set_config('request.jwt.claims', json_build_object('sub',uid::text,'role','authenticated')::text, true);
+end $f$;
+
+-- ── Urlaubskonto fuer X initialisieren (Jahr 2026, 24 Tage Anspruch) ──
+do $$
+declare v_year_id uuid;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  v_year_id := public.admin_initialize_vacation_year('52000000-0000-0000-0000-000000000002', 2026);
+  execute 'reset role';
+  insert into _r values (0,'Setup: Urlaubskonto X/2026 initialisiert (24 Tage)','not null',
+    case when v_year_id is not null then 'not null' else 'null' end);
+end $$;
+
+
+-- =========================================================
+-- CASE A — Admin legt Urlaub fuer Y (KEIN Konto) an
+-- =========================================================
+-- Erwartet: unveraendertes Alt-Verhalten — sofort approved,
+-- reviewed_by/at gesetzt, kein Ledger-Zwang.
+do $$
+declare v_status text; v_reviewed_by text; v_snapshot text;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select status::text, reviewed_by::text, coalesce(vacation_deducted_days_snapshot::text,'NULL')
+    into v_status, v_reviewed_by, v_snapshot
+  from public.admin_create_absence(
+    '52000000-0000-0000-0000-000000000003', 'vacation', '2026-09-01', '2026-09-03', 'QA CASE A'
+  );
+  execute 'reset role';
+  insert into _r values (1,'CASE A: Urlaub fuer Y (kein Konto) -> sofort approved',
+    'status=approved/reviewed_by=set/snapshot=NULL',
+    'status='||v_status||'/reviewed_by='||(case when v_reviewed_by is not null then 'set' else 'NULL' end)||'/snapshot='||v_snapshot);
+  raise notice 'CASE A -> %', v_status;
+end $$;
+
+
+-- =========================================================
+-- CASE B — Admin legt Urlaub fuer X (Konto aktiv) an
+-- =========================================================
+-- Erwartet: status=requested, reviewed_by/at NULL, snapshot NULL,
+-- KEINE Ledger-Zeile.
+do $$
+declare
+  v_id uuid; v_status text; v_reviewed_by text; v_reviewed_at text; v_snapshot text;
+  v_ledger_rows int;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select id, status::text, reviewed_by::text, reviewed_at::text,
+         coalesce(vacation_deducted_days_snapshot::text,'NULL')
+    into v_id, v_status, v_reviewed_by, v_reviewed_at, v_snapshot
+  from public.admin_create_absence(
+    '52000000-0000-0000-0000-000000000002', 'vacation', '2026-09-07', '2026-09-11', 'QA CASE B'
+  );
+  execute 'reset role';
+
+  select count(*) into v_ledger_rows from public.vacation_ledger where absence_id = v_id;
+
+  insert into _r values (2,'CASE B: Urlaub fuer X (Konto aktiv) -> requested, kein Ledger',
+    'status=requested/reviewed_by=NULL/reviewed_at=NULL/snapshot=NULL/ledger=0',
+    'status='||v_status||'/reviewed_by='||coalesce(v_reviewed_by,'NULL')||'/reviewed_at='
+      ||(case when v_reviewed_at is null then 'NULL' else 'set' end)
+      ||'/snapshot='||v_snapshot||'/ledger='||v_ledger_rows::text);
+  raise notice 'CASE B -> %', v_status;
+
+  -- Fuer CASE C/D weiterreichen.
+  create temporary table _case_b (id uuid) on commit drop;
+  insert into _case_b values (v_id);
+end $$;
+
+
+-- =========================================================
+-- CASE C — Admin genehmigt den CASE-B-Antrag ueber admin_review_vacation
+-- =========================================================
+-- Erwartet: status=approved, snapshot korrekt, approved_vacation-Zeile,
+-- Saldo korrekt reduziert (24 -> 24-5=19, 5 Kalendertage Mo-Fr).
+do $$
+declare
+  v_case_b_id uuid;
+  v_status text; v_snapshot numeric; v_ledger_amount numeric;
+  v_balance numeric;
+begin
+  select id into v_case_b_id from _case_b;
+
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select status::text, vacation_deducted_days_snapshot
+    into v_status, v_snapshot
+  from public.admin_review_vacation(v_case_b_id, 'approved', 'QA CASE C', jsonb_build_object('2026', 5));
+  execute 'reset role';
+
+  select amount_days into v_ledger_amount
+  from public.vacation_ledger
+  where absence_id = v_case_b_id and entry_type = 'approved_vacation';
+
+  select sum(vl.amount_days) into v_balance
+  from public.vacation_ledger vl
+  join public.vacation_years vy on vy.id = vl.vacation_year_id
+  where vy.employee_id = '52000000-0000-0000-0000-000000000002' and vy.year = 2026;
+
+  insert into _r values (3,'CASE C: Genehmigung des admin-erfassten Antrags via admin_review_vacation',
+    'status=approved/snapshot=5.00/ledger=-5.00/balance=19.00',
+    'status='||v_status||'/snapshot='||coalesce(v_snapshot::text,'NULL')||'/ledger='||coalesce(v_ledger_amount::text,'NULL')||'/balance='||coalesce(v_balance::text,'NULL'));
+  raise notice 'CASE C -> status=% snapshot=% ledger=% balance=%', v_status, v_snapshot, v_ledger_amount, v_balance;
+end $$;
+
+
+-- =========================================================
+-- CASE D — Admin lehnt einen admin-erfassten, noch offenen Antrag ab
+-- =========================================================
+-- Neuer, separater admin-erfasster Urlaub fuer X (Konto aktiv), diesmal
+-- abgelehnt statt genehmigt. Erwartet: status=rejected, KEINE Ledger-Zeile,
+-- Saldo bleibt bei 19.00 (aus CASE C).
+do $$
+declare
+  v_id uuid; v_status text;
+  v_ledger_rows int; v_balance numeric;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select id into v_id
+  from public.admin_create_absence(
+    '52000000-0000-0000-0000-000000000002', 'vacation', '2026-10-05', '2026-10-06', 'QA CASE D - wird abgelehnt'
+  );
+  select status::text into v_status
+  from public.admin_review_vacation(v_id, 'rejected', 'QA CASE D reject', null);
+  execute 'reset role';
+
+  select count(*) into v_ledger_rows from public.vacation_ledger where absence_id = v_id;
+  select sum(vl.amount_days) into v_balance
+  from public.vacation_ledger vl
+  join public.vacation_years vy on vy.id = vl.vacation_year_id
+  where vy.employee_id = '52000000-0000-0000-0000-000000000002' and vy.year = 2026;
+
+  insert into _r values (4,'CASE D: admin-erfasster Antrag wird abgelehnt -> kein Ledger-Effekt',
+    'status=rejected/ledger=0/balance=19.00',
+    'status='||v_status||'/ledger='||v_ledger_rows::text||'/balance='||coalesce(v_balance::text,'NULL'));
+  raise notice 'CASE D -> %', v_status;
+end $$;
+
+
+-- =========================================================
+-- CASE E — Krankheit ueber admin_create_absence bleibt unveraendert
+-- =========================================================
+-- Regressionsschutz: Krankheit landet unabhaengig vom Urlaubskonto-Status
+-- des Mitarbeiters weiterhin bei status=reported, reviewed_by/at NULL.
+do $$
+declare v_status text; v_reviewed_by text; v_reviewed_at text;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000001');
+  execute 'set local role authenticated';
+  select status::text, reviewed_by::text, reviewed_at::text
+    into v_status, v_reviewed_by, v_reviewed_at
+  from public.admin_create_absence(
+    '52000000-0000-0000-0000-000000000002', 'sickness', '2026-09-20', null, 'QA CASE E'
+  );
+  execute 'reset role';
+  insert into _r values (5,'CASE E: Krankheit via admin_create_absence unveraendert',
+    'status=reported/reviewed_by=NULL/reviewed_at=NULL',
+    'status='||v_status||'/reviewed_by='||coalesce(v_reviewed_by,'NULL')||'/reviewed_at='||coalesce(v_reviewed_at,'NULL'));
+  raise notice 'CASE E -> %', v_status;
+end $$;
+
+
+-- =========================================================
+-- CASE F — Autorisierung bleibt unveraendert
+-- =========================================================
+
+-- CASE F1: Mitarbeiterrolle darf admin_create_absence nicht aufrufen.
+do $$
+declare v_result text;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000002');
+  execute 'set local role authenticated';
+  begin
+    perform public.admin_create_absence(
+      '52000000-0000-0000-0000-000000000003', 'vacation', '2026-11-02', '2026-11-03', 'QA CASE F1'
+    );
+    v_result := 'AKZEPTIERT';
+  exception when others then v_result := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (6,'CASE F1: Mitarbeiterrolle darf admin_create_absence nicht aufrufen','ABGELEHNT',v_result);
+  raise notice 'CASE F1 -> %', v_result;
+end $$;
+
+-- CASE F2: Admin einer ANDEREN Firma kann fuer X keine Abwesenheit anlegen.
+do $$
+declare v_result text;
+begin
+  perform pg_temp.act_as('52000000-0000-0000-0000-000000000004');
+  execute 'set local role authenticated';
+  begin
+    perform public.admin_create_absence(
+      '52000000-0000-0000-0000-000000000002', 'vacation', '2026-11-09', '2026-11-10', 'QA CASE F2'
+    );
+    v_result := 'AKZEPTIERT';
+  exception when others then v_result := 'ABGELEHNT';
+  end;
+  execute 'reset role';
+  insert into _r values (7,'CASE F2: Admin ANDERER Firma kann fuer X keine Abwesenheit anlegen','ABGELEHNT',v_result);
+  raise notice 'CASE F2 -> %', v_result;
+end $$;
+
+
+-- =========================================================
+-- Ergebnisübersicht
+-- =========================================================
+select case_no, beschreibung, erwartet, ergebnis,
+       case when ergebnis = erwartet then 'PASS' else 'FAIL' end as verdikt
+from _r order by case_no;
+
+do $$
+declare fails int; gesamt int;
+begin
+  select count(*), count(*) filter (where ergebnis is distinct from erwartet)
+    into gesamt, fails from _r;
+  if fails > 0 then
+    raise exception 'ADMIN CREATE ABSENCE VACATION LEDGER TEST: % von % Faellen FEHLGESCHLAGEN', fails, gesamt;
+  end if;
+  raise notice 'ALLE % FAELLE PASS', gesamt;
+end $$;
+
+rollback;


### PR DESCRIPTION
## Summary

- **Proven accounting bypass**: `admin_create_absence(type='vacation')` always inserted `status='approved'` immediately, regardless of `profiles.vacation_management_enabled`. Verified end-to-end on Staging before this fix: a 5-day admin-created vacation for a vacation-managed employee landed as `approved`, counted as 5 effective vacation days in the Timesheet/absence resolver, but left `vacation_deducted_days_snapshot=NULL`, created zero `vacation_ledger` rows, and left the balance completely unchanged.
- **Root cause**: all deduction/ledger/snapshot logic lives exclusively inside `admin_review_vacation`. None of the three ledger-foundation migrations (`20260823/24/25`) ever touched or even mentioned `admin_create_absence` — the second path to `'approved'` was simply never accounted for when the ledger was designed.
- **Conditional behavior implemented**: `admin_create_absence` now reads `profiles.vacation_management_enabled` for the target employee — the exact same direct column read `admin_review_vacation` already uses (no company-default fallback), so the two RPCs can never disagree on which regime applies to a given employee.
  - **Vacation management disabled** (the default): unchanged — instant `status='approved'`, `reviewed_by`/`reviewed_at` set to the creating admin.
  - **Vacation management enabled**: `status='requested'` instead, `reviewed_by`/`reviewed_at` left `NULL`, no ledger row, no snapshot.
- **Reuse, no duplication**: the row created at `status='requested'` needs no special handling anywhere — `getPendingVacationRequests()`/`AdminAbsenceRow` filter only on `type`/`status`, never on who created the row, so it surfaces automatically in the existing "Urlaubsanträge" review queue. The admin then approves it through the unmodified `admin_review_vacation`, which remains the **sole** writer of `vacation_ledger` rows and `vacation_deducted_days_snapshot`. No deduction logic was copied into `admin_create_absence`.
- **Timesheet correctness**: verified with the real `resolveEffectiveAbsenceDays`/`isOperationallyActiveAbsence` functions against real data — a `requested` vacation is invisible to the Timesheet (0 effective days); the same row after approval correctly counts all 5 calendar days.
- **Sickness**: completely untouched — `type='sickness'` still always lands at `status='reported'` regardless of the employee's vacation-account state.
- **Client**: `AdminCreateAbsenceScreen`'s success message now branches on the RPC's actually-returned `status` rather than assuming approval — no new detection logic, no new deduction form; the existing review/deduction UI remains the only approval gate.

## Staging QA (real REST calls, real per-user sessions)

- Non-ledger employee: `admin_create_absence` → `status=approved`, `reviewed_by`/`reviewed_at` set — unchanged from before.
- Ledger-enabled employee, 5-day vacation: `admin_create_absence` → `status=requested`, `reviewed_by=null`, `reviewed_at=null`, `vacation_deducted_days_snapshot=null`, zero ledger rows, balance unchanged.
- Same row approved via `admin_review_vacation` with a 5-day deduction → `status=approved`, `snapshot=5.0`, one `approved_vacation` ledger row of `-5.00`, balance moved by exactly `-5` as calculated.

## Test coverage

New `supabase/tests/admin_create_absence_vacation_ledger.test.sql` — **8/8 PASS**:
- Non-ledger admin-created vacation → approved
- Ledger-enabled admin-created vacation → requested, no reviewer/snapshot/ledger row
- Subsequent `admin_review_vacation` approval → correct snapshot + ledger deduction + balance
- Subsequent rejection → no ledger effect
- Sickness via `admin_create_absence` → unchanged (`reported`, no reviewer fields)
- Employee-role calling the RPC → denied
- Cross-company admin → denied

Existing `supabase/tests/absences_foundation.test.sql` — all PASS (no regression). Full local suite re-run: only the three pre-existing, unrelated failures remain, untouched by this PR (`employee_read_via_assignments.test.sql` CASE 17, `recurring_jobs_display.test.sql` CASE 19, `shared_job_time_multi_assignment.test.sql` CASE 24).

## Deferred (intentionally out of scope for this fix)

Vacation deduction sanity-cap hardening remains separate: `admin_review_vacation` currently does not cap the confirmed deduction against the vacation period (an admin can confirm more deduction days than the vacation's calendar span). This was not part of the silent accounting-bypass fix and is tracked as a separate pre-Beta hardening item. Also left untouched: `absence_evidence` automated SQL coverage gap, AU error-message clarity after posted restorations, the three stale unrelated SQL tests, and vacation carry-over.

## Production status

**Production has not been touched.** The migration (`supabase/migrations/20260826000002_admin_create_absence_respects_vacation_ledger.sql`) has been applied to Staging only and verified there end-to-end. After this PR is approved, it still needs to be applied manually via the Supabase SQL Editor against Production, per this repo's established schema-change workflow.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] New dedicated SQL test: 8/8 PASS
- [x] Existing `absences_foundation.test.sql`: PASS
- [x] Real Staging API verification (non-ledger regression, ledger-enabled create→requested, approve→correct ledger/balance)
- [ ] Manual production migration apply (post-merge, separate step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)